### PR TITLE
[codex] make bindings generation explicit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.webp binary
+*.ico binary
+*.db binary

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "tauri": "tauri",
     "app:dev": "tauri dev --config src-tauri/tauri.dev.json",
     "app:build": "tauri build",
+    "bindings:generate": "cargo run --manifest-path src-tauri/Cargo.toml --bin export_bindings -- src/bindings.ts",
+    "bindings:check": "node ./scripts/check-bindings.mjs",
     "check:versions": "node ./scripts/check-version-consistency.mjs",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/check-bindings.mjs
+++ b/scripts/check-bindings.mjs
@@ -1,0 +1,47 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const rootDir = process.cwd();
+const expectedPath = path.join(rootDir, 'src', 'bindings.ts');
+const generatedPath = path.join(rootDir, 'src-tauri', 'target', 'bindings.check.ts');
+const generatedArg = path.relative(rootDir, generatedPath);
+
+fs.mkdirSync(path.dirname(generatedPath), { recursive: true });
+fs.rmSync(generatedPath, { force: true });
+
+const result = spawnSync(
+  'cargo',
+  [
+    'run',
+    '--manifest-path',
+    'src-tauri/Cargo.toml',
+    '--bin',
+    'export_bindings',
+    '--',
+    generatedArg,
+  ],
+  { cwd: rootDir, stdio: 'inherit' },
+);
+
+if (result.status !== 0) {
+  if (result.error) {
+    console.error(result.error.message);
+  }
+  process.exit(result.status ?? 1);
+}
+
+const normalize = (value) => value.replace(/\r\n/g, '\n');
+const expected = normalize(fs.readFileSync(expectedPath, 'utf8'));
+const generated = normalize(fs.readFileSync(generatedPath, 'utf8'));
+
+fs.rmSync(generatedPath, { force: true });
+
+if (expected !== generated) {
+  console.error('src/bindings.ts is out of date.');
+  console.error('Run `pnpm run bindings:generate` and commit the updated file.');
+  process.exit(1);
+}
+
+console.log('Binding check passed.');

--- a/src-tauri/src/bin/export_bindings.rs
+++ b/src-tauri/src/bin/export_bindings.rs
@@ -1,0 +1,24 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let output_path = env::args_os().nth(1).map(PathBuf::from).unwrap_or_else(|| {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("src")
+            .join("bindings.ts")
+    });
+
+    if let Some(parent) = output_path.parent() {
+        fs::create_dir_all(parent).expect("Failed to create bindings output directory");
+    }
+
+    app_lib::create_builder()
+        .export(
+            specta_typescript::Typescript::default()
+                .bigint(specta_typescript::BigIntExportBehavior::Number),
+            &output_path,
+        )
+        .expect("Failed to export TypeScript bindings");
+
+    println!("Exported TypeScript bindings to {}", output_path.display());
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,21 +79,10 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
     ])
 }
 
-// Force Rebuild
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 #[cfg(not(test))]
 pub fn run() {
     let builder = create_builder();
-
-    // Export generated bindings on every dev run
-    #[cfg(debug_assertions)]
-    builder
-        .export(
-            specta_typescript::Typescript::default()
-                .bigint(specta_typescript::BigIntExportBehavior::Number),
-            "../src/bindings.ts",
-        )
-        .expect("Failed to export TypeScript bindings");
 
     // Check for deferred purge request BEFORE initializing the database
     check_and_execute_deferred_purge();
@@ -234,22 +223,5 @@ fn check_and_execute_deferred_purge() {
                 let _ = std::fs::remove_file(&shm_path);
             }
         }
-    }
-}
-
-#[cfg(all(test, not(test)))] // Disabled during standard tests to avoid linking Tauri
-mod tests {
-    use super::*;
-
-    #[test]
-    fn export_bindings() {
-        let builder = create_builder();
-        builder
-            .export(
-                specta_typescript::Typescript::default()
-                    .bigint(specta_typescript::BigIntExportBehavior::Number),
-                "../src/bindings.ts",
-            )
-            .expect("Failed to export TypeScript bindings");
     }
 }


### PR DESCRIPTION
## Summary
- Move tauri-specta TypeScript binding generation out of app startup and into explicit scripts.
- Add a binding freshness check that generates to `src-tauri/target` and compares against committed `src/bindings.ts`.
- Add repository line-ending policy via `.gitattributes` to keep source files on LF and mark common binary assets.

## Why
Running the Tauri app in debug mode was rewriting `src/bindings.ts`, which made normal startup look like a source change. The new workflow keeps generated bindings tracked, but only updates them intentionally.

## Validation
- `pnpm run bindings:generate`
- `pnpm run bindings:check`
- `pnpm run build`
- `pnpm run test:rust`
- `pnpm run check:versions`