### PR TITLE
[codex] feat(filters): use typed valid-facet inputs

### DIFF
--- a/src-tauri/src/db/commands/filter_types.rs
+++ b/src-tauri/src/db/commands/filter_types.rs
@@ -1,0 +1,654 @@
+use chrono::{Datelike, Local, TimeZone};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rusqlite::types::Value;
+use serde::Deserialize;
+use specta::Type;
+use std::collections::HashMap;
+
+static TERM_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(-|!)?("(?:[^"\\]|\\.)*"|\S+)"#).unwrap());
+
+#[derive(Deserialize, Type, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RustFilterState {
+    pub search_query: String,
+    pub models: Vec<String>,
+    pub tools: Vec<String>,
+    pub loras: Vec<String>,
+    pub embeddings: Vec<String>,
+    pub hypernetworks: Vec<String>,
+    pub control_nets: Vec<String>,
+    pub ip_adapters: Vec<String>,
+    pub samplers: Vec<String>,
+    pub generation_types: Vec<String>,
+    pub date_range: String,
+    pub favorites_only: bool,
+    pub pinned_only: bool,
+    pub show_intermediates: bool,
+    pub show_grids: bool,
+    pub collection_id: Option<String>,
+    pub min_steps: Option<i32>,
+    pub max_steps: Option<i32>,
+    pub min_cfg: Option<f32>,
+    pub max_cfg: Option<f32>,
+    pub match_modes: Option<HashMap<String, String>>,
+}
+
+#[derive(Deserialize, Type, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RustCollection {
+    pub id: String,
+    pub name: String,
+    pub filters: Option<RustFilterState>,
+    pub manual_exclusions: Option<Vec<String>>,
+}
+
+impl RustFilterState {
+    pub fn build_where_clause(
+        &self,
+        privacy_enabled: bool,
+        masking_mode: &str,
+        masked_keywords: &[String],
+        collections: &[RustCollection],
+        is_recursive: bool,
+        exclude_categories: &[String],
+    ) -> (String, Vec<Value>) {
+        let mut conditions: Vec<String> = Vec::new();
+        let mut params: Vec<Value> = Vec::new();
+
+        if !is_recursive {
+            conditions.push("is_deleted = 0".to_string());
+
+            if !self.show_intermediates {
+                conditions.push("IFNULL(is_intermediate_gen, 0) = 0".to_string());
+            }
+            if !self.show_grids {
+                conditions.push("IFNULL(is_grid_gen, 0) = 0".to_string());
+            }
+        }
+
+        if privacy_enabled && masking_mode == "hide" && !masked_keywords.is_empty() {
+            let mut privacy_conditions = Vec::new();
+            for kw in masked_keywords {
+                params.push(Value::Text(format!("%{}%", kw)));
+                privacy_conditions.push("metadata_json NOT LIKE ?".to_string());
+            }
+            conditions.push(format!("({})", privacy_conditions.join(" AND ")));
+        }
+
+        if let Some(ref col_id) = self.collection_id {
+            let col = collections.iter().find(|c| c.id == *col_id);
+            let mut sub_conditions = Vec::new();
+
+            if let Some(c) = col {
+                if let Some(ref filters) = c.filters {
+                    let mut effective_smart_filters = filters.clone();
+                    if self.date_range != "all" {
+                        effective_smart_filters.date_range = "all".to_string();
+                    }
+
+                    let (smart_where, smart_params) = effective_smart_filters.build_where_clause(
+                        false,
+                        "blur",
+                        &[],
+                        &[],
+                        true,
+                        &[],
+                    );
+
+                    if !smart_where.is_empty() {
+                        sub_conditions.push(format!("({})", smart_where));
+                        params.extend(smart_params);
+                    }
+                }
+
+                if !sub_conditions.is_empty() {
+                    let mut combined = format!("({})", sub_conditions.join(" OR "));
+
+                    if let Some(ref manual_exclusions) = c.manual_exclusions {
+                        if !manual_exclusions.is_empty() {
+                            let placeholders = manual_exclusions
+                                .iter()
+                                .map(|_| "?")
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            combined = format!("({} AND id NOT IN ({}))", combined, placeholders);
+                            params.extend(manual_exclusions.iter().map(|s| Value::Text(s.clone())));
+                        }
+                    }
+
+                    conditions.push(combined);
+                }
+            }
+        }
+
+        if self.favorites_only {
+            conditions.push("is_favorite = 1".to_string());
+        }
+
+        if self.pinned_only {
+            conditions.push("is_pinned = 1".to_string());
+        }
+
+        if !self.models.is_empty() && !exclude_categories.contains(&"models".to_string()) {
+            let match_mode = self
+                .match_modes
+                .as_ref()
+                .and_then(|m| m.get("models"))
+                .map(|s| s.as_str())
+                .unwrap_or("any");
+            let mut model_conditions = Vec::new();
+            for m in &self.models {
+                if m == "Unknown" {
+                    model_conditions.push(
+                        "(resolved_model_name IS NULL OR resolved_model_name = '' OR resolved_model_name = 'Unknown')"
+                            .to_string(),
+                    );
+                } else {
+                    params.push(Value::Text(m.clone()));
+                    model_conditions.push("resolved_model_name = ? COLLATE NOCASE".to_string());
+                }
+            }
+            let joiner = if match_mode == "all" { " AND " } else { " OR " };
+            conditions.push(format!("({})", model_conditions.join(joiner)));
+        }
+
+        if !self.tools.is_empty() && !exclude_categories.contains(&"tools".to_string()) {
+            let match_mode = self
+                .match_modes
+                .as_ref()
+                .and_then(|m| m.get("tools"))
+                .map(|s| s.as_str())
+                .unwrap_or("any");
+            let mut tool_conditions = Vec::new();
+            for t in &self.tools {
+                if t == "Unknown" {
+                    tool_conditions.push("(tool = 'Unknown' OR tool IS NULL)".to_string());
+                } else {
+                    params.push(Value::Text(t.clone()));
+                    tool_conditions.push("tool = ? COLLATE NOCASE".to_string());
+                }
+            }
+            let joiner = if match_mode == "all" { " AND " } else { " OR " };
+            conditions.push(format!("({})", tool_conditions.join(joiner)));
+        }
+
+        let lora_mode = self
+            .match_modes
+            .as_ref()
+            .and_then(|m| m.get("loras"))
+            .map(|s| s.as_str())
+            .unwrap_or("any");
+        if !exclude_categories.contains(&"loras".to_string()) {
+            if self.loras.len() == 1 && lora_mode == "any" {
+            } else if !self.loras.is_empty() {
+                let mut lora_conditions = Vec::new();
+                for l in &self.loras {
+                    params.push(Value::Text(l.clone()));
+                    lora_conditions.push(
+                        "EXISTS (SELECT 1 FROM image_loras il WHERE il.image_id = id AND il.lora_name = ? COLLATE NOCASE)"
+                            .to_string(),
+                    );
+                }
+                let joiner = if lora_mode == "all" { " AND " } else { " OR " };
+                conditions.push(format!("({})", lora_conditions.join(joiner)));
+            }
+        }
+
+        let emb_mode = self
+            .match_modes
+            .as_ref()
+            .and_then(|m| m.get("embeddings"))
+            .map(|s| s.as_str())
+            .unwrap_or("any");
+        if !self.embeddings.is_empty() && !exclude_categories.contains(&"embeddings".to_string()) {
+            let mut emb_conditions = Vec::new();
+            for e in &self.embeddings {
+                params.push(Value::Text(e.clone()));
+                emb_conditions.push(
+                    "EXISTS (SELECT 1 FROM image_embeddings ie WHERE ie.image_id = id AND ie.embedding_name = ? COLLATE NOCASE)"
+                        .to_string(),
+                );
+            }
+            let joiner = if emb_mode == "all" { " AND " } else { " OR " };
+            conditions.push(format!("({})", emb_conditions.join(joiner)));
+        }
+
+        let hn_mode = self
+            .match_modes
+            .as_ref()
+            .and_then(|m| m.get("hypernetworks"))
+            .map(|s| s.as_str())
+            .unwrap_or("any");
+        if !self.hypernetworks.is_empty()
+            && !exclude_categories.contains(&"hypernetworks".to_string())
+        {
+            let mut hn_conditions = Vec::new();
+            for h in &self.hypernetworks {
+                params.push(Value::Text(h.clone()));
+                hn_conditions.push(
+                    "EXISTS (SELECT 1 FROM image_hypernetworks ih WHERE ih.image_id = id AND ih.hypernetwork_name = ? COLLATE NOCASE)"
+                        .to_string(),
+                );
+            }
+            let joiner = if hn_mode == "all" { " AND " } else { " OR " };
+            conditions.push(format!("({})", hn_conditions.join(joiner)));
+        }
+
+        let cn_mode = self
+            .match_modes
+            .as_ref()
+            .and_then(|m| m.get("controlNets"))
+            .map(|s| s.as_str())
+            .unwrap_or("any");
+        if !self.control_nets.is_empty() && !exclude_categories.contains(&"controlNets".to_string())
+        {
+            let mut cn_conditions = Vec::new();
+            for c in &self.control_nets {
+                params.push(Value::Text(c.clone()));
+                cn_conditions.push(
+                    "EXISTS (SELECT 1 FROM image_controlnets cn WHERE cn.image_id = id AND cn.controlnet_name = ? COLLATE NOCASE)"
+                        .to_string(),
+                );
+            }
+            let joiner = if cn_mode == "all" { " AND " } else { " OR " };
+            conditions.push(format!("({})", cn_conditions.join(joiner)));
+        }
+
+        let ip_mode = self
+            .match_modes
+            .as_ref()
+            .and_then(|m| m.get("ipAdapters"))
+            .map(|s| s.as_str())
+            .unwrap_or("any");
+        if !self.ip_adapters.is_empty() && !exclude_categories.contains(&"ipAdapters".to_string()) {
+            let mut ip_conditions = Vec::new();
+            for i in &self.ip_adapters {
+                params.push(Value::Text(i.clone()));
+                ip_conditions.push(
+                    "EXISTS (SELECT 1 FROM image_ipadapters ip WHERE ip.image_id = id AND ip.ipadapter_name = ? COLLATE NOCASE)"
+                        .to_string(),
+                );
+            }
+            let joiner = if ip_mode == "all" { " AND " } else { " OR " };
+            conditions.push(format!("({})", ip_conditions.join(joiner)));
+        }
+
+        if !self.search_query.is_empty() {
+            for caps in TERM_REGEX.captures_iter(&self.search_query) {
+                let is_negative = caps.get(1).is_some();
+                let mut term = caps.get(2).unwrap().as_str().to_string();
+
+                if term.starts_with('"') && term.ends_with('"') {
+                    term = term[1..term.len() - 1].replace(r#"\"#, "\"");
+                }
+
+                let lower_term = term.to_lowercase();
+                if lower_term.contains(':') && !lower_term.starts_with(':') {
+                    let parts: Vec<&str> = lower_term.splitn(2, ':').collect();
+                    let key = parts[0];
+                    let val = parts[1];
+
+                    let mut sql = String::new();
+                    let mut param: Option<Value> = None;
+
+                    match key {
+                        "steps" => {
+                            if let Some(stripped) = val.strip_prefix('>') {
+                                sql = "CAST(json_extract(metadata_json, '$.steps') AS INTEGER) > ?"
+                                    .to_string();
+                                param = stripped
+                                    .parse::<i32>()
+                                    .ok()
+                                    .map(|v| Value::Integer(v as i64));
+                            } else if let Some(stripped) = val.strip_prefix('<') {
+                                sql = "CAST(json_extract(metadata_json, '$.steps') AS INTEGER) < ?"
+                                    .to_string();
+                                param = stripped
+                                    .parse::<i32>()
+                                    .ok()
+                                    .map(|v| Value::Integer(v as i64));
+                            } else {
+                                sql = "CAST(json_extract(metadata_json, '$.steps') AS INTEGER) = ?"
+                                    .to_string();
+                                param = val.parse::<i32>().ok().map(|v| Value::Integer(v as i64));
+                            }
+                        }
+                        "cfg" => {
+                            if let Some(stripped) = val.strip_prefix('>') {
+                                sql = "CAST(json_extract(metadata_json, '$.cfg') AS FLOAT) > ?"
+                                    .to_string();
+                                param = stripped.parse::<f64>().ok().map(Value::Real);
+                            } else if let Some(stripped) = val.strip_prefix('<') {
+                                sql = "CAST(json_extract(metadata_json, '$.cfg') AS FLOAT) < ?"
+                                    .to_string();
+                                param = stripped.parse::<f64>().ok().map(Value::Real);
+                            } else {
+                                sql = "CAST(json_extract(metadata_json, '$.cfg') AS FLOAT) = ?"
+                                    .to_string();
+                                param = val.parse::<f64>().ok().map(Value::Real);
+                            }
+                        }
+                        "w" | "width" => {
+                            if let Some(stripped) = val.strip_prefix('>') {
+                                sql = "width > ?".to_string();
+                                param = stripped
+                                    .parse::<i32>()
+                                    .ok()
+                                    .map(|v| Value::Integer(v as i64));
+                            } else if let Some(stripped) = val.strip_prefix('<') {
+                                sql = "width < ?".to_string();
+                                param = stripped
+                                    .parse::<i32>()
+                                    .ok()
+                                    .map(|v| Value::Integer(v as i64));
+                            } else {
+                                sql = "width = ?".to_string();
+                                param = val.parse::<i32>().ok().map(|v| Value::Integer(v as i64));
+                            }
+                        }
+                        "h" | "height" => {
+                            if let Some(stripped) = val.strip_prefix('>') {
+                                sql = "height > ?".to_string();
+                                param = stripped
+                                    .parse::<i32>()
+                                    .ok()
+                                    .map(|v| Value::Integer(v as i64));
+                            } else if let Some(stripped) = val.strip_prefix('<') {
+                                sql = "height < ?".to_string();
+                                param = stripped
+                                    .parse::<i32>()
+                                    .ok()
+                                    .map(|v| Value::Integer(v as i64));
+                            } else {
+                                sql = "height = ?".to_string();
+                                param = val.parse::<i32>().ok().map(|v| Value::Integer(v as i64));
+                            }
+                        }
+                        "model" => {
+                            let p = format!("%{}%", val);
+                            conditions.push(
+                                "(resolved_model_name LIKE ? OR json_extract(metadata_json, '$.model') LIKE ?)"
+                                    .to_string(),
+                            );
+                            params.push(Value::Text(p.clone()));
+                            params.push(Value::Text(p));
+                            continue;
+                        }
+                        "seed" => {
+                            sql = "json_extract(metadata_json, '$.seed') LIKE ?".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "neg" | "negative" => {
+                            sql = "json_extract(metadata_json, '$.negativePrompt') LIKE ?"
+                                .to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "file" | "filename" | "path" => {
+                            sql = "path LIKE ?".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "all" => {
+                            let p = format!("%{}%", val);
+                            if is_negative {
+                                conditions.push(
+                                    "(path NOT LIKE ? AND metadata_json NOT LIKE ?)".to_string(),
+                                );
+                            } else {
+                                conditions
+                                    .push("(path LIKE ? OR metadata_json LIKE ?)".to_string());
+                            }
+                            params.push(Value::Text(p.clone()));
+                            params.push(Value::Text(p));
+                            continue;
+                        }
+                        "sampler" => {
+                            sql = "sampler LIKE ?".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "tool" => {
+                            sql = "tool LIKE ?".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "lora" => {
+                            sql = "EXISTS (SELECT 1 FROM image_loras il WHERE il.image_id = id AND il.lora_name LIKE ?)".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "cn" | "controlnet" => {
+                            sql = "EXISTS (SELECT 1 FROM image_controlnets cn WHERE cn.image_id = id AND cn.controlnet_name LIKE ?)".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "ip" | "ipadapter" => {
+                            sql = "EXISTS (SELECT 1 FROM image_ipadapters ip WHERE ip.image_id = id AND ip.ipadapter_name LIKE ?)".to_string();
+                            param = Some(Value::Text(format!("%{}%", val)));
+                        }
+                        "upscaled" => {
+                            sql = "json_extract(metadata_json, '$.upscaled') = ?".to_string();
+                            param = Some(Value::Integer(if val == "true" { 1 } else { 0 }));
+                        }
+                        _ => {}
+                    }
+
+                    if !sql.is_empty() {
+                        if let Some(p) = param {
+                            if is_negative {
+                                conditions.push(format!("NOT ({})", sql));
+                            } else {
+                                conditions.push(sql);
+                            }
+                            params.push(p);
+                        }
+                    }
+                } else {
+                    if is_negative {
+                        conditions.push(
+                            "json_extract(metadata_json, '$.positivePrompt') NOT LIKE ?"
+                                .to_string(),
+                        );
+                    } else {
+                        conditions.push(
+                            "json_extract(metadata_json, '$.positivePrompt') LIKE ?".to_string(),
+                        );
+                    }
+                    params.push(Value::Text(format!("%{}%", term)));
+                }
+            }
+        }
+
+        if let Some(min_steps) = self.min_steps {
+            conditions.push("steps >= ?".to_string());
+            params.push(Value::Integer(min_steps as i64));
+        }
+        if let Some(max_steps) = self.max_steps {
+            conditions.push("steps <= ?".to_string());
+            params.push(Value::Integer(max_steps as i64));
+        }
+        if let Some(min_cfg) = self.min_cfg {
+            conditions.push("cfg >= ?".to_string());
+            params.push(Value::Real(min_cfg as f64));
+        }
+        if let Some(max_cfg) = self.max_cfg {
+            conditions.push("cfg <= ?".to_string());
+            params.push(Value::Real(max_cfg as f64));
+        }
+
+        if !self.samplers.is_empty() && !exclude_categories.contains(&"samplers".to_string()) {
+            let sampler_conditions = self
+                .samplers
+                .iter()
+                .map(|_| "sampler = ?")
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            for s in &self.samplers {
+                params.push(Value::Text(s.to_lowercase().replace(['_', '-'], " ")));
+            }
+            conditions.push(format!("({})", sampler_conditions));
+        }
+
+        if !self.generation_types.is_empty()
+            && !exclude_categories.contains(&"generationTypes".to_string())
+        {
+            let gen_type_conditions = self
+                .generation_types
+                .iter()
+                .map(|_| "generation_type = ?")
+                .collect::<Vec<_>>()
+                .join(" OR ");
+            for gt in &self.generation_types {
+                params.push(Value::Text(gt.clone()));
+            }
+            conditions.push(format!("({})", gen_type_conditions));
+        }
+
+        if self.date_range != "all" {
+            let now = Local::now();
+            let midnight = Local
+                .with_ymd_and_hms(now.year(), now.month(), now.day(), 0, 0, 0)
+                .unwrap();
+            let today_start = midnight.timestamp_millis();
+            let day_ms = 24 * 60 * 60 * 1000;
+
+            let mut cut_off = 0;
+            match self.date_range.as_str() {
+                "today" => cut_off = today_start,
+                "week" => cut_off = today_start - (7 * day_ms),
+                "month" => cut_off = today_start - (30 * day_ms),
+                _ => {}
+            }
+
+            if cut_off > 0 {
+                conditions.push("timestamp >= ?".to_string());
+                params.push(Value::Integer(cut_off));
+            }
+        }
+
+        let mut where_clause = if conditions.is_empty() {
+            String::new()
+        } else {
+            conditions.join(" AND ")
+        };
+
+        if !is_recursive && !where_clause.is_empty() {
+            where_clause = format!("WHERE {}", where_clause);
+        }
+
+        (where_clause, params)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_default_filter() -> RustFilterState {
+        RustFilterState {
+            search_query: "".to_string(),
+            models: vec![],
+            tools: vec![],
+            loras: vec![],
+            embeddings: vec![],
+            hypernetworks: vec![],
+            control_nets: vec![],
+            ip_adapters: vec![],
+            samplers: vec![],
+            generation_types: vec![],
+            date_range: "all".to_string(),
+            favorites_only: false,
+            pinned_only: false,
+            show_intermediates: false,
+            show_grids: false,
+            collection_id: None,
+            min_steps: None,
+            max_steps: None,
+            min_cfg: None,
+            max_cfg: None,
+            match_modes: None,
+        }
+    }
+
+    #[test]
+    fn test_basic_where_clause() {
+        let filter = create_default_filter();
+        let (sql, params) = filter.build_where_clause(false, "blur", &[], &[], false, &[]);
+        assert!(sql.contains("WHERE is_deleted = 0"));
+        assert!(sql.contains("IFNULL(is_intermediate_gen, 0) = 0"));
+        assert!(sql.contains("IFNULL(is_grid_gen, 0) = 0"));
+        assert_eq!(params.len(), 0);
+    }
+
+    #[test]
+    fn test_favorites_and_pinned() {
+        let mut filter = create_default_filter();
+        filter.favorites_only = true;
+        filter.pinned_only = true;
+        let (sql, _) = filter.build_where_clause(false, "blur", &[], &[], false, &[]);
+        assert!(sql.contains("is_favorite = 1"));
+        assert!(sql.contains("is_pinned = 1"));
+    }
+
+    #[test]
+    fn test_search_query() {
+        let mut filter = create_default_filter();
+        filter.search_query = "cat steps:>20 -dog".to_string();
+        let (sql, params) = filter.build_where_clause(false, "blur", &[], &[], false, &[]);
+
+        assert!(sql.contains("json_extract(metadata_json, '$.positivePrompt') LIKE ?"));
+        assert!(sql.contains("CAST(json_extract(metadata_json, '$.steps') AS INTEGER) > ?"));
+        assert!(sql.contains("json_extract(metadata_json, '$.positivePrompt') NOT LIKE ?"));
+
+        assert_eq!(params.len(), 3);
+        assert_eq!(params[0], Value::Text("%cat%".to_string()));
+        assert_eq!(params[1], Value::Integer(20));
+        assert_eq!(params[2], Value::Text("%dog%".to_string()));
+    }
+
+    #[test]
+    fn test_models_filter() {
+        let mut filter = create_default_filter();
+        filter.models = vec!["Model A".to_string(), "Unknown".to_string()];
+        let (sql, params) = filter.build_where_clause(false, "blur", &[], &[], false, &[]);
+
+        assert!(sql.contains("(resolved_model_name = ? COLLATE NOCASE OR (resolved_model_name IS NULL OR resolved_model_name = '' OR resolved_model_name = 'Unknown'))"));
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0], Value::Text("Model A".to_string()));
+    }
+
+    #[test]
+    fn test_privacy_filter() {
+        let filter = create_default_filter();
+        let (sql, params) =
+            filter.build_where_clause(true, "hide", &["secret".to_string()], &[], false, &[]);
+
+        assert!(sql.contains("metadata_json NOT LIKE ?"));
+        assert_eq!(params.len(), 1);
+        assert_eq!(params[0], Value::Text("%secret%".to_string()));
+    }
+
+    #[test]
+    fn test_smart_collection() {
+        let smart_filter = RustFilterState {
+            search_query: "smart".to_string(),
+            ..create_default_filter()
+        };
+        let collection = RustCollection {
+            id: "col1".to_string(),
+            name: "My Collection".to_string(),
+            filters: Some(smart_filter),
+            manual_exclusions: Some(vec!["img1".to_string()]),
+        };
+
+        let mut filter = create_default_filter();
+        filter.collection_id = Some("col1".to_string());
+
+        let (sql, params) =
+            filter.build_where_clause(false, "blur", &[], &[collection], false, &[]);
+
+        assert!(sql.contains("is_deleted = 0"));
+        assert!(sql.contains("(json_extract(metadata_json, '$.positivePrompt') LIKE ?)"));
+        assert!(sql.contains("AND id NOT IN (?)"));
+        assert_eq!(params.len(), 2);
+        assert_eq!(params[0], Value::Text("%smart%".to_string()));
+        assert_eq!(params[1], Value::Text("img1".to_string()));
+    }
+}

--- a/src-tauri/src/db/commands/mod.rs
+++ b/src-tauri/src/db/commands/mod.rs
@@ -1,10 +1,11 @@
+use super::{configure_connection, resolve_db_path};
 use rusqlite::Connection;
 use tauri::AppHandle;
-use super::{configure_connection, resolve_db_path};
 
+pub mod filter_commands;
+pub mod filter_types;
 pub mod image_commands;
 pub mod maintenance;
-pub mod filter_commands;
 pub mod reparse_commands;
 
 /// Standard wrapper for Tauri commands to reduce boilerplate.

--- a/src-tauri/src/db/facets.rs
+++ b/src-tauri/src/db/facets.rs
@@ -1,3 +1,4 @@
+use super::commands::filter_types::{RustCollection, RustFilterState};
 use super::{configure_connection, resolve_db_path, ProgressPayload};
 use regex::Regex;
 use rusqlite::params;
@@ -228,7 +229,12 @@ pub async fn rebuild_facet_cache_incremental(
             "hypernetworks" => build_resource_facets(&tx, "hypernetworks", "hypernetworks")?,
             "control_nets" => build_resource_facets(&tx, "control_nets", "control_nets")?,
             "ip_adapters" => build_resource_facets(&tx, "ip_adapters", "ip_adapters")?,
-            _ => return Err(format!("Unknown facet type for incremental build: {}", facet_type)),
+            _ => {
+                return Err(format!(
+                    "Unknown facet type for incremental build: {}",
+                    facet_type
+                ))
+            }
         }
 
         tx.commit().map_err(|e| e.to_string())?;
@@ -247,7 +253,6 @@ pub async fn rebuild_facet_cache_incremental(
     .await
     .map_err(|e| e.to_string())?
 }
-
 
 /// Valid facet names result - used for drill-down filtering
 #[derive(Debug, Clone, serde::Serialize, specta::Type)]
@@ -272,51 +277,35 @@ pub struct ValidFacetNames {
 #[specta::specta]
 pub async fn get_valid_facet_names(
     app: tauri::AppHandle,
-    where_clause: String,
-    params_json: String,
-    collection_id: Option<String>,
-    lora_name: Option<String>,
+    filters: RustFilterState,
+    collections: Vec<RustCollection>,
+    exclude_categories: Vec<String>,
 ) -> Result<ValidFacetNames, String> {
     tauri::async_runtime::spawn_blocking(move || {
         let db_path = resolve_db_path(&app)?;
         let conn = rusqlite::Connection::open(&db_path).map_err(|e| e.to_string())?;
         configure_connection(&conn).map_err(|e| e.to_string())?;
 
-        // Parse JSON params
-        let params: Vec<serde_json::Value> = serde_json::from_str(&params_json)
-            .unwrap_or_else(|_| Vec::new());
+        let (where_clause, sql_params) = filters.build_where_clause(
+            true,
+            "hide",
+            &[],
+            &collections,
+            false,
+            &exclude_categories,
+        );
 
-        // Convert JSON params to rusqlite params
-        let sql_params: Vec<rusqlite::types::Value> = params.iter().map(|p| {
-            match p {
-                serde_json::Value::String(s) => rusqlite::types::Value::Text(s.clone()),
-                serde_json::Value::Number(n) => {
-                    if let Some(i) = n.as_i64() {
-                        rusqlite::types::Value::Integer(i)
-                    } else if let Some(f) = n.as_f64() {
-                        rusqlite::types::Value::Real(f)
-                    } else {
-                        rusqlite::types::Value::Null
-                    }
-                }
-                serde_json::Value::Bool(b) => rusqlite::types::Value::Integer(if *b { 1 } else { 0 }),
-                serde_json::Value::Null => rusqlite::types::Value::Null,
-                _ => rusqlite::types::Value::Text(p.to_string()),
-            }
-        }).collect();
-
-        // Build base WHERE clause, ensuring it starts with WHERE
         let base_where = if where_clause.is_empty() {
             "WHERE is_deleted = 0".to_string()
         } else {
-            where_clause.clone()
+            where_clause
         };
 
-
-        // Helper to create prefixed WHERE clause for queries that JOIN with images table aliased as 'i'
-        // Uses Regex to robustly identify "whole word" columns, avoiding matches inside other words
-        // or effectively handling parens/operators.
         let prefix_columns = |clause: &str| -> String {
+            if clause.is_empty() {
+                return String::new();
+            }
+
             let columns = [
                 "is_deleted", "is_intermediate_gen", "is_grid_gen", "resolved_model_name", 
                 "model_hash", "tool", "timestamp", "is_favorite", "is_pinned", 
@@ -325,29 +314,13 @@ pub async fn get_valid_facet_names(
             ];
             
             let mut result = clause.to_string();
-            
-            // Regex pattern:
-            // 1. (?i) Case insensitive (though columns are usually lowercase in our code)
-            // 2. \b(col1|col2|...)\b -> Match whole word only
-            // 3. We check if it's NOT already prefixed by i. manually by looking at our replacement?
-            //    Actually, regex replace_all doesn't look behind easily in Rust's regex crate (no lookaround).
-            //    BUT, if we just match \bcol\b, "i.col" matches "col" as a word boundary?
-            //    "i.col" -> "." is a boundary? Yes. 
-            //    So "i.col" would match "col". We need to avoid double prefixing.
-            //    Wait, "i.col". "." is NOT a word char. So "col" starts at boundary. 
-            //    We can match `(?P<prefix>i\.)?(?P<col>\b(col1|col2...)\b)`? 
-            //    And if prefix is there, keep it. If not, add it.
-            
-            // Construct the large OR pattern
             let pattern_str = format!(r"(?i)(i\.)?\b({})\b", columns.join("|"));
-            let re = Regex::new(&pattern_str).unwrap(); // compiled once per call is fine, or lazy_static if frequent
+            let re = Regex::new(&pattern_str).unwrap();
             
             result = re.replace_all(&result, |caps: &regex::Captures| {
                 if caps.get(1).is_some() {
-                    // Already prefixed with "i."
                     caps[0].to_string()
                 } else {
-                    // Not prefixed, add "i."
                     format!("i.{}", &caps[2])
                 }
             }).to_string();
@@ -355,47 +328,27 @@ pub async fn get_valid_facet_names(
             result
         };
 
-        // Build query parts for collection and LoRA JOINs
-        let collection_join = collection_id.as_ref().map(|_| 
-            "JOIN collection_images ci ON ci.image_id = i.id AND ci.collection_id = ?"
-        ).unwrap_or("");
-        
-        let lora_join = lora_name.as_ref().map(|_| 
-            "JOIN image_loras il_filter ON il_filter.image_id = i.id AND il_filter.lora_name = ?"
-        ).unwrap_or("");
-
         let prefixed = prefix_columns(&base_where);
 
-        // Build combined UNION ALL query for all facet types
-        // Each subquery adds a 'facet_type' discriminator column
         let combined_query = format!(
-            "SELECT 'checkpoints' as facet_type, i.resolved_model_name as name FROM images i {coll} {lora} {where} AND i.resolved_model_name IS NOT NULL AND i.resolved_model_name != ''
+            "SELECT 'checkpoints' as facet_type, i.resolved_model_name as name FROM images i {where} AND i.resolved_model_name IS NOT NULL AND i.resolved_model_name != ''
              UNION ALL
-             SELECT 'loras', il.lora_name FROM image_loras il JOIN images i ON i.id = il.image_id {coll} {lora} {where}
+             SELECT 'loras', il.lora_name FROM image_loras il JOIN images i ON i.id = il.image_id {where}
              UNION ALL
-             SELECT 'embeddings', ie.embedding_name FROM image_embeddings ie JOIN images i ON i.id = ie.image_id {coll} {lora} {where}
+             SELECT 'embeddings', ie.embedding_name FROM image_embeddings ie JOIN images i ON i.id = ie.image_id {where}
              UNION ALL
-             SELECT 'hypernetworks', ih.hypernetwork_name FROM image_hypernetworks ih JOIN images i ON i.id = ih.image_id {coll} {lora} {where}
+             SELECT 'hypernetworks', ih.hypernetwork_name FROM image_hypernetworks ih JOIN images i ON i.id = ih.image_id {where}
              UNION ALL
-             SELECT 'tools', COALESCE(NULLIF(i.tool, ''), 'Unknown') FROM images i {coll} {lora} {where}
+             SELECT 'tools', COALESCE(NULLIF(i.tool, ''), 'Unknown') FROM images i {where}
              UNION ALL
-             SELECT 'control_nets', cn.controlnet_name FROM image_controlnets cn JOIN images i ON i.id = cn.image_id {coll} {lora} {where}
+             SELECT 'control_nets', cn.controlnet_name FROM image_controlnets cn JOIN images i ON i.id = cn.image_id {where}
              UNION ALL
-             SELECT 'ip_adapters', ip.ipadapter_name FROM image_ipadapters ip JOIN images i ON i.id = ip.image_id {coll} {lora} {where}",
-            coll = collection_join,
-            lora = lora_join,
+             SELECT 'ip_adapters', ip.ipadapter_name FROM image_ipadapters ip JOIN images i ON i.id = ip.image_id {where}",
             where = prefixed
         );
 
-        // Build params - we need to repeat them 7 times (once per subquery)
         let mut all_params: Vec<rusqlite::types::Value> = Vec::new();
         for _ in 0..7 {
-            if let Some(ref cid) = collection_id {
-                all_params.push(rusqlite::types::Value::Text(cid.clone()));
-            }
-            if let Some(ref ln) = lora_name {
-                all_params.push(rusqlite::types::Value::Text(ln.clone()));
-            }
             all_params.extend(sql_params.clone());
         }
 
@@ -408,7 +361,6 @@ pub async fn get_valid_facet_names(
         let mut control_nets: Vec<String> = Vec::new();
         let mut ip_adapters: Vec<String> = Vec::new();
 
-        // Use HashSets for deduplication (UNION ALL doesn't dedupe)
         use std::collections::HashSet;
         let mut cp_set: HashSet<String> = HashSet::new();
         let mut lora_set: HashSet<String> = HashSet::new();
@@ -436,9 +388,6 @@ pub async fn get_valid_facet_names(
                 _ => {}
             }
         }
-
-        println!("[ValidFacets] Results - CP:{} LoRAs:{} Emb:{} Hyper:{} Tools:{}", 
-            checkpoints.len(), loras.len(), embeddings.len(), hypernetworks.len(), tools.len());
 
         Ok(ValidFacetNames {
             checkpoints,
@@ -480,12 +429,32 @@ fn harvest_models(conn: &rusqlite::Connection) -> Result<(), String> {
     // OPTIMIZATION: Use Junction Tables which are already populated
     let types = [
         ("loras", "harvest_lora", "image_loras", "lora_name"),
-        ("embeddings", "harvest_embedding", "image_embeddings", "embedding_name"),
-        ("hypernetworks", "harvest_hypernet", "image_hypernetworks", "hypernetwork_name"),
-        ("control_nets", "harvest_controlnet", "image_controlnets", "controlnet_name"),
-         ("ip_adapters", "harvest_ip_adapter", "image_ipadapters", "ipadapter_name"),
+        (
+            "embeddings",
+            "harvest_embedding",
+            "image_embeddings",
+            "embedding_name",
+        ),
+        (
+            "hypernetworks",
+            "harvest_hypernet",
+            "image_hypernetworks",
+            "hypernetwork_name",
+        ),
+        (
+            "control_nets",
+            "harvest_controlnet",
+            "image_controlnets",
+            "controlnet_name",
+        ),
+        (
+            "ip_adapters",
+            "harvest_ip_adapter",
+            "image_ipadapters",
+            "ipadapter_name",
+        ),
     ];
-    
+
     for (json_key, source, table, col) in types {
         let prefix = match json_key {
             "loras" => "lora_",
@@ -493,14 +462,14 @@ fn harvest_models(conn: &rusqlite::Connection) -> Result<(), String> {
             "hypernetworks" => "hyper_",
             _ => "", // ControlNets/IPAdapters don't typically use prefixes in 'models' table but let's check legacy
         };
-        
+
         // Note: 'clean_name' logic (removing version/suffix) is duplicated here.
         // Ideally the junction tables would store cleaned names, or we handle it here.
         // The junction creation in `save_images_batch` ALREADY cleans the name!
         // "CASE WHEN instr(value, ...)..." is used in save_images_batch.
         // So the values in `image_loras` ARE ALREADY CLEANED.
         // We can just select them directly.
-        
+
         conn.execute(
             &format!(
                 "INSERT OR IGNORE INTO models (hash, name, lookup_source, scanned_at, resource_type) 
@@ -881,33 +850,53 @@ mod tests {
         // --- Regression Check: Collections ---
         // Verify that rebuilding cache does NOT wipe collections
         // 1. Create a collection
-        conn.execute("INSERT INTO collections (id, name, created_at) VALUES ('col1', 'Test Col', 100)", []).unwrap();
+        conn.execute(
+            "INSERT INTO collections (id, name, created_at) VALUES ('col1', 'Test Col', 100)",
+            [],
+        )
+        .unwrap();
         // 2. Add image to collection
-        conn.execute("INSERT INTO collection_images (collection_id, image_id) VALUES ('col1', 'img1')", []).unwrap();
-        
+        conn.execute(
+            "INSERT INTO collection_images (collection_id, image_id) VALUES ('col1', 'img1')",
+            [],
+        )
+        .unwrap();
+
         // Re-run rebuild to ensure it doesn't touch collections
         // (We already ran parts of it above, this simulates a full run)
         // But wait, the test calls `build_checkpoint_facets` etc individually.
         // Let's verify collections exist now.
-        let col_count: i64 = conn.query_row("SELECT COUNT(*) FROM collections", [], |r| r.get(0)).unwrap();
-        assert_eq!(col_count, 1, "Collection should persist after manual insertions");
+        let col_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM collections", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            col_count, 1,
+            "Collection should persist after manual insertions"
+        );
 
-        // Now run the full rebuild helper if possible? 
+        // Now run the full rebuild helper if possible?
         // No, `rebuild_facet_cache` takes AppHandle. We can't call it here easily.
         // But we can call the internal functions again.
         conn.execute("DELETE FROM facet_cache", []).unwrap(); // Clear cache first
         build_checkpoint_facets(&conn).unwrap();
         build_resource_facets(&conn, "loras", "loras").unwrap();
-        
-        let col_count_after: i64 = conn.query_row("SELECT COUNT(*) FROM collections", [], |r| r.get(0)).unwrap();
-        assert_eq!(col_count_after, 1, "Collection should persist after facet rebuild");
 
+        let col_count_after: i64 = conn
+            .query_row("SELECT COUNT(*) FROM collections", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(
+            col_count_after, 1,
+            "Collection should persist after facet rebuild"
+        );
 
         // Checkpoint Check: Expected thumb2.png (Pinned)
         let (cp_count, cp_thumb): (i64, String) = conn.query_row(
             "SELECT count, thumbnail_path FROM facet_cache WHERE facet_type='checkpoints' AND resource_name='SDXL Base'", 
             [], |r| Ok((r.get(0)?, r.get(1)?))).unwrap();
-        assert_eq!(cp_count, 3, "Multiplier bug! Should count exactly 3 images for SDXL Base (not doubled/tripled)");
+        assert_eq!(
+            cp_count, 3,
+            "Multiplier bug! Should count exactly 3 images for SDXL Base (not doubled/tripled)"
+        );
         assert_eq!(
             cp_thumb, "thumb2.png",
             "Checkpoint thumbnail should be from pinned image (thumb2)"
@@ -948,7 +937,10 @@ mod tests {
         let unknown_count: i64 = conn.query_row(
             "SELECT count FROM facet_cache WHERE facet_type='checkpoints' AND resource_name='Unknown'",
             [], |r| r.get(0)).unwrap();
-        assert_eq!(unknown_count, 3, "Unknown facet should count NULL, Empty, and 'Unknown' (3 total)");
+        assert_eq!(
+            unknown_count, 3,
+            "Unknown facet should count NULL, Empty, and 'Unknown' (3 total)"
+        );
     }
 
     #[test]
@@ -970,26 +962,36 @@ mod tests {
         conn.execute(
             "INSERT INTO images (id, path, timestamp) VALUES ('img1', 'test.png', 100)",
             [],
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         // This is what happens currently: LoRA name stored WITH extension in junction table
         conn.execute(
             "INSERT INTO image_loras (image_id, lora_name) VALUES ('img1', 'MyLora.safetensors')",
             [],
-        ).unwrap();
+        )
+        .unwrap();
 
         // 3. Build LoRA facets
         build_resource_facets(&conn, "loras", "loras").unwrap();
 
         // 4. Check if the facet has the thumbnail
-        let (name, thumb): (String, Option<String>) = conn.query_row(
-            "SELECT resource_name, thumbnail_path FROM facet_cache WHERE facet_type='loras'",
-            [],
-            |r| Ok((r.get(0)?, r.get(1)?))
-        ).unwrap();
+        let (name, thumb): (String, Option<String>) = conn
+            .query_row(
+                "SELECT resource_name, thumbnail_path FROM facet_cache WHERE facet_type='loras'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
 
-        assert_eq!(name, "MyLora", "Facet name should be 'MyLora' (normalized from the model name)");
-        assert!(thumb.is_some(), "Facet should have a thumbnail path linked from the model");
+        assert_eq!(
+            name, "MyLora",
+            "Facet name should be 'MyLora' (normalized from the model name)"
+        );
+        assert!(
+            thumb.is_some(),
+            "Facet should have a thumbnail path linked from the model"
+        );
         assert_eq!(thumb.unwrap(), "C:/thumbs/MyLora.webp");
     }
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -117,9 +117,9 @@ async rebuildFacetCacheIncremental(facetType: string) : Promise<Result<number, s
  * OPTIMIZATION: Uses a single UNION ALL query instead of 5 separate queries
  * to reduce database round-trips and allow SQLite to share table scans.
  */
-async getValidFacetNames(whereClause: string, paramsJson: string, collectionId: string | null, loraName: string | null) : Promise<Result<ValidFacetNames, string>> {
+async getValidFacetNames(filters: RustFilterState, collections: RustCollection[], excludeCategories: string[]) : Promise<Result<ValidFacetNames, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("get_valid_facet_names", { whereClause, paramsJson, collectionId, loraName }) };
+    return { status: "ok", data: await TAURI_INVOKE("get_valid_facet_names", { filters, collections, excludeCategories }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -467,6 +467,8 @@ export type ReparseBatchResult = { processed: number; updated: number; errors: n
  */
 export type ReparseJobResult = { processed: number; updated: number; errors: number; wasCancelled: boolean }
 export type ResolutionResult = { resolvedCount: number; failedCount: number; namedFallbackCount: number; unknownCount: number }
+export type RustCollection = { id: string; name: string; filters: RustFilterState | null; manualExclusions: string[] | null }
+export type RustFilterState = { searchQuery: string; models: string[]; tools: string[]; loras: string[]; embeddings: string[]; hypernetworks: string[]; controlNets: string[]; ipAdapters: string[]; samplers: string[]; generationTypes: string[]; dateRange: string; favoritesOnly: boolean; pinnedOnly: boolean; showIntermediates: boolean; showGrids: boolean; collectionId: string | null; minSteps: number | null; maxSteps: number | null; minCfg: number | null; maxCfg: number | null; matchModes: Partial<{ [key in string]: string }> | null }
 export type ScanResult = { width: number; height: number; size: number; modified: number; thumbnail: string; 
 /**
  * Base64 encoded 32px WebP micro-thumbnail for instant previews

--- a/src/hooks/useLibraryStatsQuery.ts
+++ b/src/hooks/useLibraryStatsQuery.ts
@@ -99,7 +99,7 @@ export const useLibraryStatsQuery = ({
             const [facets, stats, baseValidNames] = await Promise.all([
                 getFacets(where, params, ALL_FACET_TYPES),
                 getLibraryStats(where, params, collectionId, loraName),
-                hasActiveFilters ? getValidFacetNames(where, params, collectionId, loraName) : Promise.resolve(null)
+                hasActiveFilters ? getValidFacetNames(filters, allCollections) : Promise.resolve(null)
             ]);
 
             // 2. Disjunctive Queries: For categories in ANY mode with active selections
@@ -143,7 +143,7 @@ export const useLibraryStatsQuery = ({
                         [excludeKey]
                     );
 
-                    const result = await searchRepo.getValidFacetNames(partial.where, partial.params, partial.collectionId, partial.loraName);
+                    const result = await getValidFacetNames(filters, allCollections, [excludeKey]);
                     return { cat, validNames: result[cat] };
                 });
 

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -1,4 +1,4 @@
-import { AIImage, FacetType } from '../../types';
+import { AIImage, Collection, FacetType, FilterState } from '../../types';
 import { getDb } from './connection';
 import { mapRowToImage, IMAGE_FIELDS_LIGHT } from './repoUtils';
 import { WORD_CLOUD_CONFIG } from '../../config/wordCloud';
@@ -507,20 +507,17 @@ export const getFacets = async (
  * Used to hide facet options that have no matching images in the current filter context.
  */
 export const getValidFacetNames = async (
-    whereClause: string,
-    params: unknown[],
-    collectionId?: string,
-    loraName?: string
+    filters: FilterState,
+    collections: Collection[],
+    excludeCategories: string[] = []
 ): Promise<ValidFacetNames> => {
     try {
         // Import the command dynamically to avoid circular dependencies
         const { commands } = await import('../../bindings');
-        // Serialize params as JSON string for Specta compatibility
         const result = await commands.getValidFacetNames(
-            whereClause,
-            JSON.stringify(params),
-            collectionId ?? null,
-            loraName ?? null
+            filters as any,
+            collections as any,
+            excludeCategories
         );
 
         if (result.status === 'ok') {


### PR DESCRIPTION
## What changed
This switches valid-facet lookups from ad hoc SQL input strings to typed filter payloads shared between the frontend and Rust backend.

## Why
The preserved local WIP for valid-facet drill-down logic was still hanging off the old pre-release branch state and no longer matched the generated Specta command signature. This PR moves that work onto current `main`, makes the command contract typed, and regenerates the bindings so the frontend and backend stay aligned.

## Impact
Frontend facet drill-down now calls `getValidFacetNames` with typed `FilterState` and collection data.
Rust builds the WHERE clause from typed filter structs, including support for excluded categories used by disjunctive facet queries.
Specta bindings now expose the new typed command contract.

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm test:rust`
- `pnpm build`

## Notes
- Local `tasks/` remains untracked and is intentionally not part of this PR.
- Repo-wide Rust formatting is still blocked by pre-existing trailing whitespace in unrelated files, so this PR keeps formatting scoped to the functional change.