### PR TITLE
Fix Live Watch sync coordination and stabilize the Live Watch card

### DIFF
--- a/src-tauri/src/db/commands/image_commands.rs
+++ b/src-tauri/src/db/commands/image_commands.rs
@@ -43,11 +43,11 @@ pub async fn save_images_batch(
                             thumbnail_path=COALESCE(NULLIF(excluded.thumbnail_path, ''), images.thumbnail_path),
                             micro_thumbnail=COALESCE(excluded.micro_thumbnail, images.micro_thumbnail),
                             thumbnail_source=COALESCE(excluded.thumbnail_source, images.thumbnail_source),
-                            is_favorite=COALESCE(images.is_favorite, excluded.is_favorite),
-                            is_pinned=COALESCE(images.is_pinned, excluded.is_pinned),
-                            group_id=COALESCE(images.group_id, excluded.group_id),
-                            board_id=COALESCE(images.board_id, excluded.board_id),
-                            notes=COALESCE(images.notes, excluded.notes),
+                           is_favorite=excluded.is_favorite,
+                           is_pinned=excluded.is_pinned,
+                           group_id=COALESCE(images.group_id, excluded.group_id),
+                           board_id=excluded.board_id,
+                           notes=COALESCE(images.notes, excluded.notes),
                             original_metadata_json=excluded.original_metadata_json,
                             original_state_json=COALESCE(images.original_state_json, excluded.original_state_json),
                             is_corrupt=excluded.is_corrupt,
@@ -64,6 +64,9 @@ pub async fn save_images_batch(
                          WHERE images.metadata_json != excluded.metadata_json 
                             OR images.timestamp != excluded.timestamp 
                             OR images.file_size != excluded.file_size
+                            OR images.is_favorite IS NOT excluded.is_favorite
+                            OR images.is_pinned IS NOT excluded.is_pinned
+                            OR images.board_id IS NOT excluded.board_id
                             OR images.original_metadata_json IS NULL
                             OR images.original_metadata_json != excluded.original_metadata_json"
                     ).map_err(|e| e.to_string())?;
@@ -310,4 +313,75 @@ pub async fn verify_library_integrity(app: AppHandle) -> Result<IntegrityResult,
         tx.commit().map_err(|e| e.to_string())?;
         Ok(IntegrityResult { missing: missing_count, recovered: ids_to_mark_found.len(), broken_thumbs: thumb_count })
     }).await
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{params, Connection};
+
+    #[test]
+    fn upsert_updates_live_sync_controlled_fields_even_when_metadata_is_unchanged() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+
+        conn.execute_batch(
+            "
+            CREATE TABLE images (
+                id TEXT PRIMARY KEY,
+                metadata_json TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                file_size INTEGER NOT NULL,
+                is_favorite INTEGER,
+                is_pinned INTEGER,
+                board_id TEXT,
+                original_metadata_json TEXT
+            );
+            ",
+        )
+        .expect("schema");
+
+        let upsert_sql = "
+            INSERT INTO images (id, metadata_json, timestamp, file_size, is_favorite, is_pinned, board_id, original_metadata_json)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+            ON CONFLICT(id) DO UPDATE SET
+                metadata_json = excluded.metadata_json,
+                timestamp = excluded.timestamp,
+                file_size = excluded.file_size,
+                is_favorite = excluded.is_favorite,
+                is_pinned = excluded.is_pinned,
+                board_id = excluded.board_id,
+                original_metadata_json = excluded.original_metadata_json
+            WHERE images.metadata_json != excluded.metadata_json
+                OR images.timestamp != excluded.timestamp
+                OR images.file_size != excluded.file_size
+                OR images.is_favorite IS NOT excluded.is_favorite
+                OR images.is_pinned IS NOT excluded.is_pinned
+                OR images.board_id IS NOT excluded.board_id
+                OR images.original_metadata_json IS NULL
+                OR images.original_metadata_json != excluded.original_metadata_json
+        ";
+
+        conn.execute(upsert_sql, params!["img-1", "{}", 123_i64, 456_i64, 0_i64, 0_i64, Option::<String>::None, "{}"])
+            .expect("initial insert");
+
+        conn.execute(upsert_sql, params!["img-1", "{}", 123_i64, 456_i64, 1_i64, 1_i64, Some("board-1"), "{}"])
+            .expect("conflict update");
+
+        let updated = conn
+            .query_row(
+                "SELECT is_favorite, is_pinned, board_id FROM images WHERE id = ?1",
+                ["img-1"],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                },
+            )
+            .expect("fetch row");
+
+        assert_eq!(updated.0, 1);
+        assert_eq!(updated.1, 1);
+        assert_eq!(updated.2.as_deref(), Some("board-1"));
+    }
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -1,8 +1,41 @@
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
-use std::path::PathBuf;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tauri::Emitter;
+
+const WATCHER_THROTTLE_MS: u64 = 1_000;
+const WATCHER_TIMEOUT_MS: u64 = 250;
+
+fn path_extension_label(path: &str) -> String {
+    let lower = path.to_lowercase();
+    if lower.ends_with(".db-wal") {
+        return "db-wal".to_string();
+    }
+
+    Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_lowercase())
+        .filter(|ext| !ext.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn summarize_path_types(paths: &[String]) -> String {
+    let mut counts = BTreeMap::new();
+
+    for path in paths {
+        let ext = path_extension_label(path);
+        *counts.entry(ext).or_insert(0usize) += 1;
+    }
+
+    counts
+        .into_iter()
+        .map(|(ext, count)| format!("{ext}:{count}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
 
 pub struct WatcherState {
     pub watcher: Mutex<Option<RecommendedWatcher>>,
@@ -48,17 +81,28 @@ pub fn start_native_folder_watcher(
     tauri::async_runtime::spawn(async move {
         let mut buffer = std::collections::HashSet::new();
         let mut first_event_time: Option<tokio::time::Instant> = None;
-        let throttle_duration = tokio::time::Duration::from_secs(2);
+        let throttle_duration = tokio::time::Duration::from_millis(WATCHER_THROTTLE_MS);
 
         loop {
-            match tokio::time::timeout(tokio::time::Duration::from_millis(500), rx.recv()).await {
+            match tokio::time::timeout(tokio::time::Duration::from_millis(WATCHER_TIMEOUT_MS), rx.recv()).await {
                 Ok(Some(paths)) => {
                     buffer.extend(paths);
                     if first_event_time.is_none() {
                         first_event_time = Some(tokio::time::Instant::now());
-                    } else if first_event_time.unwrap().elapsed() >= throttle_duration {
+                    } else if first_event_time
+                        .map(|started_at| started_at.elapsed() >= throttle_duration)
+                        .unwrap_or(false)
+                    {
+                        let batch_age_ms = first_event_time
+                            .map(|started_at| started_at.elapsed().as_millis())
+                            .unwrap_or(0);
                         let to_emit: Vec<String> = buffer.drain().collect();
-                        println!("[Rust Watcher] Emitting throttled batch of {} paths", to_emit.len());
+                        println!(
+                            "[LiveWatchPerf] watcher batch emitted | reason=throttle | paths={} | age_ms={} | types={}",
+                            to_emit.len(),
+                            batch_age_ms,
+                            summarize_path_types(&to_emit)
+                        );
                         let _ = app_handle.emit("folder-change-event", to_emit);
                         first_event_time = None;
                     }
@@ -66,8 +110,16 @@ pub fn start_native_folder_watcher(
                 Ok(None) => break, // Channel closed
                 Err(_) => { // Timeout elapsed
                     if !buffer.is_empty() {
+                        let batch_age_ms = first_event_time
+                            .map(|started_at| started_at.elapsed().as_millis())
+                            .unwrap_or(0);
                         let to_emit: Vec<String> = buffer.drain().collect();
-                        println!("[Rust Watcher] Emitting debounced batch of {} paths", to_emit.len());
+                        println!(
+                            "[LiveWatchPerf] watcher batch emitted | reason=timeout | paths={} | age_ms={} | types={}",
+                            to_emit.len(),
+                            batch_age_ms,
+                            summarize_path_types(&to_emit)
+                        );
                         let _ = app_handle.emit("folder-change-event", to_emit);
                         first_event_time = None;
                     }
@@ -115,6 +167,8 @@ pub fn start_native_folder_watcher(
                         return;
                     }
 
+                    let raw_path_count = event.paths.len();
+                    let event_kind = format!("{:?}", event.kind);
                     let valid_paths: Vec<String> = event
                         .paths
                         .into_iter()
@@ -133,6 +187,13 @@ pub fn start_native_folder_watcher(
                         .collect();
 
                     if !valid_paths.is_empty() {
+                        println!(
+                            "[LiveWatchPerf] watcher event received | kind={} | raw_paths={} | matched_paths={} | types={}",
+                            event_kind,
+                            raw_path_count,
+                            valid_paths.len(),
+                            summarize_path_types(&valid_paths)
+                        );
                         let _ = tx.blocking_send(valid_paths);
                     }
                 }

--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -37,6 +37,8 @@ export const ActivityDock: React.FC = () => {
 
     // Show Live Watch if active and nothing else is overriding it
     const isLiveWatchActive = liveWatchSession.active && !isHighPriorityActive && !isBackgroundActive && !isRefreshActive;
+    const isLiveWatchSummary = isLiveWatchActive && liveWatchSession.phase === 'summary';
+    const isLiveWatchTone = isLiveWatchActive;
 
     const active = isHighPriorityActive || isBackgroundActive || isRefreshActive || isLiveWatchActive;
 
@@ -86,17 +88,30 @@ export const ActivityDock: React.FC = () => {
             message: liveWatchSession.message
         };
         label = "Live Watch";
-        isLowPriority = liveWatchSession.phase === 'watching' || liveWatchSession.phase === 'summary';
-        footerMessage = liveWatchSession.phase === 'summary'
-            ? 'Watching for more images in this session.'
-            : 'Live Watch stays active in the background.';
+        isLowPriority = true;
+        footerMessage = 'Live Watch stays active in the background.';
     }
 
     const current = progress?.current || 0;
     const total = progress?.total || 0;
     const message = progress?.message || (isLiveWatchActive ? liveWatchSession.message || '' : '');
-    const percent = total > 0 ? Math.round((current / total) * 100) : (active ? 0 : 0);
-    const showIndeterminateProgress = total === 0 && active && (!isLiveWatchActive || liveWatchSession.phase !== 'summary');
+    const percent = isLiveWatchSummary ? 100 : total > 0 ? Math.round((current / total) * 100) : (active ? 0 : 0);
+    const showIndeterminateProgress = total === 0 && active && (!isLiveWatchActive || !isLiveWatchSummary);
+    const accentClasses = isLiveWatchTone || isLowPriority
+        ? {
+            iconText: 'text-violet-600 dark:text-violet-400',
+            iconBg: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
+            fill: 'bg-violet-400 shadow-[0_0_12px_rgba(139,92,246,0.3)]',
+            pillHover: 'hover:shadow-[0_0_15px_rgba(139,92,246,0.2)]',
+            percentText: 'text-violet-600 dark:text-violet-400'
+        }
+        : {
+            iconText: 'text-sage-600 dark:text-sage-400',
+            iconBg: 'bg-sage-500/10 text-sage-600 dark:text-sage-400',
+            fill: 'bg-sage-500 shadow-[0_0_12px_rgba(139,174,124,0.5)]',
+            pillHover: 'hover:shadow-[0_0_15px_rgba(139,174,124,0.3)]',
+            percentText: 'text-sage-600 dark:text-sage-400'
+        };
 
     // Should we show the dock? Active AND not dismissed.
     const shouldShow = active && !isActivityDockDismissed;
@@ -117,15 +132,15 @@ export const ActivityDock: React.FC = () => {
                         <motion.div
                             layoutId="dock-content"
                             onClick={() => setIsActivityDockMinimized(false)}
-                            className={`group bg-white/80 dark:bg-zinc-900/80 backdrop-blur-xl border border-white/20 dark:border-white/10 p-2.5 rounded-full shadow-xl flex items-center gap-3 cursor-pointer hover:scale-105 transition-transform ${isLowPriority ? 'hover:shadow-[0_0_15px_rgba(139,92,246,0.2)]' : 'hover:shadow-[0_0_15px_rgba(139,174,124,0.3)]'}`}
+                            className={`group bg-white/80 dark:bg-zinc-900/80 backdrop-blur-xl border border-white/20 dark:border-white/10 p-2.5 rounded-full shadow-xl flex items-center gap-3 cursor-pointer hover:scale-105 transition-transform ${accentClasses.pillHover}`}
                             title="Click to expand details"
                         >
-                            <motion.div layout="position" className={`${isLowPriority ? 'text-violet-600 dark:text-violet-400' : 'text-sage-600 dark:text-sage-400'}`}>
-                                {isLowPriority ? <Sparkles className="w-5 h-5 animate-pulse" /> : <Loader2 className="w-5 h-5 animate-spin" />}
+                            <motion.div layout="position" className={accentClasses.iconText}>
+                                {isLiveWatchTone || isLowPriority ? <Sparkles className="w-5 h-5 animate-pulse" /> : <Loader2 className="w-5 h-5 animate-spin" />}
                             </motion.div>
                             <motion.div layout="position" className="w-12 h-1 bg-gray-200 dark:bg-zinc-700 rounded-full overflow-hidden mr-1">
                                 <div
-                                    className={`h-full ${isLowPriority ? 'bg-violet-500' : 'bg-sage-500'}`}
+                                    className={`h-full ${isLiveWatchTone || isLowPriority ? 'bg-violet-500' : 'bg-sage-500'}`}
                                     style={{ width: `${percent}%` }}
                                 />
                             </motion.div>
@@ -134,19 +149,19 @@ export const ActivityDock: React.FC = () => {
                         // Maximized Card View
                         <motion.div
                             layoutId="dock-content"
-                            className="bg-white/70 dark:bg-zinc-900/70 backdrop-blur-2xl border border-white/20 dark:border-white/10 p-4 rounded-2xl shadow-2xl flex flex-col min-w-[320px] max-w-[400px] gap-3 group"
+                            className="bg-white/70 dark:bg-zinc-900/70 backdrop-blur-2xl border border-white/20 dark:border-white/10 p-4 rounded-2xl shadow-2xl flex flex-col w-[min(360px,calc(100vw-2rem))] gap-3 group"
                         >
                             {/* Header */}
                             <div className="flex items-center justify-between gap-4">
                                 <div className="flex items-center gap-3">
-                                    <motion.div layout="position" className={`p-2 rounded-lg ${isLowPriority ? 'bg-violet-500/10 text-violet-600 dark:text-violet-400' : 'bg-sage-500/10 text-sage-600 dark:text-sage-400'}`}>
-                                        {isLowPriority ? <Sparkles className="w-4 h-4" /> : <Loader2 className="w-4 h-4 animate-spin" />}
+                                    <motion.div layout="position" className={`p-2 rounded-lg ${accentClasses.iconBg}`}>
+                                        {isLiveWatchTone || isLowPriority ? <Sparkles className="w-4 h-4" /> : <Loader2 className="w-4 h-4 animate-spin" />}
                                     </motion.div>
                                     <motion.div layout="position">
                                         <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-500 italic opacity-80 leading-none mb-1">Background Activity</h4>
                                         <p className="text-sm font-bold text-gray-900 dark:text-white flex items-center gap-2">
                                             {label}
-                                            {total > 0 && <span className="text-xs font-medium text-gray-400 font-mono tracking-tight">{current.toLocaleString()} / {total.toLocaleString()}</span>}
+                                            {total > 0 && !isLiveWatchActive && <span className="text-xs font-medium text-gray-400 font-mono tracking-tight">{current.toLocaleString()} / {total.toLocaleString()}</span>}
                                         </p>
                                     </motion.div>
                                 </div>
@@ -175,7 +190,7 @@ export const ActivityDock: React.FC = () => {
                                         initial={{ width: 0 }}
                                         animate={{ width: `${percent}%` }}
                                         transition={{ duration: 0.5, ease: "easeOut" }}
-                                        className={`h-full ${isLowPriority ? 'bg-violet-400 shadow-[0_0_12px_rgba(139,92,246,0.3)]' : 'bg-sage-500 shadow-[0_0_12px_rgba(139,174,124,0.5)]'}`}
+                                        className={`h-full ${accentClasses.fill}`}
                                     />
                                     {showIndeterminateProgress && (
                                         <motion.div
@@ -187,11 +202,11 @@ export const ActivityDock: React.FC = () => {
                                     )}
                                 </div>
                                 <div className="flex justify-between items-center px-0.5">
-                                    <p className="text-[11px] font-medium text-gray-500 dark:text-gray-400 truncate flex-1 pr-4">
+                                    <p className="text-[11px] font-medium text-gray-500 dark:text-gray-400 truncate flex-1 pr-4 h-4 leading-4">
                                         {message || "Starting work..."}
                                     </p>
                                     {!isLiveWatchActive && (
-                                        <span className={`text-[11px] font-black font-mono italic ${isLowPriority ? 'text-violet-600 dark:text-violet-400' : 'text-sage-600 dark:text-sage-400'}`}>
+                                        <span className={`text-[11px] font-black font-mono italic ${accentClasses.percentText}`}>
                                             {percent}%
                                         </span>
                                     )}

--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -6,8 +6,8 @@ import { useLibraryStore } from '../../stores/libraryStore';
 export const ActivityDock: React.FC = () => {
     const {
         isImporting, importProgress,
-        syncStatus, syncProgress, isLiveSyncing,
-        isReceivingLiveImages, liveImagesReceivedCount,
+        syncStatus, syncProgress,
+        liveWatchSession,
         isRegeneratingThumbnails, thumbnailProgress,
         isResolvingModels, modelResolutionProgress,
         isActivityDockDismissed, setIsActivityDockDismissed,
@@ -26,17 +26,17 @@ export const ActivityDock: React.FC = () => {
         cancelRefresh
     } = useLibraryStore();
 
-    const isSyncing = syncStatus === 'syncing' || isLiveSyncing;
+    const isManualSyncing = syncStatus === 'syncing';
 
-    // Priority order: Import > Sync > Manual Regen > Model Resolution > Populating > Background Healing > Reparsing > Live Watch
-    const isHighPriorityActive = isImporting || isSyncing || isRegeneratingThumbnails || isResolvingModels || isPopulatingThumbnails || isScanningDiscovery;
+    // Priority order: Import > Manual Sync > Manual Regen > Model Resolution > Populating > Background Healing > Reparsing > Live Watch
+    const isHighPriorityActive = isImporting || isManualSyncing || isRegeneratingThumbnails || isResolvingModels || isPopulatingThumbnails || isScanningDiscovery;
     const isBackgroundActive = isBackgroundHealingActive && !backgroundHealingPaused && !isHighPriorityActive;
 
     // Show refresh if active AND no high priority
     const isRefreshActive = isRefreshingMetadata && !isHighPriorityActive && !isBackgroundActive;
 
     // Show Live Watch if active and nothing else is overriding it
-    const isLiveWatchActive = isReceivingLiveImages && !isHighPriorityActive && !isBackgroundActive && !isRefreshActive;
+    const isLiveWatchActive = liveWatchSession.active && !isHighPriorityActive && !isBackgroundActive && !isRefreshActive;
 
     const active = isHighPriorityActive || isBackgroundActive || isRefreshActive || isLiveWatchActive;
 
@@ -44,22 +44,29 @@ export const ActivityDock: React.FC = () => {
     let progress = null;
     let label = "";
     let isLowPriority = false;
+    let supportsCancel = false;
+    let footerMessage = "Tracking continues in the top header.";
 
     if (isImporting) {
         progress = importProgress;
         label = "Importing";
-    } else if (isSyncing) {
+        supportsCancel = true;
+    } else if (isManualSyncing) {
         progress = syncProgress;
         label = "Syncing";
+        supportsCancel = true;
     } else if (isRegeneratingThumbnails) {
         progress = thumbnailProgress;
         label = "Optimizing";
+        supportsCancel = true;
     } else if (isResolvingModels) {
         progress = modelResolutionProgress;
         label = "Resolving Models";
+        supportsCancel = true;
     } else if (isScanningDiscovery) {
         progress = discoveryScanProgress;
         label = "Discovery Scan";
+        supportsCancel = true;
     } else if (isPopulatingThumbnails) {
         progress = { current: 0, total: 0, message: "Matching images to models..." };
         label = "Smart Fill";
@@ -71,16 +78,25 @@ export const ActivityDock: React.FC = () => {
         progress = refreshProgress;
         label = "Refreshing Metadata";
         isLowPriority = false;
+        supportsCancel = true;
     } else if (isLiveWatchActive) {
-        progress = { current: 0, total: 0, message: `${liveImagesReceivedCount} images received this session...` };
-        label = "Live Sync Session";
-        isLowPriority = true;
+        progress = liveWatchSession.progress || {
+            current: 0,
+            total: 0,
+            message: liveWatchSession.message
+        };
+        label = "Live Watch";
+        isLowPriority = liveWatchSession.phase === 'watching' || liveWatchSession.phase === 'summary';
+        footerMessage = liveWatchSession.phase === 'summary'
+            ? 'Watching for more images in this session.'
+            : 'Live Watch stays active in the background.';
     }
 
     const current = progress?.current || 0;
     const total = progress?.total || 0;
-    const message = progress?.message || "";
+    const message = progress?.message || (isLiveWatchActive ? liveWatchSession.message || '' : '');
     const percent = total > 0 ? Math.round((current / total) * 100) : (active ? 0 : 0);
+    const showIndeterminateProgress = total === 0 && active && (!isLiveWatchActive || liveWatchSession.phase !== 'summary');
 
     // Should we show the dock? Active AND not dismissed.
     const shouldShow = active && !isActivityDockDismissed;
@@ -145,7 +161,7 @@ export const ActivityDock: React.FC = () => {
                                     <button
                                         onClick={() => setIsActivityDockDismissed(true)}
                                         className="p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg text-gray-400 hover:text-gray-900 dark:hover:text-white transition-all hover:scale-105 active:scale-95"
-                                        title="Dismiss (Continues in Header)"
+                                        title="Dismiss"
                                     >
                                         <X className="w-3.5 h-3.5" />
                                     </button>
@@ -161,7 +177,7 @@ export const ActivityDock: React.FC = () => {
                                         transition={{ duration: 0.5, ease: "easeOut" }}
                                         className={`h-full ${isLowPriority ? 'bg-violet-400 shadow-[0_0_12px_rgba(139,92,246,0.3)]' : 'bg-sage-500 shadow-[0_0_12px_rgba(139,174,124,0.5)]'}`}
                                     />
-                                    {total === 0 && active && (
+                                    {showIndeterminateProgress && (
                                         <motion.div
                                             initial={{ x: "-100%" }}
                                             animate={{ x: "200%" }}
@@ -186,14 +202,14 @@ export const ActivityDock: React.FC = () => {
                             <motion.div layout="position" className="pt-2 border-t border-black/5 dark:border-white/5 flex items-center justify-between gap-2">
                                 <div className="flex items-center gap-2">
                                     <Info className="w-3 h-3 text-gray-400" />
-                                    <span className="text-[9px] text-gray-500 font-medium">Tracking continues in the top header.</span>
+                                    <span className="text-[9px] text-gray-500 font-medium">{footerMessage}</span>
                                 </div>
 
-                                {(isImporting || isSyncing || isRegeneratingThumbnails || isResolvingModels || isScanningDiscovery || isRefreshActive) && (
+                                {supportsCancel && (
                                     <button
                                         onClick={() => {
                                             if (isImporting) cancelImport();
-                                            if (isSyncing) cancelSync();
+                                            if (isManualSyncing) cancelSync();
                                             if (isRegeneratingThumbnails) cancelThumbnailRegeneration();
                                             if (isResolvingModels) {
                                                 import('@tauri-apps/api/core').then(({ invoke }) => {

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -59,19 +59,27 @@ export const AppHeader = React.memo(({
     const {
         isLiveWatching, setIsLiveWatching,
         isImporting, importProgress,
-        isLiveSyncing, syncStatus, syncProgress,
+        liveWatchSession,
+        syncStatus, syncProgress,
         isResolvingModels, modelResolutionProgress,
         isScanningDiscovery, discoveryScanProgress, // Added
         isBackgroundHealingActive, backgroundHealingProgress // Added
     } = useLibraryStore();
 
-    const isSyncing = syncStatus === 'syncing' || isLiveSyncing;
-    const isHighPriority = isImporting || isSyncing || isResolvingModels || isScanningDiscovery;
+    const isManualSyncing = syncStatus === 'syncing';
+    const isLiveWatchActive = liveWatchSession.active && liveWatchSession.phase !== 'summary';
+    const isHighPriority = isImporting || isManualSyncing || isLiveWatchActive || isResolvingModels || isScanningDiscovery;
     const active = isHighPriority || isBackgroundHealingActive;
 
     const progress = (isImporting && importProgress)
         ? importProgress
-        : (isSyncing ? syncProgress : (isResolvingModels ? modelResolutionProgress : (isScanningDiscovery ? discoveryScanProgress : (isBackgroundHealingActive ? backgroundHealingProgress : null))));
+        : (isManualSyncing
+            ? syncProgress
+            : (isLiveWatchActive
+                ? (liveWatchSession.progress || { current: 0, total: 0, message: liveWatchSession.message })
+                : (isResolvingModels
+                    ? modelResolutionProgress
+                    : (isScanningDiscovery ? discoveryScanProgress : (isBackgroundHealingActive ? backgroundHealingProgress : null)))));
 
     // Determine color
     const isBackgroundOnly = isBackgroundHealingActive && !isHighPriority;

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -67,8 +67,10 @@ export const AppHeader = React.memo(({
     } = useLibraryStore();
 
     const isManualSyncing = syncStatus === 'syncing';
-    const isLiveWatchActive = liveWatchSession.active && liveWatchSession.phase !== 'summary';
-    const isHighPriority = isImporting || isManualSyncing || isLiveWatchActive || isResolvingModels || isScanningDiscovery;
+    const isLiveWatchActive = liveWatchSession.active;
+    const isLiveWatchSummary = isLiveWatchActive && liveWatchSession.phase === 'summary';
+    const isNonLiveTaskActive = isImporting || isManualSyncing || isResolvingModels || isScanningDiscovery;
+    const isHighPriority = isNonLiveTaskActive || isLiveWatchActive;
     const active = isHighPriority || isBackgroundHealingActive;
 
     const progress = (isImporting && importProgress)
@@ -76,16 +78,21 @@ export const AppHeader = React.memo(({
         : (isManualSyncing
             ? syncProgress
             : (isLiveWatchActive
-                ? (liveWatchSession.progress || { current: 0, total: 0, message: liveWatchSession.message })
+                ? (liveWatchSession.progress || {
+                    current: isLiveWatchSummary ? 1 : 0,
+                    total: isLiveWatchSummary ? 1 : 0,
+                    message: liveWatchSession.message
+                })
                 : (isResolvingModels
                     ? modelResolutionProgress
                     : (isScanningDiscovery ? discoveryScanProgress : (isBackgroundHealingActive ? backgroundHealingProgress : null)))));
 
     // Determine color
     const isBackgroundOnly = isBackgroundHealingActive && !isHighPriority;
-    const progressColorInfo = isBackgroundOnly
+    const progressColorInfo = isLiveWatchActive || isBackgroundOnly
         ? { bar: 'bg-violet-500', shadow: 'shadow-[0_0_10px_rgba(139,92,246,0.3)]', bg: 'bg-violet-500/10' }
         : { bar: 'bg-sage-500', shadow: 'shadow-[0_0_10px_rgba(110,121,107,0.5)]', bg: 'bg-sage-500/10' };
+    const shouldHighlightImport = isNonLiveTaskActive || isBackgroundHealingActive;
 
     // Determine visibility of middle controls
     const showLayoutSwitcher = viewMode === 'grid';
@@ -124,7 +131,7 @@ export const AppHeader = React.memo(({
                     <div className="flex items-center gap-1">
                         <button
                             onClick={onImport}
-                            className={`p-2 rounded-xl transition-all border relative group ${active ? 'animate-pulse text-sage-600 bg-sage-500/20' : 'bg-gray-100 dark:bg-zinc-800/50 border-gray-200 dark:border-white/10 text-gray-500 hover:text-gray-900 dark:hover:text-white'}`}
+                            className={`p-2 rounded-xl transition-all border relative group ${shouldHighlightImport ? 'animate-pulse text-sage-600 bg-sage-500/20' : 'bg-gray-100 dark:bg-zinc-800/50 border-gray-200 dark:border-white/10 text-gray-500 hover:text-gray-900 dark:hover:text-white'}`}
                             title="Import images. For automatic sync with favorites & boards, set up an Integration in Settings."
                         >
                             <Import className="w-4 h-4" />

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { act, render, screen } from '../../../test/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ActivityDock } from '../ActivityDock';
+import { createInitialLiveWatchSessionState, useLibraryStore } from '../../../stores/libraryStore';
+
+vi.mock('framer-motion', () => ({
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    motion: {
+        div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>
+    }
+}));
+
+const resetLibraryStore = () => {
+    useLibraryStore.setState(useLibraryStore.getInitialState(), true);
+    useLibraryStore.setState({
+        liveWatchSession: createInitialLiveWatchSessionState(),
+        syncStatus: 'idle',
+        syncProgress: { current: 0, total: 0, message: '' },
+        isImporting: false,
+        importProgress: null,
+        isRegeneratingThumbnails: false,
+        thumbnailProgress: null,
+        isResolvingModels: false,
+        modelResolutionProgress: null,
+        isScanningDiscovery: false,
+        discoveryScanProgress: null,
+        isBackgroundHealingActive: false,
+        backgroundHealingProgress: null,
+        backgroundHealingPaused: false,
+        isRefreshingMetadata: false,
+        refreshProgress: null,
+        isActivityDockDismissed: false,
+        isActivityDockMinimized: false
+    });
+};
+
+describe('ActivityDock', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        resetLibraryStore();
+    });
+
+    it('renders the manual syncing card with cancel controls', () => {
+        useLibraryStore.setState({
+            syncStatus: 'syncing',
+            syncProgress: { current: 2, total: 5, message: 'Syncing collections...' }
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Syncing')).toBeTruthy();
+        expect(screen.getByText('Cancel')).toBeTruthy();
+        expect(screen.queryByText('Live Watch')).toBeNull();
+    });
+
+    it('renders a unified Live Watch card without cancel controls during active live work', () => {
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Preparing live InvokeAI sync...',
+            progress: { current: 0, total: 0, message: undefined }
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+        expect(screen.getByText('Preparing live InvokeAI sync...')).toBeTruthy();
+        expect(screen.queryByText('Syncing')).toBeNull();
+        expect(screen.queryByText('Cancel')).toBeNull();
+    });
+
+    it('keeps the same Live Watch card through summary updates', () => {
+        render(<ActivityDock />);
+
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('generic', {
+                phase: 'importing',
+                message: 'Importing live images...',
+                progress: { current: 1, total: 2, message: undefined }
+            });
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+        expect(screen.getByText('Importing live images...')).toBeTruthy();
+
+        act(() => {
+            useLibraryStore.getState().reportLiveImagesReceived(2, { source: 'generic' });
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+        expect(screen.getByText('2 images received this session. Watching for more...')).toBeTruthy();
+        expect(screen.queryByText('Syncing')).toBeNull();
+        expect(screen.queryByText('Cancel')).toBeNull();
+    });
+});

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -61,16 +61,22 @@ describe('ActivityDock', () => {
             progress: { current: 0, total: 0, message: undefined }
         });
 
-        render(<ActivityDock />);
+        const { container } = render(<ActivityDock />);
+        const card = container.querySelector('[layoutid="dock-content"]');
+        const progressFill = container.querySelector('.bg-violet-400');
 
         expect(screen.getByText('Live Watch')).toBeTruthy();
         expect(screen.getByText('Preparing live InvokeAI sync...')).toBeTruthy();
         expect(screen.queryByText('Syncing')).toBeNull();
         expect(screen.queryByText('Cancel')).toBeNull();
+        expect(screen.queryByText('0 / 0')).toBeNull();
+        expect(card?.className).toContain('w-[min(360px,calc(100vw-2rem))]');
+        expect(progressFill).toBeTruthy();
+        expect(container.querySelector('.text-sage-600')).toBeNull();
     });
 
     it('keeps the same Live Watch card through summary updates', () => {
-        render(<ActivityDock />);
+        const { container } = render(<ActivityDock />);
 
         act(() => {
             useLibraryStore.getState().startLiveWatchSession('generic', {
@@ -91,5 +97,8 @@ describe('ActivityDock', () => {
         expect(screen.getByText('2 images received this session. Watching for more...')).toBeTruthy();
         expect(screen.queryByText('Syncing')).toBeNull();
         expect(screen.queryByText('Cancel')).toBeNull();
+        expect(screen.getByText('Live Watch stays active in the background.')).toBeTruthy();
+        expect(container.querySelector('.bg-violet-400')).toBeTruthy();
+        expect(container.querySelector('.bg-gradient-to-r')).toBeNull();
     });
 });

--- a/src/components/ui/__tests__/AppHeader.test.tsx
+++ b/src/components/ui/__tests__/AppHeader.test.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { render, screen } from '../../../test/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppHeader } from '../AppHeader';
+import { createInitialLiveWatchSessionState, useLibraryStore } from '../../../stores/libraryStore';
+
+vi.mock('../../../hooks/useLibraryContext', () => ({
+    useLibraryContext: () => ({
+        settings: { thumbnailSize: 200 },
+        setSettings: vi.fn(),
+        recentSearches: [],
+        setRecentSearches: vi.fn()
+    })
+}));
+
+vi.mock('../../../features/filters/components/SearchBar', () => ({
+    SearchBar: () => <div data-testid="search-bar" />
+}));
+
+vi.mock('../../../features/library/components/ViewControls', () => ({
+    ViewControls: () => <div data-testid="view-controls" />
+}));
+
+vi.mock('../../../features/filters/components/ActiveFilters', () => ({
+    ActiveFilters: () => <div data-testid="active-filters" />
+}));
+
+const resetLibraryStore = () => {
+    useLibraryStore.setState(useLibraryStore.getInitialState(), true);
+    useLibraryStore.setState({
+        liveWatchSession: createInitialLiveWatchSessionState(),
+        syncStatus: 'idle',
+        syncProgress: { current: 0, total: 0, message: '' },
+        isImporting: false,
+        importProgress: null,
+        isResolvingModels: false,
+        modelResolutionProgress: null,
+        isScanningDiscovery: false,
+        discoveryScanProgress: null,
+        isBackgroundHealingActive: false,
+        backgroundHealingProgress: null
+    });
+};
+
+const defaultProps = {
+    viewMode: 'grid' as const,
+    filters: {
+        searchQuery: '',
+        models: [],
+        tools: [],
+        loras: [],
+        embeddings: [],
+        hypernetworks: [],
+        samplers: [],
+        generationTypes: [],
+        controlNets: [],
+        ipAdapters: [],
+        dateRange: 'all' as const,
+        favoritesOnly: false,
+        collectionId: null,
+        showIntermediates: false,
+        showGrids: false
+    },
+    setFilters: vi.fn(),
+    searchProps: {
+        isAiSearchEnabled: false,
+        isSearchingAi: false,
+        inputRef: { current: null },
+        toggleAiSearch: vi.fn(),
+        submitSearch: vi.fn(),
+        isFocused: false,
+        onFocus: vi.fn(),
+        onBlur: vi.fn()
+    },
+    layoutMode: 'masonry' as const,
+    setLayoutMode: vi.fn(),
+    sortOption: 'date_desc' as const,
+    setSortOption: vi.fn(),
+    displayedCount: 10,
+    totalCount: 10,
+    scopeName: 'Library',
+    onImport: vi.fn(),
+    onSlideshow: vi.fn(),
+    clearAllFilters: vi.fn(),
+    isFiltering: false
+};
+
+describe('AppHeader', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        resetLibraryStore();
+    });
+
+    it('uses the purple header strip and leaves the import button neutral during live watch', () => {
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Preparing live InvokeAI sync...',
+            progress: { current: 0, total: 0, message: undefined }
+        });
+
+        const { container } = render(<AppHeader {...defaultProps} />);
+        const importButton = screen.getByTitle(/Import images\./);
+
+        expect(container.querySelector('.bg-violet-500')).toBeTruthy();
+        expect(importButton.className).not.toContain('bg-sage-500/20');
+        expect(importButton.className).toContain('bg-gray-100');
+    });
+
+    it('keeps manual sync on the existing non-live-watch styling', () => {
+        useLibraryStore.setState({
+            syncStatus: 'syncing',
+            syncProgress: { current: 1, total: 2, message: 'Syncing...' }
+        });
+
+        const { container } = render(<AppHeader {...defaultProps} />);
+        const importButton = screen.getByTitle(/Import images\./);
+
+        expect(container.querySelector('.bg-sage-500')).toBeTruthy();
+        expect(importButton.className).toContain('bg-sage-500/20');
+    });
+});

--- a/src/contexts/LibraryContext.tsx
+++ b/src/contexts/LibraryContext.tsx
@@ -7,6 +7,7 @@ import { CollectionProvider, useCollections } from './CollectionContext';
 import { SearchProvider, useSearch } from './SearchContext';
 import { WatcherProvider, useWatchers } from './WatcherContext';
 import { ErrorBoundary } from '../components/common/ErrorBoundary';
+import { MetadataRefreshScope } from '../types';
 
 // Existing type for backward compatibility
 export interface LibraryContextType {
@@ -71,7 +72,7 @@ export interface LibraryContextType {
   toggleFavorite: (id: string) => Promise<void>;
   togglePin: (id: string, isPinned?: boolean) => Promise<void>;
   clearAllFilters: () => void;
-  refreshMetadata: () => Promise<void>;
+  refreshMetadata: (scope?: MetadataRefreshScope) => Promise<void>;
   fetchData: (loadMore: boolean) => Promise<void>;
   refreshCollections: () => Promise<void>;
   refreshCollectionThumbnails: () => Promise<void>;
@@ -114,13 +115,11 @@ export const LibraryProvider: React.FC<{ children: ReactNode }> = ({ children })
 // Wrappers to inject cross-context callbacks
 const SyncProviderWrapper: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { fetchData, refreshMetadata } = useSearch();
-  const { refreshCollections } = useCollections();
 
-  const handleSyncComplete = useCallback(async () => {
-    // Consolidated refresh
-    await refreshMetadata();
-    await refreshCollections();
-  }, [refreshMetadata, refreshCollections]);
+  const handleSyncComplete = useCallback(async (scope: MetadataRefreshScope = 'full') => {
+    // SearchContext owns the scope-aware metadata refresh strategy.
+    await refreshMetadata(scope);
+  }, [refreshMetadata]);
 
   return (
     <SyncProvider onSyncComplete={handleSyncComplete}>
@@ -132,9 +131,9 @@ const SyncProviderWrapper: React.FC<{ children: ReactNode }> = ({ children }) =>
 const WatcherProviderWrapper: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { fetchData, refreshMetadata } = useSearch();
 
-  const handleNewImage = useCallback(async () => {
-    // refreshMetadata invalidates 'images' and 'libraryStats' queries
-    await refreshMetadata();
+  const handleNewImage = useCallback(async (scope: MetadataRefreshScope = 'images-only') => {
+    // Generic Live Watch keeps the grid fresh immediately, then waits for idle rebuilds
+    await refreshMetadata(scope);
   }, [refreshMetadata]);
 
   return (

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { createContext, useState, useContext, useCallback, useEffect, useRef, ReactNode } from 'react';
-import { AIImage, FilterState, SortOption, FacetType } from '../types';
+import { AIImage, FilterState, SortOption, FacetType, MetadataRefreshScope } from '../types';
 import { useSettings } from './SettingsContext';
 import { useCollections } from './CollectionContext';
 import { useSearchStore } from '../stores/searchStore';
@@ -38,7 +38,7 @@ interface SearchContextType {
     isFiltering: boolean;
     activeSqlWhere: string;
     activeSqlParams: any[];
-    refreshMetadata: () => Promise<void>;
+    refreshMetadata: (scope?: MetadataRefreshScope) => Promise<void>;
     fetchData: (isLoadMore: boolean, isSilent?: boolean) => Promise<void>;
     recentSearches: string[];
     setRecentSearches: React.Dispatch<React.SetStateAction<string[]>>;
@@ -168,13 +168,19 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
     const queryClient = useQueryClient();
 
-    const refreshMetadata = useCallback(async () => {
-        // Invalidate queries to trigger refetch
-        await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ['images'] }),
-            queryClient.invalidateQueries({ queryKey: ['libraryStats'] }),
-            refreshCollections()
-        ]);
+    const refreshMetadata = useCallback(async (scope: MetadataRefreshScope = 'full') => {
+        const refreshTasks: Promise<unknown>[] = [
+            queryClient.invalidateQueries({ queryKey: ['images'] })
+        ];
+
+        if (scope === 'full') {
+            refreshTasks.push(
+                queryClient.invalidateQueries({ queryKey: ['libraryStats'] }),
+                refreshCollections()
+            );
+        }
+
+        await Promise.all(refreshTasks);
     }, [queryClient, refreshCollections]);
 
 

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -7,11 +7,12 @@ import { useLibraryStore } from '../stores/libraryStore';
 import { useSearchStore } from '../stores/searchStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSettingsStore } from '../stores/settingsStore';
+import { MetadataRefreshScope } from '../types';
 
 
 interface SyncContextType {
     startInvokeSync: (options?: any) => Promise<void>;
-    startTargetedLiveSync: (paths: string[]) => Promise<void>;
+    startTargetedLiveSync: (paths: string[]) => Promise<TargetedLiveSyncResult>;
     cancelSync: () => void;
     syncStatus: 'idle' | 'syncing' | 'complete' | 'error';
     syncState: {
@@ -25,7 +26,13 @@ interface SyncContextType {
 
 const SyncContext = createContext<SyncContextType | undefined>(undefined);
 
-export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: () => void }> = ({ children, onSyncComplete }) => {
+export interface TargetedLiveSyncResult {
+    handledPaths: string[];
+    failedPaths: string[];
+    importedCount: number;
+}
+
+export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (scope?: MetadataRefreshScope) => void | Promise<void> }> = ({ children, onSyncComplete }) => {
     const { settings, settingsRef, setSettings } = useSettings();
     const { setCollections } = useCollections();
     const { addToast } = useToast();
@@ -43,6 +50,9 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: () =
     const cancelSyncAction = useLibraryStore(s => s.cancelSync);
 
     const isLiveSyncingRef = useRef(false);
+    const pendingInvokeLiveSyncRef = useRef(false);
+    const pendingTargetedPathsRef = useRef<Set<string>>(new Set());
+    const targetedLiveDrainPromiseRef = useRef<Promise<TargetedLiveSyncResult> | null>(null);
 
     const startInvokeSync = useCallback(async (optionsInput?: any) => {
         const options = {
@@ -55,10 +65,12 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: () =
 
         if (syncStatus === 'syncing' && (options.mode === 'manual' || options.mode === 'startup')) return;
         if ((syncStatus === 'syncing' || isLiveSyncingRef.current) && options.mode === 'live') {
+            pendingInvokeLiveSyncRef.current = true;
             return;
         }
 
         if (options.mode === 'live') {
+            pendingInvokeLiveSyncRef.current = false;
             isLiveSyncingRef.current = true;
             setIsLiveSyncing(true);
             setSyncProgress({ current: 0, total: 0, message: undefined });
@@ -185,7 +197,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: () =
                     }
                     
                     if (options.mode !== 'startup') {
-                        onSyncComplete?.();
+                        await onSyncComplete?.('full');
                     } else {
                         setSyncStatus('complete');
                     }
@@ -201,7 +213,9 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: () =
                 setSettings(prev => ({ ...prev, lastSyncedAt: newTs }));
             }
 
-            if (onSyncComplete) onSyncComplete();
+            if (onSyncComplete) {
+                await onSyncComplete(options.mode === 'live' ? 'images-only' : 'full');
+            }
 
             if (totalProcessed === 0 && options.mode === 'manual') {
                 addToast('Synchronization complete: No new changes.', 'info');
@@ -219,42 +233,89 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: () =
             if (options.mode === 'live') {
                 isLiveSyncingRef.current = false;
                 setIsLiveSyncing(false);
+                if (pendingInvokeLiveSyncRef.current) {
+                    pendingInvokeLiveSyncRef.current = false;
+                    void startInvokeSync({ mode: 'live' });
+                }
             }
         }
     }, [syncStatus, addToast, onSyncComplete, setSettings, setCollections, setSyncStatus, setSyncProgress, setIsLiveSyncing]);
 
     const startTargetedLiveSync = useCallback(async (paths: string[]) => {
-        if (!paths || paths.length === 0) return;
-        try {
-            const { processTargetedFiles } = await import('../services/importService');
-            const result = await processTargetedFiles(paths, { forceRescan: true });
-            
-            // Advance the Live Watch Session Idle Timer
-            const count = result?.images?.length || paths.length;
-            useLibraryStore.getState().reportLiveImagesReceived(count);
+        if (!paths || paths.length === 0) {
+            return { handledPaths: [], failedPaths: [], importedCount: 0 };
+        }
 
-            // IMPORTANT: Bump the `lastScanned` timestamp for matching monitored folders!
-            // This prevents `useFolderMonitor`'s generic Startup Catch-up scan from finding these explicitly handled OS-level files.
-            // Without this, turning Live Watch off and on again would redundantly scan every single file generated in the previous session.
-            if (count > 0) {
-                const { updateFolderLastScanned } = useSettingsStore.getState();
-                const monitoredFolders = settingsRef.current.monitoredFolders || [];
-                const now = Date.now();
-                const updatedFolderIds = new Set<string>();
-                
-                paths.forEach(p => {
-                    const lowerPath = p.replace(/\\/g, '/').toLowerCase();
-                    const folder = monitoredFolders.find(f => lowerPath.startsWith(f.path.replace(/\\/g, '/').toLowerCase()));
-                    if (folder && !updatedFolderIds.has(folder.id)) {
-                        updatedFolderIds.add(folder.id);
-                        updateFolderLastScanned(folder.id, now);
+        paths
+            .map(path => path.replace(/\\/g, '/'))
+            .forEach(path => pendingTargetedPathsRef.current.add(path));
+
+        if (targetedLiveDrainPromiseRef.current) {
+            return targetedLiveDrainPromiseRef.current;
+        }
+
+        const drainPromise = (async (): Promise<TargetedLiveSyncResult> => {
+            const handledPaths = new Set<string>();
+            const failedPaths = new Set<string>();
+            let importedCount = 0;
+
+            while (pendingTargetedPathsRef.current.size > 0) {
+                const nextBatch = Array.from(pendingTargetedPathsRef.current);
+                pendingTargetedPathsRef.current.clear();
+
+                try {
+                    const { processTargetedFiles } = await import('../services/importService');
+                    const result = await processTargetedFiles(nextBatch, { forceRescan: true });
+
+                    result.handledPaths.forEach(path => {
+                        handledPaths.add(path);
+                        failedPaths.delete(path);
+                    });
+                    result.failedPaths.forEach(path => {
+                        if (!handledPaths.has(path)) {
+                            failedPaths.add(path);
+                        }
+                    });
+                    importedCount += result.stats.imported;
+
+                    if (result.stats.imported > 0) {
+                        useLibraryStore.getState().reportLiveImagesReceived(result.stats.imported);
                     }
-                });
+
+                    if (result.handledPaths.length > 0) {
+                        // Keep the catch-up cursor aligned only for files we actually handled.
+                        const { updateFolderLastScanned } = useSettingsStore.getState();
+                        const monitoredFolders = settingsRef.current.monitoredFolders || [];
+                        const now = Date.now();
+                        const updatedFolderIds = new Set<string>();
+
+                        result.handledPaths.forEach(path => {
+                            const lowerPath = path.toLowerCase();
+                            const folder = monitoredFolders.find(f => lowerPath.startsWith(f.path.replace(/\\/g, '/').toLowerCase()));
+                            if (folder && !updatedFolderIds.has(folder.id)) {
+                                updatedFolderIds.add(folder.id);
+                                updateFolderLastScanned(folder.id, now);
+                            }
+                        });
+                    }
+                } catch (e) {
+                    console.error('[LiveSync] Targeted sync failed', e);
+                    nextBatch.forEach(path => failedPaths.add(path));
+                }
             }
 
-        } catch (e) {
-            console.error('[LiveSync] Targeted sync failed', e);
-        }
+            return {
+                handledPaths: Array.from(handledPaths),
+                failedPaths: Array.from(failedPaths),
+                importedCount
+            };
+        })();
+
+        targetedLiveDrainPromiseRef.current = drainPromise.finally(() => {
+            targetedLiveDrainPromiseRef.current = null;
+        });
+
+        return targetedLiveDrainPromiseRef.current;
     }, []);
 
     const cancelSync = useCallback(() => {

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -3,16 +3,87 @@ import { createContext, useContext, useCallback, useRef, ReactNode } from 'react
 import { useSettings } from './SettingsContext';
 import { useCollections } from './CollectionContext';
 import { useToast } from '../hooks/useToast';
-import { useLibraryStore } from '../stores/libraryStore';
+import { getLiveWatchSummaryMessage, useLibraryStore } from '../stores/libraryStore';
 import { useSearchStore } from '../stores/searchStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSettingsStore } from '../stores/settingsStore';
 import { MetadataRefreshScope } from '../types';
+import {
+    debugLiveWatchPerf,
+    elapsedMs,
+    infoLiveWatchPerf,
+    InvokeLiveWatchPerfContext,
+    liveWatchNow,
+    TargetedLiveSyncPerfContext,
+} from '../utils/liveWatchPerf';
 
+interface StartInvokeSyncOptions {
+    syncFavorites?: boolean;
+    syncBoards?: boolean;
+    starredAs?: 'favorite' | 'pin' | 'both' | 'none';
+    mode?: 'manual' | 'startup' | 'live';
+    afterTimestamp?: number | null;
+    importIntermediates?: boolean;
+    importOrphans?: boolean;
+    perfContext?: InvokeLiveWatchPerfContext;
+}
+
+const mergePendingInvokePerfContext = (
+    current: InvokeLiveWatchPerfContext | null,
+    incoming?: InvokeLiveWatchPerfContext
+): InvokeLiveWatchPerfContext | null => {
+    if (!incoming) {
+        return current;
+    }
+
+    if (!current) {
+        return {
+            ...incoming,
+            mergedCycleCount: incoming.mergedCycleCount ?? 1
+        };
+    }
+
+    return {
+        ...incoming,
+        cycleId: current.cycleId,
+        firstEventAt: Math.min(current.firstEventAt, incoming.firstEventAt),
+        lastEventAt: Math.max(current.lastEventAt, incoming.lastEventAt),
+        eventCount: current.eventCount + incoming.eventCount,
+        pathCount: current.pathCount + incoming.pathCount,
+        mergedCycleCount: (current.mergedCycleCount ?? 1) + (incoming.mergedCycleCount ?? 1)
+    };
+};
+
+const mergePendingTargetedPerfContext = (
+    current: TargetedLiveSyncPerfContext | null,
+    incoming?: TargetedLiveSyncPerfContext
+): TargetedLiveSyncPerfContext | null => {
+    if (!incoming) {
+        return current;
+    }
+
+    if (!current) {
+        return {
+            ...incoming,
+            mergedCycleCount: incoming.mergedCycleCount ?? 1
+        };
+    }
+
+    return {
+        ...incoming,
+        cycleId: current.cycleId,
+        source: current.source,
+        firstEventAt: Math.min(current.firstEventAt, incoming.firstEventAt),
+        lastEventAt: Math.max(current.lastEventAt, incoming.lastEventAt),
+        eventCount: current.eventCount + incoming.eventCount,
+        pathCount: current.pathCount + incoming.pathCount,
+        mergedCycleCount: (current.mergedCycleCount ?? 1) + (incoming.mergedCycleCount ?? 1)
+    };
+};
 
 interface SyncContextType {
-    startInvokeSync: (options?: any) => Promise<void>;
-    startTargetedLiveSync: (paths: string[]) => Promise<TargetedLiveSyncResult>;
+    startInvokeSync: (options?: StartInvokeSyncOptions) => Promise<void>;
+    startTargetedLiveSync: (paths: string[], perfContext?: TargetedLiveSyncPerfContext) => Promise<TargetedLiveSyncResult>;
     cancelSync: () => void;
     syncStatus: 'idle' | 'syncing' | 'complete' | 'error';
     syncState: {
@@ -48,24 +119,41 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
     const setIsLiveSyncing = useLibraryStore(s => s.setIsLiveSyncing);
     const setSyncAbortController = useLibraryStore(s => s.setSyncAbortController);
     const cancelSyncAction = useLibraryStore(s => s.cancelSync);
+    const startLiveWatchSession = useLibraryStore(s => s.startLiveWatchSession);
+    const updateLiveWatchSession = useLibraryStore(s => s.updateLiveWatchSession);
+    const reportLiveImagesReceived = useLibraryStore(s => s.reportLiveImagesReceived);
 
     const isLiveSyncingRef = useRef(false);
     const pendingInvokeLiveSyncRef = useRef(false);
+    const pendingInvokeLivePerfRef = useRef<InvokeLiveWatchPerfContext | null>(null);
     const pendingTargetedPathsRef = useRef<Set<string>>(new Set());
+    const pendingTargetedPerfRef = useRef<TargetedLiveSyncPerfContext | null>(null);
     const targetedLiveDrainPromiseRef = useRef<Promise<TargetedLiveSyncResult> | null>(null);
 
-    const startInvokeSync = useCallback(async (optionsInput?: any) => {
-        const options = {
+    const startInvokeSync = useCallback(async (optionsInput?: StartInvokeSyncOptions) => {
+        const options: StartInvokeSyncOptions = {
             syncFavorites: true,
             syncBoards: true,
             starredAs: settingsRef.current.starredAs || 'favorite',
             mode: 'manual' as const,
             ...optionsInput
         };
+        const syncStartedAt = liveWatchNow();
+        const livePerfContext = options.mode === 'live' ? options.perfContext : undefined;
+        let liveTotalProcessed = 0;
+        let liveHadChanges = false;
+        let liveOutcome: 'completed' | 'errored' | 'aborted' = 'completed';
 
         if (syncStatus === 'syncing' && (options.mode === 'manual' || options.mode === 'startup')) return;
         if ((syncStatus === 'syncing' || isLiveSyncingRef.current) && options.mode === 'live') {
             pendingInvokeLiveSyncRef.current = true;
+            pendingInvokeLivePerfRef.current = mergePendingInvokePerfContext(pendingInvokeLivePerfRef.current, livePerfContext);
+            debugLiveWatchPerf('Invoke live rerun queued', {
+                cycleId: pendingInvokeLivePerfRef.current?.cycleId ?? livePerfContext?.cycleId,
+                eventCount: pendingInvokeLivePerfRef.current?.eventCount,
+                pathCount: pendingInvokeLivePerfRef.current?.pathCount,
+                mergedCycleCount: pendingInvokeLivePerfRef.current?.mergedCycleCount ?? 1
+            });
             return;
         }
 
@@ -74,6 +162,18 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             isLiveSyncingRef.current = true;
             setIsLiveSyncing(true);
             setSyncProgress({ current: 0, total: 0, message: undefined });
+            startLiveWatchSession('invoke', {
+                phase: 'syncing',
+                message: 'Preparing live InvokeAI sync...',
+                progress: { current: 0, total: 0, message: undefined }
+            });
+            debugLiveWatchPerf('Invoke sync started', {
+                cycleId: livePerfContext?.cycleId,
+                eventCount: livePerfContext?.eventCount,
+                pathCount: livePerfContext?.pathCount,
+                debounceFireDelayMs: livePerfContext?.debounceFireDelayMs,
+                watcherToSyncStartMs: livePerfContext ? elapsedMs(livePerfContext.firstEventAt) : undefined
+            });
         } else {
             setSyncStatus('syncing');
             setSyncProgress({ current: 0, total: 0, message: options.mode === 'startup' ? 'Catching up InvokeAI DB...' : 'Preparing...' });
@@ -94,6 +194,12 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     if (options.mode === 'live') {
                         // Keep message undefined to prevent ActivityDock from exploding on screen
                         setSyncProgress({ current: c, total: t, message: undefined });
+                        updateLiveWatchSession({
+                            source: 'invoke',
+                            phase: 'syncing',
+                            message: msg || 'Synchronizing InvokeAI images...',
+                            progress: { current: c, total: t, message: undefined }
+                        });
                     } else {
                         setSyncProgress({ current: c, total: t, message: msg });
                     }
@@ -104,7 +210,9 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     syncBoards: options.syncBoards,
                     afterTimestamp: effectiveTimestamp,
                     importIntermediates: options.importIntermediates !== undefined ? options.importIntermediates : settingsRef.current.importIntermediates,
-                    starredAs: options.starredAs
+                    starredAs: options.starredAs,
+                    perfContext: livePerfContext,
+                    mode: options.mode
                 }
             );
 
@@ -156,15 +264,41 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
 
             setSyncStatus('complete');
             const totalProcessed = (imported || 0) + (updated || 0) + orphansImported;
+            liveTotalProcessed = totalProcessed;
             // Conditional Facet Rebuild
             const hasChanges = (imported || 0) > 0 || (updated || 0) > 0 || orphansImported > 0;
+            liveHadChanges = hasChanges;
 
             if (hasChanges) {
                 if (options.mode === 'live') {
                     // SILENT, LENIENT ADDITION (Matches native OS logic)
                     // Advance the Live Watch Session Idle Timer and gently refresh grid
-                    useLibraryStore.getState().reportLiveImagesReceived(totalProcessed);
-                    queryClient.invalidateQueries({ queryKey: ['images'] });
+                    const reportStartedAt = liveWatchNow();
+                    reportLiveImagesReceived(totalProcessed, { source: 'invoke' });
+                    debugLiveWatchPerf('Live images reported to session', {
+                        cycleId: livePerfContext?.cycleId,
+                        totalProcessed,
+                        reportMs: elapsedMs(reportStartedAt)
+                    });
+
+                    const invalidateStartedAt = liveWatchNow();
+                    const invalidatePromise = queryClient.invalidateQueries({ queryKey: ['images'] });
+                    debugLiveWatchPerf('Live image refresh invalidation triggered', {
+                        cycleId: livePerfContext?.cycleId,
+                        totalProcessed,
+                        triggerMs: elapsedMs(invalidateStartedAt)
+                    });
+                    void invalidatePromise
+                        .then(() => {
+                            debugLiveWatchPerf('Live image refresh invalidation settled', {
+                                cycleId: livePerfContext?.cycleId,
+                                totalProcessed,
+                                settleMs: elapsedMs(invalidateStartedAt)
+                            });
+                        })
+                        .catch((invalidateError) => {
+                            console.error('[Sync] Live image refresh invalidation failed', invalidateError);
+                        });
                 } else {
                     // MANUAL HEAVY REBUILD
                     setSyncProgress({ current: totalProcessed, total: totalProcessed, message: 'Updating gallery...' });
@@ -206,6 +340,15 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 }
             } else {
                 console.log('[Sync] No changes detected, skipping facet cache rebuild.');
+                if (options.mode === 'live') {
+                    const receivedCount = useLibraryStore.getState().liveWatchSession.receivedCount;
+                    updateLiveWatchSession({
+                        source: 'invoke',
+                        phase: 'summary',
+                        message: getLiveWatchSummaryMessage(receivedCount),
+                        progress: null
+                    });
+                }
             }
 
             // Fallback for NO CHANGES scenario (hasChanges === false)
@@ -213,8 +356,8 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 setSettings(prev => ({ ...prev, lastSyncedAt: newTs }));
             }
 
-            if (onSyncComplete) {
-                await onSyncComplete(options.mode === 'live' ? 'images-only' : 'full');
+            if (onSyncComplete && options.mode !== 'live') {
+                await onSyncComplete('full');
             }
 
             if (totalProcessed === 0 && options.mode === 'manual') {
@@ -222,8 +365,12 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             }
 
         } catch (e: any) {
-            if (e.message === 'Aborted') setSyncStatus('idle');
+            if (e.message === 'Aborted') {
+                liveOutcome = 'aborted';
+                setSyncStatus('idle');
+            }
             else {
+                liveOutcome = 'errored';
                 console.error('Sync failed', e);
                 setSyncStatus('error');
                 if (options.mode === 'manual' || options.mode === 'startup') addToast('Sync failed: ' + e.message, 'error');
@@ -231,17 +378,34 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
         } finally {
             setSyncAbortController(null);
             if (options.mode === 'live') {
+                infoLiveWatchPerf('Invoke live cycle complete', {
+                    cycleId: livePerfContext?.cycleId,
+                    outcome: liveOutcome,
+                    totalProcessed: liveTotalProcessed,
+                    hasChanges: liveHadChanges,
+                    cycleMs: elapsedMs(syncStartedAt),
+                    watcherToFinishMs: livePerfContext ? elapsedMs(livePerfContext.firstEventAt) : undefined,
+                    queuedRerun: pendingInvokeLiveSyncRef.current
+                });
                 isLiveSyncingRef.current = false;
                 setIsLiveSyncing(false);
                 if (pendingInvokeLiveSyncRef.current) {
+                    const pendingPerfContext = pendingInvokeLivePerfRef.current;
                     pendingInvokeLiveSyncRef.current = false;
-                    void startInvokeSync({ mode: 'live' });
+                    pendingInvokeLivePerfRef.current = null;
+                    debugLiveWatchPerf('Invoke live rerun starting', {
+                        cycleId: pendingPerfContext?.cycleId,
+                        eventCount: pendingPerfContext?.eventCount,
+                        pathCount: pendingPerfContext?.pathCount,
+                        mergedCycleCount: pendingPerfContext?.mergedCycleCount ?? 1
+                    });
+                    void startInvokeSync({ mode: 'live', perfContext: pendingPerfContext || undefined });
                 }
             }
         }
-    }, [syncStatus, addToast, onSyncComplete, setSettings, setCollections, setSyncStatus, setSyncProgress, setIsLiveSyncing]);
+    }, [syncStatus, addToast, onSyncComplete, setSettings, setCollections, setSyncStatus, setSyncProgress, setIsLiveSyncing, startLiveWatchSession, updateLiveWatchSession, reportLiveImagesReceived]);
 
-    const startTargetedLiveSync = useCallback(async (paths: string[]) => {
+    const startTargetedLiveSync = useCallback(async (paths: string[], perfContext?: TargetedLiveSyncPerfContext) => {
         if (!paths || paths.length === 0) {
             return { handledPaths: [], failedPaths: [], importedCount: 0 };
         }
@@ -249,8 +413,15 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
         paths
             .map(path => path.replace(/\\/g, '/'))
             .forEach(path => pendingTargetedPathsRef.current.add(path));
+        pendingTargetedPerfRef.current = mergePendingTargetedPerfContext(pendingTargetedPerfRef.current, perfContext);
 
         if (targetedLiveDrainPromiseRef.current) {
+            debugLiveWatchPerf('Targeted live paths merged into active queue', {
+                cycleId: pendingTargetedPerfRef.current?.cycleId,
+                pendingPathCount: pendingTargetedPathsRef.current.size,
+                eventCount: pendingTargetedPerfRef.current?.eventCount,
+                mergedCycleCount: pendingTargetedPerfRef.current?.mergedCycleCount ?? 1
+            });
             return targetedLiveDrainPromiseRef.current;
         }
 
@@ -260,12 +431,40 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             let importedCount = 0;
 
             while (pendingTargetedPathsRef.current.size > 0) {
+                const cyclePerfContext = pendingTargetedPerfRef.current;
                 const nextBatch = Array.from(pendingTargetedPathsRef.current);
                 pendingTargetedPathsRef.current.clear();
+                pendingTargetedPerfRef.current = null;
+                const targetedSyncStartedAt = liveWatchNow();
+                startLiveWatchSession('generic', {
+                    phase: 'importing',
+                    message: 'Preparing live import...',
+                    progress: { current: 0, total: nextBatch.length, message: undefined }
+                });
+
+                debugLiveWatchPerf('Targeted live sync started', {
+                    cycleId: cyclePerfContext?.cycleId,
+                    source: cyclePerfContext?.source,
+                    batchPathCount: nextBatch.length,
+                    eventCount: cyclePerfContext?.eventCount,
+                    mergedCycleCount: cyclePerfContext?.mergedCycleCount ?? 1,
+                    watcherToImportStartMs: cyclePerfContext ? elapsedMs(cyclePerfContext.firstEventAt) : undefined
+                });
 
                 try {
                     const { processTargetedFiles } = await import('../services/importService');
-                    const result = await processTargetedFiles(nextBatch, { forceRescan: true });
+                    const result = await processTargetedFiles(nextBatch, {
+                        forceRescan: true,
+                        onProgress: (current, total, message) => {
+                            updateLiveWatchSession({
+                                source: 'generic',
+                                phase: 'importing',
+                                message: message || 'Importing live images...',
+                                progress: { current, total, message: undefined }
+                            });
+                        },
+                        perfContext: cyclePerfContext ? { ...cyclePerfContext, queueDepthAtStart: nextBatch.length } : undefined
+                    });
 
                     result.handledPaths.forEach(path => {
                         handledPaths.add(path);
@@ -279,7 +478,15 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     importedCount += result.stats.imported;
 
                     if (result.stats.imported > 0) {
-                        useLibraryStore.getState().reportLiveImagesReceived(result.stats.imported);
+                        reportLiveImagesReceived(result.stats.imported, { source: 'generic' });
+                    } else {
+                        const receivedCount = useLibraryStore.getState().liveWatchSession.receivedCount;
+                        updateLiveWatchSession({
+                            source: 'generic',
+                            phase: 'summary',
+                            message: getLiveWatchSummaryMessage(receivedCount),
+                            progress: null
+                        });
                     }
 
                     if (result.handledPaths.length > 0) {
@@ -298,9 +505,30 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                             }
                         });
                     }
+
+                    infoLiveWatchPerf('Targeted live cycle complete', {
+                        cycleId: cyclePerfContext?.cycleId,
+                        source: cyclePerfContext?.source,
+                        batchPathCount: nextBatch.length,
+                        handledPathCount: result.handledPaths.length,
+                        failedPathCount: result.failedPaths.length,
+                        importedCount: result.stats.imported,
+                        cycleMs: elapsedMs(targetedSyncStartedAt),
+                        watcherToFinishMs: cyclePerfContext ? elapsedMs(cyclePerfContext.firstEventAt) : undefined
+                    });
                 } catch (e) {
                     console.error('[LiveSync] Targeted sync failed', e);
                     nextBatch.forEach(path => failedPaths.add(path));
+                    infoLiveWatchPerf('Targeted live cycle complete', {
+                        cycleId: cyclePerfContext?.cycleId,
+                        source: cyclePerfContext?.source,
+                        batchPathCount: nextBatch.length,
+                        handledPathCount: 0,
+                        failedPathCount: nextBatch.length,
+                        importedCount: 0,
+                        cycleMs: elapsedMs(targetedSyncStartedAt),
+                        watcherToFinishMs: cyclePerfContext ? elapsedMs(cyclePerfContext.firstEventAt) : undefined
+                    });
                 }
             }
 
@@ -316,7 +544,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
         });
 
         return targetedLiveDrainPromiseRef.current;
-    }, []);
+    }, [reportLiveImagesReceived, startLiveWatchSession, updateLiveWatchSession]);
 
     const cancelSync = useCallback(() => {
         cancelSyncAction();

--- a/src/contexts/WatcherContext.tsx
+++ b/src/contexts/WatcherContext.tsx
@@ -6,6 +6,15 @@ import { watcherService } from '../services/WatcherService';
 import { getMaintenanceCounts } from '../services/db/maintenanceRepo';
 import { useLibraryStore } from '../stores/libraryStore';
 import { normalizeInvokeRoot } from '../utils/pathUtils';
+import {
+    createLiveWatchPerfId,
+    debugLiveWatchPerf,
+    elapsedMs,
+    infoLiveWatchPerf,
+    InvokeLiveWatchPerfContext,
+    liveWatchNow,
+    TargetedLiveSyncPerfContext,
+} from '../utils/liveWatchPerf';
 import { MetadataRefreshScope } from '../types';
 
 interface WatcherContextType {
@@ -18,6 +27,63 @@ interface WatcherContextType {
 
 const WatcherContext = createContext<WatcherContextType | undefined>(undefined);
 
+const WATCHER_INIT_DEBOUNCE_MS = 500;
+const INVOKE_LIVE_DEBOUNCE_MS = 500;
+
+const mergeTargetedPerfContext = (
+    current: TargetedLiveSyncPerfContext | null,
+    pathCount: number,
+    receivedAt: number
+): TargetedLiveSyncPerfContext => {
+    if (!current) {
+        return {
+            cycleId: createLiveWatchPerfId('generic-live'),
+            source: 'generic-folder-watch',
+            firstEventAt: receivedAt,
+            lastEventAt: receivedAt,
+            eventCount: 1,
+            pathCount,
+            mergedCycleCount: 1
+        };
+    }
+
+    return {
+        ...current,
+        lastEventAt: receivedAt,
+        eventCount: current.eventCount + 1,
+        pathCount: current.pathCount + pathCount,
+        mergedCycleCount: current.mergedCycleCount ?? 1
+    };
+};
+
+const mergeInvokePerfContext = (
+    current: InvokeLiveWatchPerfContext | null,
+    pathCount: number,
+    receivedAt: number
+): InvokeLiveWatchPerfContext => {
+    if (!current) {
+        return {
+            cycleId: createLiveWatchPerfId('invoke-live'),
+            firstEventAt: receivedAt,
+            lastEventAt: receivedAt,
+            eventCount: 1,
+            pathCount,
+            debounceScheduledAt: receivedAt,
+            debounceDelayMs: INVOKE_LIVE_DEBOUNCE_MS,
+            debounceFireDelayMs: 0,
+            mergedCycleCount: 1
+        };
+    }
+
+    return {
+        ...current,
+        lastEventAt: receivedAt,
+        eventCount: current.eventCount + 1,
+        pathCount: current.pathCount + pathCount,
+        mergedCycleCount: current.mergedCycleCount ?? 1
+    };
+};
+
 export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected?: (scope?: MetadataRefreshScope) => void | Promise<void> }> = ({ children, onNewImageDetected }) => {
     const { settings, isLoaded } = useSettings();
     const { startInvokeSync, startTargetedLiveSync } = useSync();
@@ -28,6 +94,7 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
     const [lastWatcherEvent, setLastWatcherEvent] = React.useState<number>(0);
     const maintenanceCounts = useLibraryStore(s => s.maintenanceCounts);
     const setMaintenanceCounts = useLibraryStore(s => s.setMaintenanceCounts);
+    const startLiveWatchSession = useLibraryStore(s => s.startLiveWatchSession);
 
     const refreshMaintenanceCounts = useCallback(async () => {
         if (!isLoaded) return;
@@ -57,6 +124,8 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
     const callbacksRef = useRef({ onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync });
     const invokeSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingGenericPathsRef = useRef<Set<string>>(new Set());
+    const pendingGenericPerfRef = useRef<TargetedLiveSyncPerfContext | null>(null);
+    const pendingInvokePerfRef = useRef<InvokeLiveWatchPerfContext | null>(null);
     const genericLiveDrainPromiseRef = useRef<Promise<void> | null>(null);
 
     useEffect(() => {
@@ -68,22 +137,54 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
             .map(path => path.replace(/\\/g, '/'))
             .forEach(path => pendingGenericPathsRef.current.add(path));
 
+        const pendingPathCount = pendingGenericPathsRef.current.size;
+
         if (genericLiveDrainPromiseRef.current) {
+            debugLiveWatchPerf('Generic live paths merged into active queue', {
+                cycleId: pendingGenericPerfRef.current?.cycleId,
+                pendingPathCount,
+                eventCount: pendingGenericPerfRef.current?.eventCount,
+                mergedCycleCount: pendingGenericPerfRef.current?.mergedCycleCount ?? 1
+            });
             return genericLiveDrainPromiseRef.current;
         }
 
         const drainPromise = (async () => {
             while (pendingGenericPathsRef.current.size > 0) {
+                const perfContext = pendingGenericPerfRef.current;
                 const nextBatch = Array.from(pendingGenericPathsRef.current);
                 pendingGenericPathsRef.current.clear();
+                pendingGenericPerfRef.current = null;
+                const cycleStartAt = liveWatchNow();
+
+                debugLiveWatchPerf('Generic live sync started', {
+                    cycleId: perfContext?.cycleId,
+                    batchPathCount: nextBatch.length,
+                    eventCount: perfContext?.eventCount,
+                    mergedCycleCount: perfContext?.mergedCycleCount ?? 1,
+                    watcherToImportStartMs: perfContext ? elapsedMs(perfContext.firstEventAt) : undefined
+                });
 
                 const cb = callbacksRef.current;
-                const liveResult = await cb.startTargetedLiveSync(nextBatch);
+                const liveResult = await cb.startTargetedLiveSync(
+                    nextBatch,
+                    perfContext ? { ...perfContext, queueDepthAtStart: nextBatch.length } : undefined
+                );
 
                 if (liveResult.handledPaths.length > 0) {
                     await cb.onNewImageDetected?.('images-only');
                     await cb.refreshMaintenanceCounts();
                 }
+
+                infoLiveWatchPerf('Generic live cycle complete', {
+                    cycleId: perfContext?.cycleId,
+                    batchPathCount: nextBatch.length,
+                    handledPathCount: liveResult.handledPaths.length,
+                    failedPathCount: liveResult.failedPaths.length,
+                    importedCount: liveResult.importedCount,
+                    cycleMs: elapsedMs(cycleStartAt),
+                    watcherToFinishMs: perfContext ? elapsedMs(perfContext.firstEventAt) : undefined
+                });
             }
         })();
 
@@ -124,7 +225,10 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
 
             await watcherService.startWatching(pathsToWatch, async (paths?: string[]) => {
                 if (!paths || paths.length === 0) return;
-                console.log(`[WatcherContext] Targeted change detected for ${paths.length} files`);
+                const eventReceivedAt = liveWatchNow();
+                debugLiveWatchPerf('folder-change-event received', {
+                    pathCount: paths.length
+                });
                 
                 const cb = callbacksRef.current;
                 
@@ -149,9 +253,30 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
                     }
                 });
 
+                debugLiveWatchPerf('folder-change-event split', {
+                    totalPathCount: paths.length,
+                    genericPathCount: genericPaths.length,
+                    invokePathCount: invokePaths.length
+                });
+
                 // Use O(1) targeted import strictly for non-Invoke generic folder drops
                 if (genericPaths.length > 0) {
-                    await drainGenericLiveChanges(genericPaths);
+                    startLiveWatchSession('generic', {
+                        phase: 'watching',
+                        message: 'Detected new files. Preparing live import...'
+                    });
+                    pendingGenericPerfRef.current = mergeTargetedPerfContext(
+                        pendingGenericPerfRef.current,
+                        genericPaths.length,
+                        eventReceivedAt
+                    );
+                    debugLiveWatchPerf('Generic live activity detected', {
+                        cycleId: pendingGenericPerfRef.current.cycleId,
+                        receivedPathCount: genericPaths.length,
+                        eventCount: pendingGenericPerfRef.current.eventCount,
+                        pathCount: pendingGenericPerfRef.current.pathCount
+                    });
+                    void drainGenericLiveChanges(genericPaths);
                 }
 
                 // Signal consumers (like useFolderMonitor) that a change occurred
@@ -159,28 +284,87 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
 
                 // Immediately Trigger full InvokeAI SQLite Sync evaluation if an Invoke local path dropped
                 if (invokePaths.length > 0 && cb.settings.invokeAiPath) {
-                    console.log(`[WatcherContext] Activity detected in InvokeAI database. Debouncing sync...`);
+                    startLiveWatchSession('invoke', {
+                        phase: 'watching',
+                        message: 'Detected InvokeAI activity. Waiting for completed images...'
+                    });
+                    pendingInvokePerfRef.current = mergeInvokePerfContext(
+                        pendingInvokePerfRef.current,
+                        invokePaths.length,
+                        eventReceivedAt
+                    );
+                    debugLiveWatchPerf('Invoke DB activity detected', {
+                        cycleId: pendingInvokePerfRef.current.cycleId,
+                        receivedPathCount: invokePaths.length,
+                        eventCount: pendingInvokePerfRef.current.eventCount,
+                        pathCount: pendingInvokePerfRef.current.pathCount
+                    });
                     
                     if (invokeSyncTimeoutRef.current) {
                         clearTimeout(invokeSyncTimeoutRef.current);
+                        debugLiveWatchPerf('Invoke debounce rescheduled', {
+                            cycleId: pendingInvokePerfRef.current.cycleId,
+                            debounceDelayMs: INVOKE_LIVE_DEBOUNCE_MS
+                        });
                     }
-                    
+
+                    pendingInvokePerfRef.current = {
+                        ...pendingInvokePerfRef.current,
+                        debounceScheduledAt: liveWatchNow(),
+                        debounceDelayMs: INVOKE_LIVE_DEBOUNCE_MS
+                    };
+                    debugLiveWatchPerf('Invoke sync scheduled', {
+                        cycleId: pendingInvokePerfRef.current.cycleId,
+                        eventCount: pendingInvokePerfRef.current.eventCount,
+                        pathCount: pendingInvokePerfRef.current.pathCount,
+                        debounceDelayMs: INVOKE_LIVE_DEBOUNCE_MS
+                    });
                     invokeSyncTimeoutRef.current = setTimeout(() => {
-                        console.log(`[WatcherContext] Triggering SQLite-driven sync for InvokeAI via Live Watch...`);
-                        cb.startInvokeSync({ mode: 'live' });
                         invokeSyncTimeoutRef.current = null;
-                    }, 1000);
+                        const perfContext = pendingInvokePerfRef.current;
+                        pendingInvokePerfRef.current = null;
+                        if (!perfContext) {
+                            return;
+                        }
+
+                        const firedAt = liveWatchNow();
+                        const resolvedPerfContext: InvokeLiveWatchPerfContext = {
+                            ...perfContext,
+                            debounceFireDelayMs: Math.round(firedAt - perfContext.debounceScheduledAt),
+                            debounceDelayMs: INVOKE_LIVE_DEBOUNCE_MS
+                        };
+
+                        debugLiveWatchPerf('Invoke debounce fired', {
+                            cycleId: resolvedPerfContext.cycleId,
+                            eventCount: resolvedPerfContext.eventCount,
+                            pathCount: resolvedPerfContext.pathCount,
+                            debounceFireDelayMs: resolvedPerfContext.debounceFireDelayMs,
+                            watcherToSyncStartMs: Math.round(firedAt - resolvedPerfContext.firstEventAt)
+                        });
+                        void cb.startInvokeSync({ mode: 'live', perfContext: resolvedPerfContext });
+                        invokeSyncTimeoutRef.current = null;
+                    }, INVOKE_LIVE_DEBOUNCE_MS);
                 }
             });
 
+            debugLiveWatchPerf('Native watcher initialized', {
+                watchedPathCount: pathsToWatch.length,
+                invokeDebounceMs: INVOKE_LIVE_DEBOUNCE_MS
+            });
 
         };
 
         // Debounce initialization
-        const timer = setTimeout(initWatcher, 500);
-        return () => clearTimeout(timer);
+        const timer = setTimeout(initWatcher, WATCHER_INIT_DEBOUNCE_MS);
+        return () => {
+            clearTimeout(timer);
+            if (invokeSyncTimeoutRef.current) {
+                clearTimeout(invokeSyncTimeoutRef.current);
+                invokeSyncTimeoutRef.current = null;
+            }
+        };
 
-    }, [isLoaded, isLiveWatching, monitoredFoldersConfig, invokePathConfig, drainGenericLiveChanges]);
+    }, [isLoaded, isLiveWatching, monitoredFoldersConfig, invokePathConfig, drainGenericLiveChanges, startLiveWatchSession]);
 
     // Maintenance interval
     useEffect(() => {

--- a/src/contexts/WatcherContext.tsx
+++ b/src/contexts/WatcherContext.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { createContext, useContext, useEffect, useRef, ReactNode, useCallback } from 'react';
 import { useSettings } from './SettingsContext';
 import { useSync } from './SyncContext';
-import { useToast } from '../hooks/useToast';
 import { watcherService } from '../services/WatcherService';
-import { startLiveLink } from '../services/invoke/liveLink';
 import { getMaintenanceCounts } from '../services/db/maintenanceRepo';
 import { useLibraryStore } from '../stores/libraryStore';
 import { normalizeInvokeRoot } from '../utils/pathUtils';
+import { MetadataRefreshScope } from '../types';
 
 interface WatcherContextType {
     isLiveWatching: boolean;
@@ -19,10 +18,9 @@ interface WatcherContextType {
 
 const WatcherContext = createContext<WatcherContextType | undefined>(undefined);
 
-export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected?: () => void }> = ({ children, onNewImageDetected }) => {
+export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected?: (scope?: MetadataRefreshScope) => void | Promise<void> }> = ({ children, onNewImageDetected }) => {
     const { settings, isLoaded } = useSettings();
     const { startInvokeSync, startTargetedLiveSync } = useSync();
-    const { addToast } = useToast();
 
     // Zustand State
     const isLiveWatching = useLibraryStore(s => s.isLiveWatching);
@@ -47,16 +45,54 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
     }, [isLoaded, refreshMaintenanceCounts]);
 
     // Unified Watcher Logic (Live Sync)
-    const monitoredFoldersConfig = JSON.stringify(settings.monitoredFolders);
+    const monitoredFoldersConfig = React.useMemo(() => JSON.stringify(
+        (settings.monitoredFolders || []).map(folder => ({
+            path: folder.path,
+            isActive: folder.isActive
+        }))
+    ), [settings.monitoredFolders]);
     const invokePathConfig = settings.invokeAiPath;
 
     // Stable ref for callbacks to avoid restarting watcher on every render
     const callbacksRef = useRef({ onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync });
     const invokeSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pendingGenericPathsRef = useRef<Set<string>>(new Set());
+    const genericLiveDrainPromiseRef = useRef<Promise<void> | null>(null);
 
     useEffect(() => {
         callbacksRef.current = { onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync };
     });
+
+    const drainGenericLiveChanges = useCallback(async (paths: string[]) => {
+        paths
+            .map(path => path.replace(/\\/g, '/'))
+            .forEach(path => pendingGenericPathsRef.current.add(path));
+
+        if (genericLiveDrainPromiseRef.current) {
+            return genericLiveDrainPromiseRef.current;
+        }
+
+        const drainPromise = (async () => {
+            while (pendingGenericPathsRef.current.size > 0) {
+                const nextBatch = Array.from(pendingGenericPathsRef.current);
+                pendingGenericPathsRef.current.clear();
+
+                const cb = callbacksRef.current;
+                const liveResult = await cb.startTargetedLiveSync(nextBatch);
+
+                if (liveResult.handledPaths.length > 0) {
+                    await cb.onNewImageDetected?.('images-only');
+                    await cb.refreshMaintenanceCounts();
+                }
+            }
+        })();
+
+        genericLiveDrainPromiseRef.current = drainPromise.finally(() => {
+            genericLiveDrainPromiseRef.current = null;
+        });
+
+        return genericLiveDrainPromiseRef.current;
+    }, []);
 
     useEffect(() => {
         if (!isLoaded) return;
@@ -115,11 +151,7 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
 
                 // Use O(1) targeted import strictly for non-Invoke generic folder drops
                 if (genericPaths.length > 0) {
-                    if (cb.startTargetedLiveSync) {
-                        await cb.startTargetedLiveSync(genericPaths);
-                    }
-                    if (cb.onNewImageDetected) cb.onNewImageDetected();
-                    await cb.refreshMaintenanceCounts();
+                    await drainGenericLiveChanges(genericPaths);
                 }
 
                 // Signal consumers (like useFolderMonitor) that a change occurred
@@ -148,7 +180,7 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
         const timer = setTimeout(initWatcher, 500);
         return () => clearTimeout(timer);
 
-    }, [isLoaded, isLiveWatching, monitoredFoldersConfig, invokePathConfig, addToast]);
+    }, [isLoaded, isLiveWatching, monitoredFoldersConfig, invokePathConfig, drainGenericLiveChanges]);
 
     // Maintenance interval
     useEffect(() => {

--- a/src/contexts/__tests__/LibraryIntegration.test.tsx
+++ b/src/contexts/__tests__/LibraryIntegration.test.tsx
@@ -12,8 +12,30 @@ const mocks = vi.hoisted(() => ({
     countImages: vi.fn().mockResolvedValue(0),
     getFacets: vi.fn().mockResolvedValue({ models: [], loras: [], tools: [] }),
     getLibraryStats: vi.fn().mockResolvedValue({ totalImages: 0 }),
+    syncImages: vi.fn().mockResolvedValue({ imported: 5, updated: 0, maxTimestamp: 100, syncedIds: new Set(), boardMapping: new Map() }),
     getAllCollectionsWithStats: vi.fn().mockResolvedValue([
-        { id: 'smart1', name: 'Smart Col', filters: { searchQuery: 'ai', models: [], loras: [], tools: [], controlNets: [], ipAdapters: [] }, source: 'ambit' }
+        {
+            id: 'smart1',
+            name: 'Smart Col',
+            filters: {
+                searchQuery: 'ai',
+                models: [],
+                tools: [],
+                loras: [],
+                embeddings: [],
+                hypernetworks: [],
+                samplers: [],
+                generationTypes: [],
+                controlNets: [],
+                ipAdapters: [],
+                dateRange: 'all',
+                favoritesOnly: false,
+                collectionId: null,
+                showIntermediates: false,
+                showGrids: false
+            },
+            source: 'ambit'
+        }
     ]),
     appRepository: {
         load: vi.fn().mockResolvedValue({
@@ -67,7 +89,7 @@ vi.mock('../../services/WatcherService', () => ({
 }));
 
 vi.mock('../../services/invoke/syncService', () => ({
-    syncImages: vi.fn().mockResolvedValue({ imported: 5, updated: 0, maxTimestamp: 100, syncedIds: [] })
+    syncImages: (...args: any[]) => mocks.syncImages(...args)
 }));
 
 vi.mock('../../services/invoke/orphanScanner', () => ({
@@ -166,5 +188,45 @@ describe('Library Integration (Provider Stack)', () => {
             expect(mocks.searchImages).toHaveBeenCalled();
             expect(mocks.getFacets).toHaveBeenCalled();
         }, { timeout: 5000 });
+    });
+
+    it('does not refresh image queries after a no-op live Invoke cycle', async () => {
+        let hook: any;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook.isLoaded).toBe(true));
+
+        await act(async () => {
+            hook.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai/databases'
+            });
+        });
+
+        await waitFor(() => {
+            expect(hook.settings.invokeAiPath).toBe('D:/AI/art/webUI/invokeai/databases');
+        });
+
+        mocks.syncImages.mockResolvedValueOnce({
+            imported: 0,
+            updated: 0,
+            maxTimestamp: 100,
+            syncedIds: new Set(),
+            boardMapping: new Map()
+        });
+        mocks.searchImages.mockClear();
+        mocks.getFacets.mockClear();
+
+        await act(async () => {
+            await hook.startInvokeSync({ mode: 'live' });
+        });
+
+        expect(mocks.syncImages).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.any(Function),
+            expect.any(AbortSignal),
+            expect.objectContaining({ mode: 'live' })
+        );
+        expect(mocks.searchImages).not.toHaveBeenCalled();
+        expect(mocks.getFacets).not.toHaveBeenCalled();
     });
 });

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -641,6 +641,11 @@ export interface ExistingMetadata {
     timestamp: number;
     fileSize: number;
     metadataJson: string;
+    isFavorite: boolean;
+    isPinned: boolean;
+    boardId?: string;
+    groupId?: string;
+    notes?: string;
 }
 
 export const getExistingMetadata = async (ids: string[]): Promise<Map<string, ExistingMetadata>> => {
@@ -655,8 +660,8 @@ export const getExistingMetadata = async (ids: string[]): Promise<Map<string, Ex
         const placeholders = chunk.map(() => '?').join(',');
 
         try {
-            const rows = await db.select<{ id: string, timestamp: number, file_size: number, metadata_json: string }[]>(
-                `SELECT id, timestamp, file_size, metadata_json FROM images WHERE id IN (${placeholders})`,
+            const rows = await db.select<{ id: string, timestamp: number, file_size: number, metadata_json: string, is_favorite: number, is_pinned: number, board_id?: string | null, group_id?: string | null, notes?: string | null }[]>(
+                `SELECT id, timestamp, file_size, metadata_json, is_favorite, is_pinned, board_id, group_id, notes FROM images WHERE id IN (${placeholders})`,
                 chunk
             );
 
@@ -664,7 +669,12 @@ export const getExistingMetadata = async (ids: string[]): Promise<Map<string, Ex
                 map.set(r.id, {
                     timestamp: r.timestamp,
                     fileSize: r.file_size,
-                    metadataJson: r.metadata_json
+                    metadataJson: r.metadata_json,
+                    isFavorite: !!r.is_favorite,
+                    isPinned: !!r.is_pinned,
+                    boardId: r.board_id ?? undefined,
+                    groupId: r.group_id ?? undefined,
+                    notes: r.notes ?? undefined
                 });
             });
         } catch (e) {

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -4,6 +4,12 @@ import { AIImage, GeneratorTool } from '../../types';
 import { getDb, dbMutex } from './connection';
 import { mapRowToImage, IMAGE_FIELDS_LIGHT } from './repoUtils';
 import { normalizePath, urlToPath } from '../../utils/pathUtils';
+import {
+    debugLiveWatchPerf,
+    elapsedMs,
+    infoLiveWatchPerf,
+    liveWatchNow,
+} from '../../utils/liveWatchPerf';
 
 export const insertImage = async (image: AIImage) => {
     await dbMutex.dispatch(async () => {
@@ -47,6 +53,7 @@ export const insertImage = async (image: AIImage) => {
 
 export const insertImagesBatch = async (images: AIImage[]) => {
     if (images.length === 0) return;
+    const insertStartedAt = liveWatchNow();
 
     await dbMutex.dispatch(async () => {
         const records = images.map(img => ({
@@ -80,7 +87,13 @@ export const insertImagesBatch = async (images: AIImage[]) => {
         for (let i = 0; i < records.length; i += CHUNK_SIZE) {
             const chunk = records.slice(i, i + CHUNK_SIZE);
             try {
+                const chunkStartedAt = liveWatchNow();
                 await unwrap(commands.saveImagesBatch(chunk));
+                debugLiveWatchPerf('DB image batch persisted', {
+                    batchIndex: Math.floor(i / CHUNK_SIZE) + 1,
+                    chunkSize: chunk.length,
+                    chunkMs: elapsedMs(chunkStartedAt)
+                });
             } catch (e) {
                 console.error('[DB] Rust batch insert failed', e);
                 throw e;
@@ -88,8 +101,17 @@ export const insertImagesBatch = async (images: AIImage[]) => {
         }
     });
 
+    const cleanupStartedAt = liveWatchNow();
     const db = await getDb();
     await db.execute('UPDATE images SET user_masked = NULL WHERE user_masked = 0');
+    debugLiveWatchPerf('DB user_masked cleanup complete', {
+        imageCount: images.length,
+        cleanupMs: elapsedMs(cleanupStartedAt)
+    });
+    infoLiveWatchPerf('insertImagesBatch complete', {
+        imageCount: images.length,
+        totalMs: elapsedMs(insertStartedAt)
+    });
 
     // rebuildFacetCache() is no longer called automatically per batch to avoid O(N^2) behavior during syncs.
     // It should be called once at the end of the sync/import process.

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -7,6 +7,14 @@ import { unwrap } from '../utils/spectaUtils';
 import { normalizePath } from '../utils/pathUtils';
 import { useLibraryStore } from '../stores/libraryStore';
 import { getDb } from './db/connection';
+import {
+    createLiveWatchPerfId,
+    debugLiveWatchPerf,
+    elapsedMs,
+    infoLiveWatchPerf,
+    liveWatchNow,
+    TargetedLiveSyncPerfContext,
+} from '../utils/liveWatchPerf';
 
 /**
  * Queries the database for paths that already exist.
@@ -56,6 +64,7 @@ export interface ImportOptions {
     isStartup?: boolean;
     forceRescan?: boolean;
     skipThumbnail?: boolean;
+    perfContext?: TargetedLiveSyncPerfContext;
 }
 
 interface FileEntry {
@@ -84,10 +93,12 @@ async function processFileEntries(
     options: ImportOptions = {},
     defaultTool?: GeneratorTool
 ): Promise<{ images: AIImage[]; handledPaths: string[]; failedPaths: string[] }> {
-    const { onProgress, abortSignal, forceRescan, skipThumbnail = true } = options;
+    const { onProgress, abortSignal, forceRescan, skipThumbnail = true, perfContext } = options;
     const newImages: AIImage[] = [];
     const handledPaths: string[] = [];
     const failedPaths: string[] = [];
+    const importStartedAt = liveWatchNow();
+    const cycleId = perfContext?.cycleId ?? createLiveWatchPerfId('import');
 
     // Sort by Modified Date (Newest First)
     entries.sort((a, b) => b.modified - a.modified);
@@ -99,12 +110,32 @@ async function processFileEntries(
     if (!forceRescan) {
         if (onProgress) onProgress(0, allPaths.length, 'Checking for duplicates...');
 
+        const existingLookupStartedAt = liveWatchNow();
         const existingPaths = await getExistingPaths(allPaths);
         pathsToProcess = allPaths.filter(p => !existingPaths.has(normalizePath(p)));
         stats.skipped += (allPaths.length - pathsToProcess.length);
+        debugLiveWatchPerf('Import duplicate check complete', {
+            cycleId,
+            candidatePathCount: allPaths.length,
+            existingPathCount: existingPaths.size,
+            skippedPathCount: allPaths.length - pathsToProcess.length,
+            duplicateCheckMs: elapsedMs(existingLookupStartedAt)
+        });
     }
 
     if (pathsToProcess.length === 0) {
+        infoLiveWatchPerf('Import processing complete', {
+            cycleId,
+            source: perfContext?.source,
+            candidatePathCount: allPaths.length,
+            processedPathCount: stats.processed,
+            importedCount: stats.imported,
+            skippedCount: stats.skipped,
+            errorCount: stats.errors,
+            handledPathCount: handledPaths.length,
+            failedPathCount: failedPaths.length,
+            totalMs: elapsedMs(importStartedAt)
+        });
         return { images: [], handledPaths, failedPaths };
     }
 
@@ -122,6 +153,7 @@ async function processFileEntries(
 
         let unlisten: (() => void) | null = null;
         try {
+            const batchStartedAt = liveWatchNow();
             // Setup listener for native progress stream for silky smooth UI loading bars
             const { listen } = await import('@tauri-apps/api/event');
             unlisten = await listen<{current: number, total: number, message: string}>('import_progress', (e) => {
@@ -132,7 +164,9 @@ async function processFileEntries(
             });
 
             // true for extractWorkflow (always want full metadata)
+            const scanStartedAt = liveWatchNow();
             const results = await scanImagesBulk(chunk, '', skipThumbnail, true, defaultTool);
+            const scanMs = elapsedMs(scanStartedAt);
 
 
             const batchImages: AIImage[] = [];
@@ -178,7 +212,9 @@ async function processFileEntries(
                 // console.time(`insertBatch-${i}`);
                 const ids = batchImages.map(img => img.id);
                 const { insertImagesBatch, getExistingMetadata } = await import('./db/imageRepo');
+                const existingMetaStartedAt = liveWatchNow();
                 const existingMeta = await getExistingMetadata(ids);
+                const existingMetadataMs = elapsedMs(existingMetaStartedAt);
 
                 batchImages.forEach(img => {
                     const existing = existingMeta.get(img.id);
@@ -205,11 +241,39 @@ async function processFileEntries(
                     return false;
                 });
 
+                let upsertMs = 0;
                 if (imagesToUpdate.length > 0) {
+                    const upsertStartedAt = liveWatchNow();
                     await insertImagesBatch(imagesToUpdate);
+                    upsertMs = elapsedMs(upsertStartedAt);
                     stats.imported += imagesToUpdate.length;
                 }
+                debugLiveWatchPerf('Import batch stage timings', {
+                    cycleId,
+                    batchIndex: Math.floor(i / BATCH_SIZE) + 1,
+                    batchPathCount: chunk.length,
+                    scannedPathCount: results.length,
+                    batchImageCount: batchImages.length,
+                    upsertCount: imagesToUpdate.length,
+                    scanMs,
+                    existingMetadataMs,
+                    upsertMs,
+                    batchMs: elapsedMs(batchStartedAt)
+                });
                 // console.timeEnd(`insertBatch-${i}`);
+            } else {
+                debugLiveWatchPerf('Import batch stage timings', {
+                    cycleId,
+                    batchIndex: Math.floor(i / BATCH_SIZE) + 1,
+                    batchPathCount: chunk.length,
+                    scannedPathCount: results.length,
+                    batchImageCount: 0,
+                    upsertCount: 0,
+                    scanMs,
+                    existingMetadataMs: 0,
+                    upsertMs: 0,
+                    batchMs: elapsedMs(batchStartedAt)
+                });
             }
 
             newImages.push(...batchImages);
@@ -228,6 +292,19 @@ async function processFileEntries(
             unlisten?.();
         }
     }
+
+    infoLiveWatchPerf('Import processing complete', {
+        cycleId,
+        source: perfContext?.source,
+        candidatePathCount: allPaths.length,
+        processedPathCount: stats.processed,
+        importedCount: stats.imported,
+        skippedCount: stats.skipped,
+        errorCount: stats.errors,
+        handledPathCount: handledPaths.length,
+        failedPathCount: failedPaths.length,
+        totalMs: elapsedMs(importStartedAt)
+    });
 
     return { images: newImages, handledPaths, failedPaths };
 }
@@ -475,6 +552,7 @@ export const processTargetedFiles = async (
     };
 
     if (paths.length === 0) return result;
+    const targetedImportStartedAt = liveWatchNow();
 
     const entries: FileEntry[] = paths.map(p => ({ 
         path: p, 
@@ -491,6 +569,15 @@ export const processTargetedFiles = async (
     // Removed synchronous rebuildFacetCache.
     // Live Watch relies on the 60s idle timeout `useLibraryStore.getState().reportLiveImagesReceived()` 
     // managed in SyncContext to gracefully handle heavy aggregations off-thread.
+    infoLiveWatchPerf('Targeted import complete', {
+        cycleId: options.perfContext?.cycleId,
+        source: options.perfContext?.source,
+        inputPathCount: paths.length,
+        handledPathCount: result.handledPaths.length,
+        failedPathCount: result.failedPaths.length,
+        importedCount: result.stats.imported,
+        totalMs: elapsedMs(targetedImportStartedAt)
+    });
     return result;
 };
 

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -46,6 +46,8 @@ export interface ImportStats {
 export interface ImportResult {
     images: AIImage[];
     stats: ImportStats;
+    handledPaths: string[];
+    failedPaths: string[];
 }
 
 export interface ImportOptions {
@@ -81,9 +83,11 @@ async function processFileEntries(
     stats: ImportStats,
     options: ImportOptions = {},
     defaultTool?: GeneratorTool
-): Promise<AIImage[]> {
+): Promise<{ images: AIImage[]; handledPaths: string[]; failedPaths: string[] }> {
     const { onProgress, abortSignal, forceRescan, skipThumbnail = true } = options;
     const newImages: AIImage[] = [];
+    const handledPaths: string[] = [];
+    const failedPaths: string[] = [];
 
     // Sort by Modified Date (Newest First)
     entries.sort((a, b) => b.modified - a.modified);
@@ -100,7 +104,9 @@ async function processFileEntries(
         stats.skipped += (allPaths.length - pathsToProcess.length);
     }
 
-    if (pathsToProcess.length === 0) return [];
+    if (pathsToProcess.length === 0) {
+        return { images: [], handledPaths, failedPaths };
+    }
 
     const BATCH_SIZE = 300;
     const totalToProcess = pathsToProcess.length;
@@ -114,10 +120,11 @@ async function processFileEntries(
         const chunk = pathsToProcess.slice(i, i + BATCH_SIZE);
         // console.log(`[Import] Processing batch ${i / BATCH_SIZE + 1} (${chunk.length} files)`);
 
+        let unlisten: (() => void) | null = null;
         try {
             // Setup listener for native progress stream for silky smooth UI loading bars
             const { listen } = await import('@tauri-apps/api/event');
-            const unlisten = await listen<{current: number, total: number, message: string}>('import_progress', (e) => {
+            unlisten = await listen<{current: number, total: number, message: string}>('import_progress', (e) => {
                 if (onProgress) {
                     const absCurrent = Math.min(i + e.payload.current, totalToProcess);
                     onProgress(absCurrent, totalToProcess, e.payload.message);
@@ -126,8 +133,6 @@ async function processFileEntries(
 
             // true for extractWorkflow (always want full metadata)
             const results = await scanImagesBulk(chunk, '', skipThumbnail, true, defaultTool);
-            
-            unlisten(); // Clean up IPC listener immediately after the chunk is done
 
 
             const batchImages: AIImage[] = [];
@@ -139,6 +144,7 @@ async function processFileEntries(
                 if (info.errorReason) {
                     stats.errors++;
                     console.warn(`Scan error for ${path}:`, info.errorReason);
+                    failedPaths.push(normalizePath(path));
                     continue; // Skip valid object creation if hard error
                 }
 
@@ -174,6 +180,17 @@ async function processFileEntries(
                 const { insertImagesBatch, getExistingMetadata } = await import('./db/imageRepo');
                 const existingMeta = await getExistingMetadata(ids);
 
+                batchImages.forEach(img => {
+                    const existing = existingMeta.get(img.id);
+                    if (!existing) return;
+
+                    img.isFavorite = existing.isFavorite;
+                    img.isPinned = existing.isPinned;
+                    img.boardId = existing.boardId;
+                    img.groupId = existing.groupId;
+                    img.notes = existing.notes;
+                });
+
                 const imagesToUpdate = batchImages.filter(img => {
                     const existing = existingMeta.get(img.id);
                     if (!existing) return true; // New
@@ -196,6 +213,7 @@ async function processFileEntries(
             }
 
             newImages.push(...batchImages);
+            handledPaths.push(...batchImages.map(img => img.id));
             stats.processed += chunk.length;
 
             if (onProgress) {
@@ -205,10 +223,13 @@ async function processFileEntries(
         } catch (e) {
             console.error('Import batch error:', e);
             stats.errors += chunk.length;
+            failedPaths.push(...chunk.map(path => normalizePath(path)));
+        } finally {
+            unlisten?.();
         }
     }
 
-    return newImages;
+    return { images: newImages, handledPaths, failedPaths };
 }
 
 // --- Unified Folder Import ---
@@ -223,7 +244,9 @@ export async function processFoldersUnified(
 ): Promise<ImportResult> {
     const result: ImportResult = {
         images: [],
-        stats: { processed: 0, imported: 0, skipped: 0, errors: 0 }
+        stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+        handledPaths: [],
+        failedPaths: []
     };
 
     const { onProgress, abortSignal } = options;
@@ -325,7 +348,9 @@ export async function processFoldersUnified(
             task.variant
         );
 
-        result.images.push(...imported);
+        result.images.push(...imported.images);
+        result.handledPaths.push(...imported.handledPaths);
+        result.failedPaths.push(...imported.failedPaths);
 
         // precise increment
         globalProcessed += task.files.length;
@@ -390,7 +415,9 @@ export const processWebFiles = async (files: File[]): Promise<ImportResult> => {
             imported: newImages.length,
             skipped,
             errors
-        }
+        },
+        handledPaths: [],
+        failedPaths: []
     };
 };
 
@@ -442,7 +469,9 @@ export const processTargetedFiles = async (
 ): Promise<ImportResult> => {
     const result: ImportResult = {
         images: [],
-        stats: { processed: 0, imported: 0, skipped: 0, errors: 0 }
+        stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+        handledPaths: [],
+        failedPaths: []
     };
 
     if (paths.length === 0) return result;
@@ -455,7 +484,9 @@ export const processTargetedFiles = async (
 
     console.log(`[Import] Processing ${paths.length} targeted paths...`);
     const imported = await processFileEntries(entries, result.stats, options, defaultTool);
-    result.images = imported;
+    result.images = imported.images;
+    result.handledPaths = imported.handledPaths;
+    result.failedPaths = imported.failedPaths;
 
     // Removed synchronous rebuildFacetCache.
     // Live Watch relies on the 60s idle timeout `useLibraryStore.getState().reportLiveImagesReceived()` 

--- a/src/services/invoke/__tests__/syncService.test.ts
+++ b/src/services/invoke/__tests__/syncService.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from '@tauri-apps/plugin-sql';
+import { commands } from '../../../bindings';
+import { fetchBoardMappings } from '../connection';
+import { insertImagesBatch } from '../../db';
+import { upsertCollection } from '../../db/collectionRepo';
+import { getImagesByIds, syncCollectionImages } from '../../db/imageRepo';
+import { syncImages } from '../syncService';
+
+vi.mock('@tauri-apps/plugin-sql', () => ({
+    default: {
+        load: vi.fn()
+    }
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+    convertFileSrc: vi.fn((path: string) => `asset://${path}`)
+}));
+
+vi.mock('../../../bindings', () => ({
+    commands: {
+        getFileSizesBulk: vi.fn()
+    }
+}));
+
+vi.mock('../metadataMapper', () => ({
+    mapInvokeMetadata: vi.fn(() => ({
+        tool: 'invokeai',
+        model: 'Test Model',
+        seed: 1,
+        steps: 20,
+        cfg: 7,
+        sampler: 'Euler',
+        positivePrompt: 'test',
+        negativePrompt: '',
+        generationType: 'txt2img'
+    }))
+}));
+
+vi.mock('../connection', () => ({
+    fetchBoardMappings: vi.fn()
+}));
+
+vi.mock('../../db', () => ({
+    insertImagesBatch: vi.fn()
+}));
+
+vi.mock('../../db/imageRepo', () => ({
+    getImagesByIds: vi.fn(),
+    syncCollectionImages: vi.fn()
+}));
+
+vi.mock('../../db/collectionRepo', () => ({
+    upsertCollection: vi.fn()
+}));
+
+const createInvokeDb = (selectMock: ReturnType<typeof vi.fn>) => ({
+    select: selectMock
+});
+
+describe('syncImages live mode', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(commands.getFileSizesBulk).mockResolvedValue({ status: 'ok', data: [123] } as never);
+        vi.mocked(insertImagesBatch).mockResolvedValue(undefined as never);
+        vi.mocked(getImagesByIds).mockResolvedValue([]);
+        vi.mocked(syncCollectionImages).mockResolvedValue(undefined as never);
+        vi.mocked(upsertCollection).mockResolvedValue(undefined as never);
+        vi.mocked(fetchBoardMappings).mockResolvedValue({
+            imageToBoardId: new Map(),
+            boards: new Map()
+        });
+    });
+
+    it('returns early for no-op live cycles before board and collection sync work', async () => {
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [{ name: 'metadata_json' }, { name: 'updated_at' }, { name: 'is_intermediate' }];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [];
+            }
+            throw new Error(`Unexpected query: ${query}`);
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'live',
+                syncBoards: true,
+                syncFavorites: true,
+                starredAs: 'favorite'
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(0);
+        expect(fetchBoardMappings).not.toHaveBeenCalled();
+        expect(getImagesByIds).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+        expect(syncCollectionImages).not.toHaveBeenCalled();
+        expect(upsertCollection).not.toHaveBeenCalled();
+    });
+
+    it('keeps live changed cycles incremental and skips the final full collection sync', async () => {
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'updated_at' },
+                    { name: 'is_intermediate' },
+                    { name: 'starred' },
+                    { name: 'thumbnail_name' },
+                    { name: 'has_workflow' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }, { name: 'boards' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [{ found: 1 }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 1 }];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table' AND name='boards'")) {
+                return [{ name: 'boards' }];
+            }
+            if (query.includes('FROM images i') && query.includes('OFFSET 0')) {
+                return [
+                    {
+                        image_name: 'new-image.png',
+                        metadata_blob: { positive_prompt: 'test' },
+                        created_at: '2026-04-18 12:00:00',
+                        updated_at: '2026-04-18 12:00:05',
+                        width: 1024,
+                        height: 1024,
+                        starred: 1,
+                        thumbnail_name: 'new-image.webp',
+                        has_workflow: 1,
+                        is_intermediate: 0
+                    }
+                ];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(fetchBoardMappings).mockResolvedValue({
+            imageToBoardId: new Map([['new-image.png', 'board-1']]),
+            boards: new Map([['board-1', { name: 'Board One', createdAt: 123 }]])
+        });
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'live',
+                syncBoards: true,
+                syncFavorites: true,
+                starredAs: 'both'
+            }
+        );
+
+        expect(result.imported).toBe(1);
+        expect(insertImagesBatch).toHaveBeenCalledTimes(1);
+        expect(syncCollectionImages).toHaveBeenCalledTimes(1);
+        expect(syncCollectionImages).toHaveBeenCalledWith([
+            'D:/AI/art/webUI/invokeai/outputs/images/new-image.png'
+        ]);
+        expect(upsertCollection).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/services/invoke/syncService.ts
+++ b/src/services/invoke/syncService.ts
@@ -4,17 +4,47 @@ import { commands } from '../../bindings';
 import { unwrap } from '../../utils/spectaUtils';
 import { mapInvokeMetadata } from './metadataMapper';
 import { fetchBoardMappings } from './connection';
-import { getDb } from '../db/connection';
 import { APP_NAME } from '../../constants/app';
 import { AIImage } from '../../types';
+import {
+    debugLiveWatchPerf,
+    elapsedMs,
+    infoLiveWatchPerf,
+    InvokeLiveWatchPerfContext,
+    liveWatchNow,
+} from '../../utils/liveWatchPerf';
+
+interface InvokeSyncOptions {
+    syncFavorites?: boolean;
+    syncBoards?: boolean;
+    afterTimestamp?: any;
+    importIntermediates?: boolean;
+    starredAs?: 'favorite' | 'pin' | 'both' | 'none';
+    perfContext?: InvokeLiveWatchPerfContext;
+    mode?: 'manual' | 'startup' | 'live';
+}
 
 export const syncImages = async (
     rootPath: string,
     onProgress: (current: number, total: number, message?: string) => void,
     signal?: AbortSignal,
-    options: { syncFavorites?: boolean, syncBoards?: boolean, afterTimestamp?: any, importIntermediates?: boolean, starredAs?: 'favorite' | 'pin' | 'both' | 'none' } = { syncFavorites: true, syncBoards: true, importIntermediates: false, starredAs: 'favorite' }
+    options: InvokeSyncOptions = { syncFavorites: true, syncBoards: true, importIntermediates: false, starredAs: 'favorite' }
 ): Promise<{ imported: number, updated: number, maxTimestamp: any, syncedIds: Set<string>, boardMapping: Map<string, { name: string, createdAt: number }> }> => {
     console.log('[InvokeAI Sync] syncImages started with path:', rootPath);
+    const syncStartedAt = liveWatchNow();
+    const cycleId = options.perfContext?.cycleId;
+    const logSyncDebug = (label: string, data?: Record<string, unknown>) => {
+        debugLiveWatchPerf(label, {
+            cycleId,
+            ...(data ?? {})
+        });
+    };
+    const logSyncInfo = (label: string, data?: Record<string, unknown>) => {
+        infoLiveWatchPerf(label, {
+            cycleId,
+            ...(data ?? {})
+        });
+    };
     if (!rootPath) return { imported: 0, updated: 0, maxTimestamp: '', syncedIds: new Set(), boardMapping: new Map() };
 
     let imagesRoot = rootPath.replace(/[\\/]$/, '');
@@ -30,19 +60,31 @@ export const syncImages = async (
 
     onProgress(0, 0, 'Connecting to InvokeAI database...');
     let invokeDb;
+    const connectStartedAt = liveWatchNow();
     try {
         invokeDb = await Database.load(connectionString);
     } catch (e) {
         throw new Error(`Could not connect to InvokeAI DB at ${dbPath}`);
     }
+    logSyncDebug('Invoke DB connect complete', {
+        dbPath,
+        connectMs: elapsedMs(connectStartedAt)
+    });
 
     onProgress(0, 0, 'Analyzing database schema...');
+    const schemaStartedAt = liveWatchNow();
     const tableInfo = await (invokeDb as any).select('PRAGMA table_info(images)');
     const columns = tableInfo.map(c => c.name);
 
     const allTablesRows = await (invokeDb as any).select("SELECT name FROM sqlite_master WHERE type='table'");
     const allTables = allTablesRows.map((t: any) => t.name);
     const hasGraphsTable = allTables.includes('graphs');
+    logSyncDebug('Invoke DB schema analyzed', {
+        schemaMs: elapsedMs(schemaStartedAt),
+        columnCount: columns.length,
+        tableCount: allTables.length,
+        hasGraphsTable
+    });
 
     const hasMetadataJson = columns.includes('metadata_json');
     const hasMetadata = columns.includes('metadata');
@@ -57,21 +99,6 @@ export const syncImages = async (
 
     if (!metaCol) {
         throw new Error("Could not find metadata column (checked 'metadata_json' and 'metadata')");
-    }
-
-    let hasBoardsTable = false;
-    try {
-        const boardsTable = await (invokeDb as any).select("SELECT name FROM sqlite_master WHERE type='table' AND name='boards'");
-        hasBoardsTable = boardsTable.length > 0;
-    } catch (e) { }
-
-    let imageToBoardId = new Map<string, string>();
-    let boards = new Map<string, { name: string, createdAt: number }>();
-    if (options.syncBoards && hasBoardsTable) {
-        onProgress(0, 0, 'Fetching board mappings...');
-        const result = await fetchBoardMappings(invokeDb);
-        imageToBoardId = result.imageToBoardId;
-        boards = result.boards;
     }
 
     const conditions: string[] = [];
@@ -93,33 +120,75 @@ export const syncImages = async (
     }
 
     const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')} ` : '';
-    const countRes = await (invokeDb as any).select(`SELECT count(*) as count FROM images i ${whereClause} `);
-    const totalToImport = countRes[0]?.count || 0;
+    let totalToImport = 0;
+    let hasCandidates = true;
+    let boards = new Map<string, { name: string, createdAt: number }>();
 
-    onProgress(0, 0, `Scanning ${APP_NAME} library...`);
-    const { getDb, insertImagesBatch } = await import('../db');
-    const ambitDb = await getDb();
-    const existingRows = await ambitDb.select('SELECT id FROM images') as { id: string }[];
-    const ambitExistingIds = new Set(existingRows.map(r => r.id));
+    if (options.mode === 'live') {
+        const candidateCheckStartedAt = liveWatchNow();
+        const candidateRes = await (invokeDb as any).select(`SELECT 1 as found FROM images i ${whereClause} LIMIT 1`);
+        hasCandidates = candidateRes.length > 0;
+        logSyncDebug('Invoke live candidate detection complete', {
+            hasCandidates,
+            candidateCheckMs: elapsedMs(candidateCheckStartedAt)
+        });
+    }
 
-    // Fetch existing states for favorite/pin/board to preserve them if sync is disabled for those fields
-    const { getImagesByIds } = await import('../db/imageRepo');
-    const existingImagesMeta = new Map<string, { isFavorite: boolean, isPinned: boolean, boardId?: string }>();
+    if (hasCandidates) {
+        const countStartedAt = liveWatchNow();
+        const countRes = await (invokeDb as any).select(`SELECT count(*) as count FROM images i ${whereClause} `);
+        totalToImport = countRes[0]?.count || 0;
+        logSyncDebug('Invoke sync candidate count computed', {
+            totalToImport,
+            countMs: elapsedMs(countStartedAt),
+            hasUpdatedAt,
+            importIntermediates: options.importIntermediates ?? false
+        });
+    } else {
+        logSyncDebug('Invoke sync candidate count computed', {
+            totalToImport,
+            countMs: 0,
+            hasUpdatedAt,
+            importIntermediates: options.importIntermediates ?? false
+        });
+    }
 
     const syncedIds = new Set<string>();
 
     if (totalToImport === 0) {
-        if (options.syncBoards && imageToBoardId.size > 0) {
-            try {
-                const mappingObj: Record<string, string> = {};
-                imageToBoardId.forEach((val, key) => { mappingObj[key] = val; });
-                await unwrap(commands.refreshBoardsNative(mappingObj));
-                const { syncCollectionImages } = await import('../db/imageRepo');
-                await syncCollectionImages();
-            } catch (e) { }
-        }
+        logSyncInfo('Invoke sync service complete', {
+            totalToImport,
+            importedCount: 0,
+            updatedCount: 0,
+            batchCount: 0,
+            totalMs: elapsedMs(syncStartedAt)
+        });
         return { imported: 0, updated: 0, maxTimestamp: options.afterTimestamp || 0, syncedIds, boardMapping: options.syncBoards ? boards : new Map() };
     }
+
+    let hasBoardsTable = false;
+    try {
+        const boardsTable = await (invokeDb as any).select("SELECT name FROM sqlite_master WHERE type='table' AND name='boards'");
+        hasBoardsTable = boardsTable.length > 0;
+    } catch (e) { }
+
+    let imageToBoardId = new Map<string, string>();
+    if (options.syncBoards && hasBoardsTable) {
+        onProgress(0, 0, 'Fetching board mappings...');
+        const boardMappingStartedAt = liveWatchNow();
+        const result = await fetchBoardMappings(invokeDb);
+        imageToBoardId = result.imageToBoardId;
+        boards = result.boards;
+        logSyncDebug('Invoke board mappings loaded', {
+            boardCount: boards.size,
+            imageBoardLinks: imageToBoardId.size,
+            boardMappingMs: elapsedMs(boardMappingStartedAt)
+        });
+    }
+
+    onProgress(0, 0, `Scanning ${APP_NAME} library...`);
+    const { insertImagesBatch } = await import('../db');
+    const { getImagesByIds } = await import('../db/imageRepo');
 
     let processed = 0;
     let newImportedCount = 0;
@@ -135,10 +204,13 @@ export const syncImages = async (
     const intermediateCol = hasIsIntermediate ? ', i.is_intermediate' : '';
 
     const createdBoardIds = new Set<string>();
+    let batchCount = 0;
 
     while (true) {
         if (signal?.aborted) throw new Error('Aborted');
 
+        const batchStartedAt = liveWatchNow();
+        const batchIndex = batchCount + 1;
         const metaSelect = metaCol ? `i.${metaCol} as metadata_blob` : "NULL as metadata_blob";
         const query = `
             SELECT i.image_name, ${metaSelect}, i.created_at, i.width, i.height ${favCol} ${thumbCol} ${hasWfCol} ${updatedCol} ${intermediateCol}
@@ -148,8 +220,11 @@ export const syncImages = async (
             LIMIT ${BATCH_SIZE} OFFSET ${offset}
 `;
 
+        const batchQueryStartedAt = liveWatchNow();
         const rows = await (invokeDb as any).select(query);
+        const batchQueryMs = elapsedMs(batchQueryStartedAt);
         if (rows.length === 0) break;
+        batchCount++;
 
         const batchPaths = rows.map((row: any) => {
             const rawPath = `${imagesRoot}/outputs/images/${row.image_name}`;
@@ -157,16 +232,21 @@ export const syncImages = async (
         });
 
         let sizes: number[] = [];
+        const fileSizeProbeStartedAt = liveWatchNow();
         try {
             sizes = await unwrap(commands.getFileSizesBulk(batchPaths));
         } catch (e) {
             sizes = new Array(rows.length).fill(0);
         }
+        const fileSizeProbeMs = elapsedMs(fileSizeProbeStartedAt);
 
+        const existingLookupStartedAt = liveWatchNow();
         const existingImagesInBatch = await getImagesByIds(batchPaths);
         const existingMap = new Map(existingImagesInBatch.map(img => [img.id, img]));
+        const existingLookupMs = elapsedMs(existingLookupStartedAt);
 
         const currentBatch: any[] = [];
+        const batchBuildStartedAt = liveWatchNow();
         for (let i = 0; i < rows.length; i++) {
             const row = rows[i];
             const fullPath = batchPaths[i];
@@ -360,7 +440,6 @@ export const syncImages = async (
 
                 if (!existing) {
                     newImportedCount++;
-                    ambitExistingIds.add(fullPath);
                 } else {
                     totalUpdated++;
                 }
@@ -370,11 +449,16 @@ export const syncImages = async (
                 processed++;
             } catch (e) { }
         }
+        const batchBuildMs = elapsedMs(batchBuildStartedAt);
 
+        let boardCreateMs = 0;
+        let insertMs = 0;
+        let collectionSyncMs = 0;
         if (currentBatch.length > 0) {
             // Lazy Board Creation
             if (options.syncBoards) {
                 const { upsertCollection } = await import('../db/collectionRepo');
+                const boardCreateStartedAt = liveWatchNow();
                 const batchBoardIds = new Set(currentBatch.map(img => img.boardId).filter(id => id && !createdBoardIds.has(id)));
                 for (const bId of batchBoardIds) {
                     const boardInfo = boards.get(bId!);
@@ -388,28 +472,58 @@ export const syncImages = async (
                         createdBoardIds.add(bId!);
                     }
                 }
+                boardCreateMs = elapsedMs(boardCreateStartedAt);
             }
 
+            const insertStartedAt = liveWatchNow();
             await insertImagesBatch(currentBatch);
+            insertMs = elapsedMs(insertStartedAt);
 
             // Incremental Linking
             if (options.syncBoards) {
                 const { syncCollectionImages } = await import('../db/imageRepo');
+                const collectionSyncStartedAt = liveWatchNow();
                 await syncCollectionImages(currentBatch.map(img => img.id));
+                collectionSyncMs = elapsedMs(collectionSyncStartedAt);
             }
         }
+        logSyncDebug('Invoke sync batch complete', {
+            batchIndex,
+            rowCount: rows.length,
+            upsertCount: currentBatch.length,
+            queryMs: batchQueryMs,
+            fileSizeProbeMs,
+            existingLookupMs,
+            batchBuildMs,
+            boardCreateMs,
+            insertMs,
+            collectionSyncMs,
+            batchMs: elapsedMs(batchStartedAt)
+        });
         offset += rows.length;
         onProgress(Math.min(processed, totalToImport), totalToImport, `Importing: ${Math.min(processed, totalToImport)} / ${totalToImport}`);
         await new Promise(r => setTimeout(r, 0));
     }
 
     // Final cleanup / sync (optional fallback)
-    if (options.syncBoards && boards.size > 0) {
+    if (options.syncBoards && boards.size > 0 && options.mode !== 'live') {
         // We've already done incremental sync, but this ensures everything is correct
         // especially for images that might have been updated/synced without being in a new batch
         const { syncCollectionImages } = await import('../db/imageRepo');
+        const finalCollectionSyncStartedAt = liveWatchNow();
         await syncCollectionImages();
+        logSyncDebug('Invoke final collection sync complete', {
+            collectionSyncMs: elapsedMs(finalCollectionSyncStartedAt)
+        });
     }
+
+    logSyncInfo('Invoke sync service complete', {
+        totalToImport,
+        importedCount: newImportedCount,
+        updatedCount: totalUpdated,
+        batchCount,
+        totalMs: elapsedMs(syncStartedAt)
+    });
 
     return { imported: newImportedCount, updated: totalUpdated, maxTimestamp: maxTimestampNum, syncedIds, boardMapping: boards };
 };

--- a/src/services/metadataParser.ts
+++ b/src/services/metadataParser.ts
@@ -2,6 +2,12 @@ import { ImageMetadata, GeneratorTool, ParseResult, AIImage } from '../types';
 import { commands, ScanResult } from '../bindings';
 import { unwrap } from '../utils/spectaUtils';
 import { getFilename } from '../utils/pathUtils';
+import {
+    debugLiveWatchPerf,
+    elapsedMs,
+    infoLiveWatchPerf,
+    liveWatchNow,
+} from '../utils/liveWatchPerf';
 
 // Initializing the worker
 // Using ?worker&inline might be needed depending on Vite config, 
@@ -27,10 +33,12 @@ const parseInWorker = (chunks: any, filename: string, path?: string, defaultTool
 
         // Let's implement a simple Request ID system.
         const requestId = Math.random().toString(36).substring(7);
+        let timeoutId: ReturnType<typeof setTimeout>;
 
         const handler = (e: MessageEvent) => {
             if (e.data.requestId === requestId) {
                 worker.removeEventListener('message', handler);
+                clearTimeout(timeoutId);
                 if (e.data.error) reject(e.data.error);
                 else resolve(e.data);
             }
@@ -40,7 +48,7 @@ const parseInWorker = (chunks: any, filename: string, path?: string, defaultTool
         worker.postMessage({ chunks: (chunks as any).chunks, buffer: (chunks as any).buffer, filename, requestId, path, defaultTool });
 
         // Timeout safety
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
             worker.removeEventListener('message', handler);
             reject(new Error("Worker timed out"));
         }, 5000);
@@ -92,10 +100,15 @@ const processScanResult = async (info: ScanResult, path: string, defaultTool?: G
     // from chunks, and is_intermediate is only set if explicit in metadata.
 
     const filename = path.split(/[\\/]/).pop() || "unknown";
+    const workerStartedAt = liveWatchNow();
 
     try {
         const { metadata, extra, isIntermediate } = (await parseInWorker(info.chunks, filename, path, defaultTool)) as any;
         const finalIsIntermediate = isIntermediate || metadata.isIntermediate;
+        debugLiveWatchPerf('Worker parse complete', {
+            filename,
+            workerMs: elapsedMs(workerStartedAt)
+        });
         return {
             metadata: {
                 ...metadata,
@@ -115,6 +128,11 @@ const processScanResult = async (info: ScanResult, path: string, defaultTool?: G
             errorReason: (info as any).error
         };
     } catch (workerError) {
+        debugLiveWatchPerf('Worker parse failed', {
+            filename,
+            workerMs: elapsedMs(workerStartedAt),
+            error: workerError instanceof Error ? workerError.message : String(workerError)
+        });
         console.error(`Worker parse failed/timed out for ${path}:`, workerError);
         return {
             metadata: { tool: GeneratorTool.UNKNOWN, model: 'Unknown' },
@@ -152,14 +170,25 @@ export const scanImageNative = async (path: string, thumbnailDir?: string, skipT
 
 export const scanImagesBulk = async (paths: string[], thumbnailDir?: string, skipThumbnail: boolean = false, extractWorkflow: boolean = true, defaultTool?: GeneratorTool): Promise<ParseResult[]> => {
     try {
+        const bulkScanStartedAt = liveWatchNow();
+        const nativeScanStartedAt = liveWatchNow();
         const results = await unwrap(commands.scanImagesBulk(paths, thumbnailDir || null, skipThumbnail, extractWorkflow, defaultTool || null));
+        const nativeScanMs = elapsedMs(nativeScanStartedAt);
 
         const tasks = results.map((info, index) => {
             const path = paths[index];
             return processScanResult(info, path, defaultTool);
         });
 
-        return Promise.all(tasks);
+        const postProcessStartedAt = liveWatchNow();
+        const parsedResults = await Promise.all(tasks);
+        infoLiveWatchPerf('scanImagesBulk complete', {
+            pathCount: paths.length,
+            nativeScanMs,
+            postProcessMs: elapsedMs(postProcessStartedAt),
+            totalMs: elapsedMs(bulkScanStartedAt)
+        });
+        return parsedResults;
     } catch (e) {
         console.error("Bulk scan invocation failed", e);
         return [];

--- a/src/stores/__tests__/libraryStore.test.ts
+++ b/src/stores/__tests__/libraryStore.test.ts
@@ -1,0 +1,97 @@
+import { act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createInitialLiveWatchSessionState, useLibraryStore } from '../libraryStore';
+import { rebuildFacetCache } from '../../services/db/imageRepo';
+
+vi.mock('../../bindings', () => ({
+    commands: {
+        cancelModelDiscovery: vi.fn().mockResolvedValue(undefined)
+    }
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+    invoke: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../../services/db/imageRepo', () => ({
+    rebuildFacetCache: vi.fn().mockResolvedValue(undefined)
+}));
+
+const resetLibraryStore = () => {
+    useLibraryStore.setState(useLibraryStore.getInitialState(), true);
+    useLibraryStore.setState({
+        liveWatchSession: createInitialLiveWatchSessionState(),
+        isActivityDockDismissed: false,
+        facetCacheVersion: 0
+    });
+};
+
+describe('libraryStore live watch session', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        resetLibraryStore();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('resets the idle timer when new live activity arrives', async () => {
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'watching',
+                message: 'Detected InvokeAI activity.'
+            });
+            useLibraryStore.getState().reportLiveImagesReceived(1, { source: 'invoke' });
+        });
+
+        expect(useLibraryStore.getState().liveWatchSession.receivedCount).toBe(1);
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(59000);
+        });
+
+        expect(useLibraryStore.getState().liveWatchSession.active).toBe(true);
+        expect(rebuildFacetCache).not.toHaveBeenCalled();
+
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('generic', {
+                phase: 'watching',
+                message: 'Detected new files.'
+            });
+        });
+
+        expect(useLibraryStore.getState().liveWatchSession.source).toBe('mixed');
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(59000);
+        });
+
+        expect(useLibraryStore.getState().liveWatchSession.active).toBe(true);
+        expect(rebuildFacetCache).not.toHaveBeenCalled();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(1000);
+        });
+
+        expect(useLibraryStore.getState().liveWatchSession.active).toBe(false);
+        expect(rebuildFacetCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the idle facet rebuild when no images were received', async () => {
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'watching',
+                message: 'Waiting for completed images...'
+            });
+        });
+
+        await act(async () => {
+            await useLibraryStore.getState().endLiveImageSession();
+        });
+
+        expect(useLibraryStore.getState().liveWatchSession.active).toBe(false);
+        expect(rebuildFacetCache).not.toHaveBeenCalled();
+    });
+});

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -2,7 +2,8 @@ import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
 import { commands } from '../bindings';
 
-let liveWatchTimeout: any = null;
+let liveWatchTimeout: ReturnType<typeof setTimeout> | null = null;
+const LIVE_WATCH_IDLE_TIMEOUT_MS = 60000;
 
 export interface SyncProgress {
     current: number;
@@ -11,6 +12,80 @@ export interface SyncProgress {
 }
 
 export type SyncStatus = 'idle' | 'syncing' | 'complete' | 'error';
+export type LiveWatchSessionSource = 'generic' | 'invoke' | 'mixed';
+export type LiveWatchSessionPhase = 'watching' | 'syncing' | 'importing' | 'summary';
+
+export interface LiveWatchSessionState {
+    active: boolean;
+    source: LiveWatchSessionSource | null;
+    phase: LiveWatchSessionPhase | null;
+    message?: string;
+    progress: SyncProgress | null;
+    receivedCount: number;
+    startedAt: number | null;
+    lastActivityAt: number | null;
+}
+
+interface LiveWatchSessionUpdate {
+    source?: LiveWatchSessionSource;
+    phase?: LiveWatchSessionPhase;
+    message?: string;
+    progress?: SyncProgress | null;
+}
+
+const mergeLiveWatchSource = (
+    current: LiveWatchSessionSource | null,
+    next?: LiveWatchSessionSource
+): LiveWatchSessionSource | null => {
+    if (!next) {
+        return current;
+    }
+
+    if (!current || current === next) {
+        return next;
+    }
+
+    return 'mixed';
+};
+
+export const getLiveWatchSummaryMessage = (receivedCount: number): string => {
+    if (receivedCount <= 0) {
+        return 'Watching for completed images...';
+    }
+
+    return receivedCount === 1
+        ? '1 image received this session. Watching for more...'
+        : `${receivedCount} images received this session. Watching for more...`;
+};
+
+export const createInitialLiveWatchSessionState = (): LiveWatchSessionState => ({
+    active: false,
+    source: null,
+    phase: null,
+    message: undefined,
+    progress: null,
+    receivedCount: 0,
+    startedAt: null,
+    lastActivityAt: null
+});
+
+const scheduleLiveWatchSessionEnd = () => {
+    if (liveWatchTimeout) {
+        clearTimeout(liveWatchTimeout);
+    }
+
+    liveWatchTimeout = setTimeout(async () => {
+        const endSession = useLibraryStore.getState().endLiveImageSession;
+        await endSession();
+    }, LIVE_WATCH_IDLE_TIMEOUT_MS);
+};
+
+const clearLiveWatchSessionEnd = () => {
+    if (liveWatchTimeout) {
+        clearTimeout(liveWatchTimeout);
+        liveWatchTimeout = null;
+    }
+};
 
 export interface MaintenanceCounts {
     untagged: number;
@@ -60,8 +135,7 @@ interface LibraryState {
     refreshProgress: SyncProgress | null;
 
     // Live Watch Session State
-    isReceivingLiveImages: boolean;
-    liveImagesReceivedCount: number;
+    liveWatchSession: LiveWatchSessionState;
 
     // Facet Cache Version (incremented after cache rebuild to trigger React Query refetch)
     facetCacheVersion: number;
@@ -106,7 +180,9 @@ interface LibraryState {
     cancelRefresh: () => void;
 
     // Live Watch Session Actions
-    reportLiveImagesReceived: (count: number) => void;
+    startLiveWatchSession: (source: LiveWatchSessionSource, update?: Omit<LiveWatchSessionUpdate, 'source'>) => void;
+    updateLiveWatchSession: (update: LiveWatchSessionUpdate) => void;
+    reportLiveImagesReceived: (count: number, update?: Omit<LiveWatchSessionUpdate, 'phase'>) => void;
     endLiveImageSession: () => Promise<void>;
 }
 
@@ -153,8 +229,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     refreshProgress: null,
 
     // Live Watch Session State
-    isReceivingLiveImages: false,
-    liveImagesReceivedCount: 0,
+    liveWatchSession: createInitialLiveWatchSessionState(),
 
     // Actions
     setSyncStatus: (status) => set({ syncStatus: status }),
@@ -221,20 +296,80 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     },
 
     // Live Watch Session Actions
-    reportLiveImagesReceived: (count) => {
-        set((state) => ({ 
-            isReceivingLiveImages: true, 
-            liveImagesReceivedCount: state.liveImagesReceivedCount + count 
-        }));
-        
-        if (liveWatchTimeout) clearTimeout(liveWatchTimeout);
-        liveWatchTimeout = setTimeout(async () => {
-            const endSession = useLibraryStore.getState().endLiveImageSession;
-            await endSession();
-        }, 60000); // 60-second idle session timeout
+    startLiveWatchSession: (source, update = {}) => {
+        const now = Date.now();
+        set((state) => {
+            const currentSession = state.liveWatchSession;
+            const resolvedSource = mergeLiveWatchSource(currentSession.source, source);
+            return {
+                liveWatchSession: {
+                    active: true,
+                    source: resolvedSource,
+                    phase: update.phase ?? 'watching',
+                    message: update.message,
+                    progress: update.progress ?? null,
+                    receivedCount: currentSession.receivedCount,
+                    startedAt: currentSession.active ? currentSession.startedAt : now,
+                    lastActivityAt: now
+                },
+                isActivityDockDismissed: false
+            };
+        });
+        scheduleLiveWatchSessionEnd();
+    },
+    updateLiveWatchSession: (update) => {
+        const now = Date.now();
+        set((state) => {
+            const currentSession = state.liveWatchSession;
+            const resolvedSource = mergeLiveWatchSource(currentSession.source, update.source);
+            return {
+                liveWatchSession: {
+                    active: true,
+                    source: resolvedSource,
+                    phase: update.phase ?? currentSession.phase ?? 'watching',
+                    message: update.message ?? currentSession.message,
+                    progress: update.progress !== undefined ? update.progress : currentSession.progress,
+                    receivedCount: currentSession.receivedCount,
+                    startedAt: currentSession.startedAt ?? now,
+                    lastActivityAt: now
+                },
+                isActivityDockDismissed: false
+            };
+        });
+        scheduleLiveWatchSessionEnd();
+    },
+    reportLiveImagesReceived: (count, update = {}) => {
+        const now = Date.now();
+        set((state) => {
+            const currentSession = state.liveWatchSession;
+            const receivedCount = currentSession.receivedCount + count;
+            const resolvedSource = mergeLiveWatchSource(currentSession.source, update.source);
+            return {
+                liveWatchSession: {
+                    active: true,
+                    source: resolvedSource,
+                    phase: 'summary',
+                    message: update.message ?? getLiveWatchSummaryMessage(receivedCount),
+                    progress: update.progress ?? null,
+                    receivedCount,
+                    startedAt: currentSession.startedAt ?? now,
+                    lastActivityAt: now
+                },
+                isActivityDockDismissed: false
+            };
+        });
+        scheduleLiveWatchSessionEnd();
     },
     endLiveImageSession: async () => {
-        set({ isReceivingLiveImages: false, liveImagesReceivedCount: 0 });
+        clearLiveWatchSessionEnd();
+        const { liveWatchSession } = useLibraryStore.getState();
+        const shouldRebuildFacetCache = liveWatchSession.receivedCount > 0;
+        set({ liveWatchSession: createInitialLiveWatchSessionState() });
+
+        if (!shouldRebuildFacetCache) {
+            return;
+        }
+
         try {
             console.log('[LiveWatch] Idle timeout reached. Rebuilding Facet Cache.');
             const { rebuildFacetCache } = await import('../services/db/imageRepo');

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,8 @@ export interface SmartCollection extends Collection {
 
 export type SortOption = 'date_desc' | 'date_asc' | 'name_asc' | 'name_desc' | 'size_desc' | 'size_asc';
 
+export type MetadataRefreshScope = 'full' | 'images-only';
+
 export type FacetSortOption =
   | 'count_desc' | 'count_asc'
   | 'name_asc' | 'name_desc'

--- a/src/utils/liveWatchPerf.ts
+++ b/src/utils/liveWatchPerf.ts
@@ -1,0 +1,60 @@
+export interface InvokeLiveWatchPerfContext {
+    cycleId: string;
+    firstEventAt: number;
+    lastEventAt: number;
+    eventCount: number;
+    pathCount: number;
+    debounceScheduledAt: number;
+    debounceDelayMs: number;
+    debounceFireDelayMs: number;
+    mergedCycleCount?: number;
+}
+
+export interface TargetedLiveSyncPerfContext {
+    cycleId: string;
+    source: string;
+    firstEventAt: number;
+    lastEventAt: number;
+    eventCount: number;
+    pathCount: number;
+    queueDepthAtStart?: number;
+    mergedCycleCount?: number;
+}
+
+const PREFIX = '[LiveWatchPerf]';
+
+export const liveWatchNow = (): number => {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+        return performance.now();
+    }
+
+    return Date.now();
+};
+
+export const elapsedMs = (start: number): number => {
+    return Math.round(liveWatchNow() - start);
+};
+
+export const createLiveWatchPerfId = (prefix: string): string => {
+    return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+};
+
+const stringifyPerfData = (data?: Record<string, unknown>): string => {
+    if (!data || Object.keys(data).length === 0) {
+        return '';
+    }
+
+    try {
+        return ` ${JSON.stringify(data)}`;
+    } catch {
+        return ` ${JSON.stringify({ serializationError: true })}`;
+    }
+};
+
+export const debugLiveWatchPerf = (label: string, data?: Record<string, unknown>) => {
+    console.debug(`${PREFIX} ${label}${stringifyPerfData(data)}`);
+};
+
+export const infoLiveWatchPerf = (label: string, data?: Record<string, unknown>) => {
+    console.info(`${PREFIX} ${label}${stringifyPerfData(data)}`);
+};


### PR DESCRIPTION
## Summary
- harden Live Watch queueing and no-op Invoke handling so repeated DB-wal chatter stays cheap
- add end-to-end Live Watch performance instrumentation and regression coverage
- unify Live Watch session feedback and stabilize the Live Watch card/header presentation

## What changed
- short-circuit live Invoke no-op cycles before expensive board/collection refresh work
- serialize and coalesce generic and Invoke live work so useful imports do not wait behind stale reruns
- add a real Live Watch session model with phase-aware dock behavior and deferred idle facet rebuilds
- keep the Live Watch card purple and stable in width/height across watching, syncing, importing, and summary states
- align the top header strip with the Live Watch session state instead of generic task styling

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm test -- --run src/components/ui/__tests__/ActivityDock.test.tsx src/components/ui/__tests__/AppHeader.test.tsx src/stores/__tests__/libraryStore.test.ts src/services/invoke/__tests__/syncService.test.ts src/contexts/__tests__/LibraryIntegration.test.tsx`
- `pnpm run build`
- `pnpm run test:rust`