### PR TITLE
fix(ci): add PR checks and stabilize release workflows

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,4 +1,6 @@
 {
+  "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,65 @@
+name: pr-ci
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  frontend-checks:
+    name: frontend-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: typecheck
+        run: pnpm exec tsc --noEmit
+
+      - name: run frontend tests
+        run: pnpm exec vitest run
+
+      - name: build frontend
+        run: pnpm build
+
+  rust-tests:
+    name: rust-tests
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: install rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: run rust tests
+        run: pnpm test:rust

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -14,16 +14,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
       - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-
-      - name: install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: install frontend dependencies
         run: pnpm install --frozen-lockfile
@@ -44,16 +44,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
       - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
-
-      - name: install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,6 +14,17 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Verify release automation prerequisites
+        env:
+          HAS_RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
+        run: |
+          if [ "${HAS_RELEASE_PLEASE_TOKEN}" != "true" ]; then
+            echo "::warning::RELEASE_PLEASE_TOKEN is not configured. Release PRs and tags created with GITHUB_TOKEN will not trigger downstream workflows."
+          else
+            echo "RELEASE_PLEASE_TOKEN detected."
+          fi
+          echo "::notice::Verify Settings > Actions > General allows GitHub Actions to create and approve pull requests."
+
       - name: Create release PR or GitHub Release
         id: release
         uses: google-github-actions/release-please-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "ambit-v*"
 
 jobs:
   publish-tauri:
@@ -46,8 +47,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tagName: v__VERSION__ # the Action will use the version from src-tauri/tauri.conf.json
-          releaseName: "Ambit v__VERSION__"
+          tagName: ${{ github.ref_name }}
+          releaseName: "Ambit ${{ github.ref_name }}"
           releaseBody: "See the assets below to download the latest version of Ambit."
           releaseDraft: false
           prerelease: false

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -26,6 +26,16 @@ The `release-please` workflow automates the versioning of the application and th
 1.  Work on a feature branch.
 2.  Push the branch and open a Pull Request.
 3.  Ensure the PR title follows **Conventional Commits** (e.g., `feat: something new` or `fix: resolve bug`).
-4.  **Squash and Merge** the PR into `main`.
-5.  `release-please` will automatically open a "Release PR".
-6.  When you merge the "Release PR", the `release.yml` workflow kicks off to build the installers for Mac, Windows, and Linux.
+4.  PRs into `main` must pass the `frontend-checks` and `rust-tests` GitHub Actions jobs.
+5.  **Squash and Merge** the PR into `main` so the squashed commit title is the Conventional Commit that lands on the release branch.
+6.  `release-please` will automatically open or refresh a "Release PR".
+7.  When you merge the "Release PR", the `release.yml` workflow builds the installers for Mac, Windows, and Linux.
+
+## Release Tag Notes
+*   Release tags are intended to normalize to `vX.Y.Z`.
+*   During the current transition, the publish workflow accepts both `v*` and legacy `ambit-v*` tags and publishes against the actual tag that triggered the workflow.
+
+## Repository Settings To Verify
+*   **Branch protection:** `main` should require pull requests and the `frontend-checks` plus `rust-tests` status checks.
+*   **Actions permissions:** Under **Settings > Actions > General**, enable **Allow GitHub Actions to create and approve pull requests**.
+*   **Release token:** If `RELEASE_PLEASE_TOKEN` is missing, `release-please` still works with `GITHUB_TOKEN`, but downstream workflows triggered from release PRs or release tags will not run automatically.

--- a/src/components/ui/OnboardingWizard.tsx
+++ b/src/components/ui/OnboardingWizard.tsx
@@ -299,7 +299,7 @@ export const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
                                                 error={verificationError}
                                                 isEnvKey={isEnvKey}
                                                 onTestEnvKey={() => {
-                                                    const keyToTest = initialApiKey || process.env.API_KEY || '';
+                                                    const keyToTest = process.env.API_KEY || apiKey || '';
                                                     if (keyToTest) {
                                                         handleVerifyKey(keyToTest);
                                                     }

--- a/src/workers/metadata.worker.ts
+++ b/src/workers/metadata.worker.ts
@@ -552,6 +552,7 @@ export const decompressDeflate = async (buffer: Uint8Array): Promise<Uint8Array 
         while (true) {
             const { done, value } = await reader.read();
             if (done) break;
+            if (!(value instanceof Uint8Array)) continue;
 
             totalSize += value.length;
             if (totalSize > MAX_DECOMPRESSED_SIZE) {


### PR DESCRIPTION
## Summary
- add a pull-request CI workflow with stable `frontend-checks` and `rust-tests` jobs
- normalize the release workflows so publish runs against the actual triggering tag and accepts the legacy `ambit-v*` tag format during transition
- add release-please prerequisite notices for `RELEASE_PLEASE_TOKEN` and Actions PR permissions
- document the updated squash-merge and required-checks workflow
- fix the current TypeScript issues in `OnboardingWizard` and `metadata.worker` so the new frontend checks start green

## Verification
- `tsc --noEmit`
- `vitest run src/workers/__tests__/metadata.worker.security.test.ts`
- `vite build`
- `pnpm test:rust`

## Notes
- GitHub `main` already contains the earlier security work via merged PR #5, so this PR only handles the remaining workflow and verification cleanup.
- The primary `D:/AI/WebDev/project-ambit-alpha` worktree has unrelated uncommitted changes on local `main`, so it was intentionally left untouched.