### PR TITLE
[codex] release prep library removal and reliability fixes

### DIFF
--- a/docs/release-test-checklist.md
+++ b/docs/release-test-checklist.md
@@ -1,0 +1,339 @@
+# Release Test Checklist
+
+Status: Working draft
+Last updated: 2026-04-24
+
+Use this checklist for staged release testing of Ambit. It is scoped to the current app shape:
+
+- Tauri desktop shell with Rust commands
+- React/TypeScript frontend
+- SQLite-backed image library and metadata
+- `library.json` settings persistence
+- local filesystem folder sync, watcher, thumbnails, search, and viewer flows
+- optional Gemini-backed intelligence features
+
+## Test Flow
+
+```mermaid
+flowchart LR
+    A["Phase 0\nBuild + Environment"] --> B["Phase 1\nSmoke"]
+    B --> C["Phase 2\nCore User Flows"]
+    C --> D["Phase 3\nSearch + Viewer Depth"]
+    D --> E["Phase 4\nScale + Reliability"]
+    E --> F["Phase 5\nPackaging + Upgrade"]
+    F --> G["Release Sign-Off"]
+```
+
+## How To Use This
+
+- Run phases in order. Do not spend time on deep feature checks until smoke passes.
+- Record OS, build type, app version, test library size, and whether the run used a fresh or existing profile.
+- For every failure, note: expected result, actual result, repro steps, and whether it blocks release.
+- Mark each item `Pass`, `Fail`, `N/A`, or `Deferred`.
+
+## Ownership Split
+
+Use two lanes so we do not both spend time on the same check.
+
+```mermaid
+flowchart TD
+    A["Codex lane\nworkspace-driven checks"] --> B["build scripts"]
+    A --> C["unit and Rust tests"]
+    A --> D["version and repo consistency"]
+    A --> E["targeted code inspection"]
+    F["User lane\nmanual release verification"] --> G["real UI behavior"]
+    F --> H["installer and upgrade paths"]
+    F --> I["watcher timing and OS integration"]
+    F --> J["large-library feel and trust checks"]
+```
+
+### Codex Lane
+
+I should own checks that can be run or inspected directly in the workspace:
+
+- build and packaging commands
+- frontend and Rust automated tests
+- version consistency checks
+- code review of risky release paths
+- log and failure triage when a command breaks
+- turning findings into concrete follow-up issues or fixes
+
+### User Lane
+
+You should own checks that require judgment, live desktop interaction, or a real install environment:
+
+- whether the app feels responsive and coherent in the UI
+- whether search results, counts, and metadata look correct on your real libraries
+- whether viewer navigation, compare mode, and timeline behavior feel right
+- whether watcher behavior matches your expectation during live file changes
+- whether installer, upgrade, uninstall, and persisted state behave correctly on your machine
+- whether a release candidate feels trustworthy enough to ship
+
+### Shared Lane
+
+Some checks are best split:
+
+- I run the command or prepare the candidate build.
+- You verify the visible behavior in the app.
+- I investigate and fix anything that fails.
+
+## Test Matrix
+
+Capture one line per run:
+
+| Run | OS | Build | Dataset | Profile | Result |
+| --- | --- | --- | --- | --- | --- |
+| 1 |  | dev / packaged | small / medium / large | fresh / existing |  |
+| 2 |  | dev / packaged | small / medium / large | fresh / existing |  |
+| 3 |  | dev / packaged | small / medium / large | fresh / existing |  |
+
+## Phase 0: Build And Environment Gate
+
+Goal: confirm the branch is shippable before manual QA starts.
+
+Owner: Codex first, then user only if a packaged artifact behaves differently on the target machine.
+
+- [ ] `pnpm run build` completes successfully.
+- [ ] `pnpm run test` passes for the current branch or any failures are known and documented.
+- [ ] `pnpm run test:rust` passes or any failures are known and documented.
+- [ ] `pnpm run check:versions` passes before packaging.
+- [ ] Packaged app can be produced with `pnpm run app:build`.
+- [ ] Release notes/version numbers are consistent across package metadata and Tauri config.
+- [ ] No accidental debug artifacts, local secrets, or scratch files are included in the build.
+
+## Phase 1: Smoke Test
+
+Goal: catch immediate release blockers in under 15 minutes.
+
+Owner: Shared. I can prepare the build and review logs; you should verify the visible desktop behavior.
+
+- [ ] App launches cleanly from a packaged build.
+- [ ] Existing library opens without crash, long stall, or blank screen.
+- [ ] Fresh profile can complete first-run setup.
+- [ ] Settings modal opens and closes cleanly.
+- [ ] At least one watched folder can be added successfully.
+- [ ] Initial scan/import completes and images appear in the library.
+- [ ] A basic search returns expected images.
+- [ ] Opening an image in the viewer works.
+- [ ] Closing the app and reopening preserves the expected library/settings state.
+
+Exit criteria:
+
+- No crash on launch, scan, search, viewer open, or restart.
+- No corruption of settings, folders, or library records.
+
+## Phase 2: Core User Workflows
+
+Goal: validate the main product loop for local image management.
+
+Owner: Mostly user. I can support with targeted data setup, code inspection, and bug-fix follow-through.
+
+### Library Setup And Persistence
+
+- [ ] Add one valid library folder.
+- [ ] Add multiple folders and verify they persist after restart.
+- [ ] Reject or safely handle an invalid, missing, or inaccessible folder.
+- [ ] Removing a folder does not corrupt the remaining library.
+- [ ] App handles rescanning an already-known folder cleanly.
+- [ ] Folder sync or watcher state survives restart as expected.
+
+### Import, Scan, And Metadata
+
+- [ ] PNGs with expected metadata parse correctly.
+- [ ] Images with weak or partial metadata do not crash import.
+- [ ] Non-image files in library folders are ignored safely.
+- [ ] Duplicate or repeat scans do not create obvious duplicate records unless intended.
+- [ ] Thumbnail generation completes for newly imported files.
+- [ ] Metadata-heavy images still appear and remain viewable.
+- [ ] ComfyUI or workflow-style metadata can be opened where available.
+
+### Settings And Local-First Behavior
+
+- [ ] Settings changes persist after restart.
+- [ ] Sensitive keys are not written into plain JSON settings.
+- [ ] Disabling optional intelligence features leaves the rest of the app functional.
+- [ ] No core workflow requires network access.
+
+## Phase 3: Search, Filter, Collection, And Viewer Depth
+
+Goal: validate the day-to-day interaction surface.
+
+Owner: Mostly user. These checks depend heavily on visible correctness and interaction quality.
+
+### Search And Filters
+
+- [ ] Free-text search returns expected matches.
+- [ ] Clearing search fully resets result state.
+- [ ] Filter combinations work together without obviously wrong counts/results.
+- [ ] Date range filters behave correctly at boundaries.
+- [ ] Collection-based filtering matches actual collection membership.
+- [ ] Filter state remains understandable after navigation and restart.
+
+Deferred UX note:
+- Search/smart-collection transition feedback should be revisited later in a dedicated UI worktree. Current release pass does not require a loading indicator here. Future options to evaluate: subtle search-bar glow, true in-place results skeleton for smart collections, or both.
+
+### Library Browsing
+
+- [ ] Grid view scroll remains smooth on a representative large dataset.
+- [ ] Changing sort/view controls does not break selection or scroll position unexpectedly.
+- [ ] Timeline view renders correctly and remains navigable.
+- [ ] Multi-selection works across browse interactions.
+- [ ] Pinned shelf or related quick-access affordances behave as intended.
+
+Open performance note:
+- Image pinning can block collection navigation for multiple seconds on some real-library flows. Treat this as a dedicated performance investigation after the broader release pass, not as routine UI polish.
+
+### Collections
+
+- [ ] Create a collection.
+- [ ] Rename a collection.
+- [ ] Add selected images to a collection.
+- [ ] Remove images from a collection.
+- [ ] Delete a collection without affecting underlying files.
+
+Deferred note:
+- Collection thumbnail selection after adding images may lag behind the count/update path. Track this as low-priority follow-up unless it starts causing wrong thumbnails or obvious user confusion during release testing.
+
+### Viewer
+
+- [ ] Viewer opens from library and collection contexts.
+- [ ] Next/previous navigation matches visible ordering.
+- [ ] Zoom, pan, and fit behavior work as expected.
+- [ ] Metadata sidebar opens and shows correct image details.
+- [ ] Raw metadata inspector works on supported files.
+- [ ] Compare mode opens and exits cleanly.
+- [ ] Slideshow mode opens and exits cleanly.
+- [ ] Version selector and workflow inspector behave correctly when metadata supports them.
+
+Deferred coverage note:
+- Version selector currently depends on image-stack flows that are not actively exercised in the gallery because stacking is not part of the present release pass. Track this separately with any future temporal stacking feature work.
+
+## Phase 4: Maintenance, Reliability, And Recovery
+
+Goal: exercise the failure-prone and trust-sensitive paths.
+
+Owner: Shared. I can run and inspect command-level failures; you should verify trust-sensitive UI outcomes and live watcher behavior.
+
+### Maintenance Features
+
+- [ ] Missing-file detection reports expected entries.
+- [ ] Duplicate finder produces believable results on a controlled metadata-rich sample.
+- [ ] Untagged/intermediates/trash views load without errors.
+- [ ] Health/maintenance screens complete without freezing the app.
+
+Phase 4 notes:
+- Missing-file expectation: gallery entries may continue to appear from cached metadata/thumbnails; `Maintenance > Missing` is the authoritative detection surface.
+- Duplicate limitation: same-binary files under different names are not reliably detected today, especially for non-AI or sparse-metadata images. Treat this as a known limitation unless duplicate detection is redesigned later.
+- Thumbnail maintenance is no longer core release coverage. Thumbnails are primarily background-healed now; any remaining maintenance UI here should be treated as legacy or dev-oriented unless it proves misleading in release use.
+
+### Watcher And Live Updates
+
+- [ ] Adding a new file to a watched folder appears without a manual restart if watcher support is expected.
+- [ ] Deleting or moving a watched file updates the app state correctly.
+- [ ] Burst file changes do not leave the UI in an obviously inconsistent state.
+
+### Recovery And Edge Cases
+
+- [ ] App handles empty library folders cleanly.
+- [ ] App handles very long paths or nested folder structures relevant to target OS.
+- [ ] App handles unsupported or corrupted image files gracefully.
+- [ ] Interrupting a scan does not leave the app stuck on next launch.
+- [ ] Restart after an abnormal close does not corrupt the visible library state.
+- [ ] After an abnormal close during import, a normal rescan repairs the incomplete folder import without requiring remove/re-add.
+
+## Phase 5: Performance And Scale
+
+Goal: confirm the release is safe for real-world library sizes.
+
+Owner: Mostly user. I can help interpret hotspots and review virtualization/performance-sensitive code, but real confidence comes from your representative libraries and machine.
+
+- [ ] Test on a representative large library, not only a small sample set.
+- [ ] Initial launch time is acceptable for an existing large library.
+- [ ] Search response time is acceptable on a large library.
+- [ ] Scrolling remains virtualized and does not degrade into eager full rendering.
+- [ ] Opening viewer from a deep scroll position remains responsive.
+- [ ] Memory growth looks stable during long browse sessions.
+- [ ] Thumbnail generation/backfill does not make the app unusable.
+- [ ] Maintenance operations complete within acceptable time on a large library.
+
+Suggested benchmark notes:
+
+- Library size:
+- Cold launch time:
+- Warm launch time:
+- Search latency:
+- Viewer open latency:
+- Any obvious memory/CPU spikes:
+
+## Phase 6: Packaging, Upgrade, And Release Readiness
+
+Goal: validate the actual artifact users will install.
+
+Owner: Shared, leaning user. I can produce and inspect artifacts; you should validate the actual install/upgrade experience.
+
+- [ ] Installer runs cleanly on the target OS.
+- [ ] Installed app launches outside the dev environment.
+- [ ] App version shown in UI or metadata matches the intended release.
+- [ ] Upgrade from the previous release preserves the library and settings.
+- [ ] Uninstall or reinstall behavior is understood and documented.
+- [ ] Build artifact names and release attachments are correct.
+- [ ] Release notes accurately describe changes and known limitations.
+
+Phase 6 notes:
+- Fresh profile requires clearing both `AppData\Local\com.ambit.app` and `AppData\Roaming\com.ambit.app`; settings live under Local, while the main SQLite library lives under Roaming.
+- Updater validation is not closed in this pass. Local updater artifacts require signing setup/keys, and the release workflow should be validated in a dedicated future worktree before shipping auto-update support.
+- Version state as of this pass: GitHub releases and tags only go through `v0.3.0`; `main` package metadata is still `0.3.0`; the release-please branch prepares `0.4.0` in `package.json`, `tauri.conf.json`, and `CHANGELOG.md`. Align this before final release.
+
+## Sign-Off Summary
+
+Use this at the end of a pass:
+
+- Release candidate:
+- Tested by:
+- Date:
+- Platforms covered:
+- Highest dataset size covered:
+- Blocking issues:
+- Non-blocking issues:
+- Deferred coverage:
+- Recommendation: ship / fix blockers / run another pass
+
+Deferred Phase 4 investigations:
+- Prod can feel noticeably slower than dev on some real-library flows, including search/live updates.
+- Image pinning can still block collection navigation for multiple seconds in some production-sized libraries.
+
+Deferred release investigations:
+- Auto-updater signing and artifact validation must be handled in a dedicated worktree/session with the required signing key setup.
+- Final release version/tag alignment must happen before publishing: current GitHub latest is `v0.3.0`, while release-please has prepared `0.4.0` but no `v0.4.0` tag or release exists yet.
+
+## Recommended Pass Order
+
+If time is limited, use this sequence:
+
+1. Codex lane: run Phase 0 and report blockers
+2. User lane: fresh-profile smoke on packaged build
+3. User lane: existing-library smoke on packaged build
+4. Shared lane: core workflows on dev or packaged build, with me triaging failures as they appear
+5. User lane: large-library performance and upgrade/install pass
+
+## Recommended Working Agreement
+
+Use this loop to avoid unnecessary work:
+
+1. I run the automatable gate first and summarize only failures, warnings, and residual risk.
+2. You run only the manual checks that still matter after that gate passes.
+3. When you hit a problem, send me the shortest repro you can; I’ll own investigation and fixes.
+4. After fixes, I rerun the relevant automated checks and tell you exactly which manual checks need re-verification.
+
+## High-Risk Areas To Watch Closely
+
+These areas deserve extra attention during release testing:
+
+- [src/App.tsx](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src/App.tsx)
+- [src/contexts/SearchContext.tsx](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src/contexts/SearchContext.tsx)
+- [src/features/library/components/VirtualGrid.tsx](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src/features/library/components/VirtualGrid.tsx)
+- [src/stores/settingsStore.ts](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src/stores/settingsStore.ts)
+- [src/services/TauriFsRepository.ts](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src/services/TauriFsRepository.ts)
+- [src-tauri/src/db](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src-tauri/src/db)
+- [src-tauri/src/metadata](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src-tauri/src/metadata)
+- [src-tauri/src/watcher.rs](C:/Users/Artemis/.codex/worktrees/26f3/project-ambit-alpha/src-tauri/src/watcher.rs)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@tauri-apps/plugin-process": "2.3.1",
     "@tauri-apps/plugin-shell": "^2.3.4",
     "@tauri-apps/plugin-sql": "^2.3.1",
-    "@tauri-apps/plugin-updater": "2.9.0",
+    "@tauri-apps/plugin-updater": "2.10.1",
     "@tauri-apps/plugin-window-state": "^2.4.1",
     "clsx": "^2.1.0",
     "framer-motion": "^12.25.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^2.3.1
         version: 2.4.0
       '@tauri-apps/plugin-updater':
-        specifier: 2.9.0
-        version: 2.9.0
+        specifier: 2.10.1
+        version: 2.10.1
       '@tauri-apps/plugin-window-state':
         specifier: ^2.4.1
         version: 2.4.1
@@ -589,8 +589,8 @@ packages:
   '@tauri-apps/plugin-sql@2.4.0':
     resolution: {integrity: sha512-SIICc5JlnK6OrBZzOw7MmhXHPlmASpt5zLWIu10WW4kLr5cDYOXHdV2MoCgYQkgZLQfyBYgF3SQa5XCisUiQkw==}
 
-  '@tauri-apps/plugin-updater@2.9.0':
-    resolution: {integrity: sha512-j++sgY8XpeDvzImTrzWA08OqqGqgkNyxczLD7FjNJJx/uXxMZFz5nDcfkyoI/rCjYuj2101Tci/r/HFmOmoxCg==}
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
 
   '@tauri-apps/plugin-window-state@2.4.1':
     resolution: {integrity: sha512-OuvdrzyY8Q5Dbzpj+GcrnV1iCeoZbcFdzMjanZMMcAEUNy/6PH5pxZPXpaZLOR7whlzXiuzx0L9EKZbH7zpdRw==}
@@ -2483,7 +2483,7 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-updater@2.9.0':
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/src/db/migrations/m49_removed_images.rs
+++ b/src-tauri/src/db/migrations/m49_removed_images.rs
@@ -1,0 +1,95 @@
+use tauri_plugin_sql::{Migration, MigrationKind};
+
+/// Migration 49: Add persisted tombstones for library-removed images.
+/// These records keep files out of future rescans until the user explicitly restores them.
+pub fn migration49() -> Migration {
+    Migration {
+        version: 49,
+        description: "add_removed_images_tombstones",
+        sql: "
+            CREATE TABLE IF NOT EXISTS removed_images (
+                id TEXT PRIMARY KEY,
+                path TEXT UNIQUE NOT NULL,
+                width INTEGER,
+                height INTEGER,
+                file_size INTEGER,
+                timestamp INTEGER NOT NULL,
+                metadata_json TEXT,
+                thumbnail_path TEXT,
+                micro_thumbnail TEXT,
+                thumbnail_source TEXT,
+                is_favorite INTEGER DEFAULT 0,
+                is_pinned INTEGER DEFAULT 0,
+                is_missing INTEGER DEFAULT 0,
+                user_masked INTEGER,
+                group_id TEXT,
+                board_id TEXT,
+                notes TEXT,
+                original_metadata_json TEXT,
+                original_parsed_json TEXT,
+                original_state_json TEXT,
+                is_corrupt INTEGER NOT NULL DEFAULT 0,
+                removed_at INTEGER NOT NULL,
+                collection_ids_json TEXT
+            ) STRICT;
+
+            CREATE INDEX IF NOT EXISTS idx_removed_images_removed_at
+                ON removed_images(removed_at DESC);
+
+            INSERT OR IGNORE INTO removed_images (
+                id,
+                path,
+                width,
+                height,
+                file_size,
+                timestamp,
+                metadata_json,
+                thumbnail_path,
+                micro_thumbnail,
+                thumbnail_source,
+                is_favorite,
+                is_pinned,
+                is_missing,
+                user_masked,
+                group_id,
+                board_id,
+                notes,
+                original_metadata_json,
+                original_parsed_json,
+                original_state_json,
+                is_corrupt,
+                removed_at,
+                collection_ids_json
+            )
+            SELECT
+                id,
+                path,
+                width,
+                height,
+                file_size,
+                timestamp,
+                metadata_json,
+                thumbnail_path,
+                micro_thumbnail,
+                thumbnail_source,
+                is_favorite,
+                is_pinned,
+                is_missing,
+                user_masked,
+                group_id,
+                board_id,
+                notes,
+                original_metadata_json,
+                original_parsed_json,
+                original_state_json,
+                is_corrupt,
+                (strftime('%s', 'now') * 1000),
+                NULL
+            FROM images
+            WHERE is_deleted = 1;
+
+            DELETE FROM images WHERE is_deleted = 1;
+        ",
+        kind: MigrationKind::Up,
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -15,6 +15,7 @@ pub mod m45_optimize_triggers;
 pub mod m46_optimize_fts;
 pub mod m47_facet_cleanup;
 pub mod m48_original_parsed;
+pub mod m49_removed_images;
 
 
 pub fn init_db() -> Vec<Migration> {
@@ -40,6 +41,7 @@ pub fn get_migrations() -> Vec<Migration> {
     migrations.push(m46_optimize_fts::migration46());
     migrations.push(m47_facet_cleanup::migration47());
     migrations.push(m48_original_parsed::migration48());
+    migrations.push(m49_removed_images::migration49());
     
     // Ensure migrations are sorted by version (tauri-plugin-sql needs this?)
     // Actually, pushing in order is usually enough, but let's be safe if needed.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { useAppVersion } from './hooks/useAppVersion';
 import { useThumbnailQueue } from './hooks/useThumbnailQueue';
 import { useMetadataRefresh } from './hooks/useMetadataRefresh';
 import { useSync } from './contexts/SyncContext';
+import { useWatchers } from './contexts/WatcherContext';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -130,7 +131,7 @@ export default function App() {
 
     const setAllCollections = useCollectionStore(s => s.setCollections);
     const refreshCollectionThumbnails = useCollectionStore(s => s.refreshCollections);
-    const refreshMaintenanceCounts = useCallback(() => { }, []); // Placeholder
+    const { refreshMaintenanceCounts } = useWatchers();
 
     const handlers = useAppHandlers({ images, setImages, refreshMaintenanceCounts });
 
@@ -182,6 +183,50 @@ export default function App() {
     });
 
     const { startInvokeSync } = useSync();
+
+    const handleSelectFilesImport = useCallback(async () => {
+        const isTauriEnv = typeof window !== 'undefined' && !!(window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+
+        if (isTauriEnv) {
+            try {
+                const { open } = await import('@tauri-apps/plugin-dialog');
+                const selected = await open({
+                    multiple: true,
+                    directory: false,
+                    filters: [
+                        {
+                            name: 'Images',
+                            extensions: ['png', 'jpg', 'jpeg', 'webp']
+                        }
+                    ]
+                });
+
+                const paths = Array.isArray(selected)
+                    ? selected.filter((item): item is string => typeof item === 'string')
+                    : (typeof selected === 'string' ? [selected] : []);
+
+                if (paths.length > 0) {
+                    await fileOps.handleImportPaths(paths);
+                }
+                return;
+            } catch (error) {
+                console.error('[App] Native file picker import failed, falling back to file input.', error);
+            }
+        }
+
+        fileOps.fileInputRef.current?.click();
+    }, [fileOps]);
+
+    const handleOpenRecovery = useCallback(() => {
+        if (!settings.enableAI || !geminiApiKey) {
+            modals.setInitialSettingsTab('intelligence');
+            modals.openModal('settings');
+            addToast('Enable AI features and configure a Gemini API key in Settings to use Prompt Recovery.', 'info');
+            return;
+        }
+
+        modals.openModal('recovery');
+    }, [settings.enableAI, geminiApiKey, modals, addToast]);
 
     useFolderMonitor({
         isLoaded,
@@ -369,7 +414,7 @@ export default function App() {
                     fileOps={fileOps}
                     onOpenImportModal={() => {
                         if (settings.hideImportModal) {
-                            fileOps.fileInputRef.current?.click();
+                            void handleSelectFilesImport();
                         } else {
                             setIsImportModalOpen(true);
                         }
@@ -416,7 +461,7 @@ export default function App() {
                     isOpen={isImportModalOpen}
                     onClose={() => setIsImportModalOpen(false)}
                     onOpenSettings={(tab) => { modals.setInitialSettingsTab(tab); modals.openModal('settings'); }}
-                    onImportFiles={() => fileOps.fileInputRef.current?.click()}
+                    onImportFiles={() => { void handleSelectFilesImport(); }}
                     settings={settings}
                     setSettings={setSettings}
                 />
@@ -471,7 +516,7 @@ export default function App() {
                         onNavigate: changeViewMode,
                         onToggleTheme: toggleTheme,
                         onOpenSettings: () => { modals.setInitialSettingsTab('general'); modals.openModal('settings'); },
-                        onImport: () => fileOps.fileInputRef.current?.click(),
+                        onImport: () => { void handleSelectFilesImport(); },
                         onCreateCollection: () => { setIsFilterPanelOpen(true); setTimeout(() => document.getElementById('create-col-btn')?.click(), 100); },
                         onToggleAI: toggleAiSearch,
                         settings: settings
@@ -542,7 +587,7 @@ export default function App() {
                                 setRecentSearches(prev => [term, ...prev.filter(s => s !== term)].slice(0, 8));
                             }}
                             onRevertMetadata={(id) => handlers.handleRevertMetadata(id)}
-                            onRecoverMetadata={() => modals.openModal('recovery')}
+                            onRecoverMetadata={handleOpenRecovery}
                             onAddToCollection={(id) => handleOpenCollectionModal('add')}
                             availableTags={availableTags}
                             isSidebarOpen={!settings.defaultTheaterMode}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -101,6 +101,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
 
     // Stores
     const settings = useSettingsStore(s => s.settings);
+    const geminiApiKey = useSettingsStore(s => s.geminiApiKey);
 
     const allCollections = useCollectionStore(s => s.collections);
     const onRefreshCollections = useCollectionStore(s => s.refreshCollections);
@@ -278,8 +279,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                                     images={images}
                                     onResolveDuplicate={handlers.handleResolveDuplicate}
                                     onRestoreImages={handlers.handleRestoreImages}
-                                    onMoveToTrash={handlers.handleMoveToTrash}
-                                    onDeleteForever={handlers.handleDeleteForever}
+                                    onRemoveFromLibrary={handlers.handleRemoveFromLibrary}
+                                    onDeleteFile={handlers.handleDeleteFile}
                                     onEmptyTrash={handlers.handleEmptyTrash}
                                     onGroupImages={handlers.handleGroupImages}
                                     onViewImage={(id) => setViewingImageId(id)}
@@ -289,7 +290,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                                     onUpdateModel={handlers.handleUpdateModel}
                                     onUpdateTool={handlers.handleUpdateTool}
                                     onUpdateNotes={(id, n) => { handlers.handleUpdateNotes(id, n); }}
-                                    onRecoverMetadata={() => { if (!settings.enableAI) { addToast("Enable AI features first", "error"); modals.openModal('settings'); } else { modals.openModal('recovery'); } }}
+                                    onRecoverMetadata={() => {
+                                        if (!settings.enableAI || !geminiApiKey) {
+                                            addToast("Enable AI features and configure a Gemini API key first", "error");
+                                            modals.setInitialSettingsTab('intelligence');
+                                            modals.openModal('settings');
+                                        } else {
+                                            modals.openModal('recovery');
+                                        }
+                                    }}
                                     onToggleFavorite={(id) => toggleFavorite(id)}
                                     onTogglePin={actions.handlePinImage}
                                     availableTags={availableTags}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -177,9 +177,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
             onClick={(e, id, idx) => handleImageClick(e, id, idx, setSelectedImageIndex)}
             onToggleSelection={handleSelectionToggle}
             onToggleFavorite={(e, id) => toggleFavorite(id)}
-            onTogglePin={async (e, id) => {
+            onTogglePin={(e, id) => {
                 const imgFound = images.find(i => i.id === id);
-                if (imgFound) await actions.handlePinImage(id, !imgFound.isPinned);
+                if (imgFound) actions.handlePinImage(id, !imgFound.isPinned);
             }}
             onContextMenu={(e, id) => handlers.setContextMenu({ x: e.clientX, y: e.clientY, imageId: id })}
             isThumbnail={((activeCollection?.customThumbnail || activeSmartCollection?.customThumbnail) === img.id || (activeCollection?.thumbnail || activeSmartCollection?.thumbnail) === img.id)}
@@ -317,9 +317,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                                             onImageClick={(e, id, index) => handleImageClick(e, id, index, setSelectedImageIndex)}
                                             onSelectionToggle={handleSelectionToggle}
                                             onToggleFavorite={(e, id) => { toggleFavorite(id); }}
-                                            onTogglePin={async (e, id) => {
+                                            onTogglePin={(e, id) => {
                                                 const img = images.find(i => i.id === id);
-                                                if (img) await actions.handlePinImage(id, !img.isPinned);
+                                                if (img) actions.handlePinImage(id, !img.isPinned);
                                             }}
                                             onContextMenu={(e, id) => handlers.setContextMenu({ x: e.clientX, y: e.clientY, imageId: id })}
                                             onRangeSelection={handleRangeSelection}
@@ -338,9 +338,9 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                                                     onImageClick={(e, id, index) => handleImageClick(e, id, index, setSelectedImageIndex)}
                                                     onToggleSelection={handleSelectionToggle}
                                                     onToggleFavorite={(e, id) => toggleFavorite(id)}
-                                                    onTogglePin={async (e, id) => {
+                                                    onTogglePin={(e, id) => {
                                                         const img = images.find(i => i.id === id);
-                                                        if (img) await actions.handlePinImage(id, !img.isPinned);
+                                                        if (img) actions.handlePinImage(id, !img.isPinned);
                                                     }}
                                                     onContextMenu={(e, id) => handlers.setContextMenu({ x: e.clientX, y: e.clientY, imageId: id })}
                                                     thumbnailSize={settings.thumbnailSize}

--- a/src/components/GlobalModals.tsx
+++ b/src/components/GlobalModals.tsx
@@ -134,16 +134,16 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
             <ConfirmDialog
                 isOpen={modals.deleteConfirm}
                 onCancel={() => closeModal('deleteConfirm')}
-                onConfirm={onDeleteConfirm}
-                title="Delete Images"
-                message={`Are you sure you want to delete ${pendingViewerDeleteId ? 1 : selectedIds.size} image(s)? This action cannot be undone.`}
+                onConfirm={() => onDeleteConfirm()}
+                title="Remove from Library?"
+                message={`Remove ${pendingViewerDeleteId ? 1 : selectedIds.size} image(s) from Ambit while keeping the original file(s) on disk? You can restore them later from Maintenance > Removed.`}
                 isDangerous={true}
             />
 
             <ConfirmDialog
                 isOpen={modals.deleteCollection}
                 onCancel={() => closeModal('deleteCollection')}
-                onConfirm={onDeleteCollectionConfirm}
+                onConfirm={() => onDeleteCollectionConfirm()}
                 title="Delete Collection"
                 message="Are you sure you want to delete this collection? Images will not be deleted from your library."
                 isDangerous={true}

--- a/src/components/__tests__/GlobalModals.test.tsx
+++ b/src/components/__tests__/GlobalModals.test.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '../../test/testUtils';
+import { GlobalModals } from '../GlobalModals';
+
+vi.mock('../../features/settings/components/SettingsModal', () => ({ SettingsModal: () => null }));
+vi.mock('../../features/library/components/ExportModal', () => ({ ExportModal: () => null }));
+vi.mock('../../features/viewer/components/SlideshowModal', () => ({ SlideshowModal: () => null }));
+vi.mock('../../features/library/components/MetadataRecoveryModal', () => ({ MetadataRecoveryModal: () => null }));
+vi.mock('../../features/collections/components/AddToCollectionModal', () => ({ AddToCollectionModal: () => null }));
+vi.mock('../ui/CommandPalette', () => ({ CommandPalette: () => null }));
+vi.mock('../ui/ShortcutsModal', () => ({ ShortcutsModal: () => null }));
+vi.mock('../../features/viewer/components/CompareModal', () => ({ CompareModal: () => null }));
+vi.mock('../ui/DonationModal', () => ({ DonationModal: () => null }));
+vi.mock('../../features/collections/components/CollectionEditorModal', () => ({ CollectionEditorModal: () => null }));
+
+describe('GlobalModals', () => {
+    it('describes delete confirmation as remove-from-library behavior', () => {
+        render(
+            <GlobalModals
+                modals={{
+                    settings: false,
+                    export: false,
+                    deleteConfirm: true,
+                    deleteCollection: false,
+                    compare: false,
+                    shortcuts: false,
+                    recovery: false,
+                    slideshow: false,
+                    donation: false,
+                    commandPalette: false,
+                    addToCollection: false,
+                    collectionEditor: false
+                }}
+                setModals={vi.fn()}
+                selectedIds={new Set(['img-1'])}
+                filteredImages={[]}
+                canCheckForUpdates={false}
+                onSettingsSave={vi.fn()}
+                onExportConfirm={vi.fn()}
+                onDeleteConfirm={vi.fn()}
+                onDeleteCollectionConfirm={vi.fn()}
+                onRecoverMetadata={vi.fn()}
+                onCollectionAction={vi.fn()}
+                onCloseExport={vi.fn()}
+                exportIds={new Set()}
+                pendingViewerDeleteId={'img-1'}
+                collectionToDeleteId={null}
+                addToCollectionMode="add"
+                sourceCollectionId={null}
+                isRecoveringMetadata={false}
+                isExporting={false}
+                slideshowShuffle={false}
+                initialSettingsTab="general"
+                shortcutsModalTab="shortcuts"
+                commandPaletteProps={{
+                    onNavigate: vi.fn(),
+                    onToggleTheme: vi.fn(),
+                    onOpenSettings: vi.fn(),
+                    onImport: vi.fn(),
+                    onCreateCollection: vi.fn(),
+                    onToggleAI: vi.fn(),
+                    settings: {} as any
+                }}
+                collections={[]}
+                smartCollections={[]}
+                toggleFavorite={vi.fn()}
+                settings={{} as any}
+                hasPendingUpdate={false}
+                pendingUpdateVersion={null}
+                updateErrorMessage={null}
+                updateStatus={'idle' as any}
+                onCheckForUpdates={vi.fn()}
+                onOpenUpdatePrompt={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText('Remove from Library?')).toBeTruthy();
+        expect(screen.getByText(/keeping the original file/i)).toBeTruthy();
+        expect(screen.getByText(/Maintenance > Removed/i)).toBeTruthy();
+    });
+});

--- a/src/components/ui/AppContextMenu.tsx
+++ b/src/components/ui/AppContextMenu.tsx
@@ -137,11 +137,11 @@ export const AppContextMenu: React.FC<AppContextMenuProps> = ({
                     onClose();
                 }
             }}
-            onTogglePin={async () => {
+            onTogglePin={() => {
                 const id = contextMenu.imageId;
                 const img = images.find(i => i.id === id);
                 if (img) {
-                    await actions.handlePinImage(id, !img.isPinned);
+                    actions.handlePinImage(id, !img.isPinned);
                 }
                 onClose();
             }}

--- a/src/components/ui/AppContextMenu.tsx
+++ b/src/components/ui/AppContextMenu.tsx
@@ -159,7 +159,9 @@ export const AppContextMenu: React.FC<AppContextMenuProps> = ({
                 onClose();
             }}
             onDelete={() => {
-                settings.confirmDelete ? modals.openModal('deleteConfirm') : actions.executeDelete();
+                if (contextMenu.imageId) {
+                    actions.requestDeleteForId(contextMenu.imageId);
+                }
                 onClose();
             }}
             onShowInFolder={async () => {

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -68,7 +68,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
 
               <div className="mt-10 flex flex-col gap-3">
                 <button
-                  onClick={onConfirm}
+                  onClick={() => { void onConfirm(); }}
                   disabled={isLoading}
                   className={`w-full py-3.5 px-6 text-sm font-bold text-white rounded-2xl shadow-lg transition-all active:scale-[0.98] ${isDangerous
                     ? 'bg-gradient-to-br from-red-500 to-rose-600 hover:shadow-red-500/40'

--- a/src/components/ui/ContextMenu.tsx
+++ b/src/components/ui/ContextMenu.tsx
@@ -130,7 +130,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({
         <ActionButton
           icon={<Trash2 className="w-4 h-4 text-gray-400" />}
           onClick={onDelete}
-          title="Delete Image"
+          title="Remove from Library"
           className="hover:!bg-red-500/20 hover:!text-red-400"
         />
       </div>

--- a/src/components/ui/GlobalModals.tsx
+++ b/src/components/ui/GlobalModals.tsx
@@ -144,7 +144,7 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
         message={`This will remove ${pendingViewerDeleteId ? '1' : selectedIds.size} image(s) from Ambit while keeping the original file(s) on disk. You can restore them later from Removed.`}
         confirmLabel="Remove from Library"
         isDangerous={true}
-        onConfirm={onDeleteConfirm}
+        onConfirm={() => onDeleteConfirm()}
         onCancel={() => close('deleteConfirm')}
       />
 
@@ -154,7 +154,7 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
         message="This will delete the collection folder. The images themselves will remain in your library."
         confirmLabel="Delete Collection"
         isDangerous={true}
-        onConfirm={onDeleteCollectionConfirm}
+        onConfirm={() => onDeleteCollectionConfirm()}
         onCancel={() => close('deleteCollection')}
       />
 

--- a/src/components/ui/GlobalModals.tsx
+++ b/src/components/ui/GlobalModals.tsx
@@ -140,9 +140,9 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
 
       <ConfirmDialog
         isOpen={modals.deleteConfirm}
-        title="Move to Trash?"
-        message={`This will move ${pendingViewerDeleteId ? '1' : selectedIds.size} image(s) to the Trash bin. You can restore them later.`}
-        confirmLabel="Move to Trash"
+        title="Remove from Library?"
+        message={`This will remove ${pendingViewerDeleteId ? '1' : selectedIds.size} image(s) from Ambit while keeping the original file(s) on disk. You can restore them later from Removed.`}
+        confirmLabel="Remove from Library"
         isDangerous={true}
         onConfirm={onDeleteConfirm}
         onCancel={() => close('deleteConfirm')}

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '../../../test/testUtils';
+import { ConfirmDialog } from '../ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('does not pass the click event payload to onConfirm', () => {
+    const onConfirm = vi.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Confirm action"
+        message="This is a test confirmation."
+        confirmLabel="Confirm"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0]).toEqual([]);
+  });
+});

--- a/src/features/library/components/SelectionBar.tsx
+++ b/src/features/library/components/SelectionBar.tsx
@@ -136,7 +136,7 @@ export function SelectionBar({
                     <Share className="w-5 h-5" />
                 </button>
 
-                <button onClick={onDelete} className="p-2 text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-full transition-colors" title="Delete">
+                <button onClick={onDelete} className="p-2 text-red-500 dark:text-red-400 hover:text-red-700 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/30 rounded-full transition-colors" title="Remove from Library">
                     <Trash2 className="w-5 h-5" />
                 </button>
 

--- a/src/features/maintenance/components/DuplicateFinder.tsx
+++ b/src/features/maintenance/components/DuplicateFinder.tsx
@@ -129,7 +129,7 @@ const DuplicateGroupCard: React.FC<{
                     </div>
                     <div className="flex-1">
                         <p className="text-[10px] text-gray-500 dark:text-gray-400">
-                            Keep version with best tag data. Others moved to trash bin.
+                            Keep version with best tag data. Others removed from Ambit and kept in the Removed list.
                         </p>
                     </div>
                 </div>

--- a/src/features/maintenance/components/MaintenanceTabs.tsx
+++ b/src/features/maintenance/components/MaintenanceTabs.tsx
@@ -15,7 +15,7 @@ export const MaintenanceTabs: React.FC<MaintenanceTabsProps> = ({ activeTab, onT
         { id: 'untagged', label: 'Untagged', color: 'text-amber-500' },
         { id: 'intermediates', label: 'Intermediates', color: 'text-blue-500' },
         { id: 'missing', label: 'Missing', color: 'text-orange-500' },
-        { id: 'trash', label: 'Trash', color: 'text-red-500' },
+        { id: 'trash', label: 'Removed', color: 'text-red-500' },
     ];
 
     // Hide Intermediates tab if there are no intermediate images
@@ -33,7 +33,7 @@ export const MaintenanceTabs: React.FC<MaintenanceTabsProps> = ({ activeTab, onT
                         </div>
                         <h2 className="text-xl font-bold text-gray-900 dark:text-white">Gallery Maintenance</h2>
                     </div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 pl-1">Organize your library, resolve conflicts, and manage deleted items.</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 pl-1">Organize your library, resolve conflicts, and manage removed items.</p>
                 </div>
 
                 <div className="bg-gray-100 dark:bg-zinc-800 p-1 rounded-xl flex items-center shadow-inner self-start md:self-auto overflow-x-auto max-w-full">

--- a/src/features/maintenance/components/MaintenanceView.tsx
+++ b/src/features/maintenance/components/MaintenanceView.tsx
@@ -71,6 +71,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
     const [includeUpgradeable, setIncludeUpgradeable] = useState(false);
 
     const [viewingImageId, setViewingImageId] = useState<string | null>(null);
+    const [removedAction, setRemovedAction] = useState<'restoring' | 'deleting' | null>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
 
     // Missing Scan Special State
@@ -186,37 +187,52 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
     const handleRestoreSelected = async () => {
         const ids = Array.from(selectedIds);
         if (ids.length === 0) return;
-        await onRestoreImages(ids);
-        await refreshData('trash', false);
-        clearSelection();
+        setRemovedAction('restoring');
+        try {
+            await onRestoreImages(ids);
+            await refreshData('trash', false);
+            clearSelection();
+        } finally {
+            setRemovedAction(null);
+        }
     };
 
     const handleDeleteSelected = async () => {
         const ids = Array.from(selectedIds);
         if (ids.length === 0) return;
 
-        if (activeTab === 'untagged' || activeTab === 'missing') {
-            await onRemoveFromLibrary(ids);
-        } else {
-            await onDeleteFile(ids);
+        if (activeTab === 'trash') {
+            setRemovedAction('deleting');
         }
 
-        const scope = activeTab === 'untagged' ? untaggedScope :
-            activeTab === 'thumbnails' ? thumbnailsScope :
-                activeTab === 'duplicates' ? duplicatesScope :
-                    activeTab === 'intermediates' ? intermediatesScope : 'global';
+        try {
+            if (activeTab === 'untagged' || activeTab === 'missing') {
+                await onRemoveFromLibrary(ids);
+            } else {
+                await onDeleteFile(ids);
+            }
 
-        await refreshData(activeTab, false, { scope: scope as any });
+            const scope = activeTab === 'untagged' ? untaggedScope :
+                activeTab === 'thumbnails' ? thumbnailsScope :
+                    activeTab === 'duplicates' ? duplicatesScope :
+                        activeTab === 'intermediates' ? intermediatesScope : 'global';
 
-        if (activeTab === 'missing') {
-            setScanMissingIds(prev => {
-                const next = new Set(prev);
-                ids.forEach(id => next.delete(id));
-                return next;
-            });
-            setFetchedMissingImages(prev => prev.filter(img => !ids.includes(img.id)));
+            await refreshData(activeTab, false, { scope: scope as any });
+
+            if (activeTab === 'missing') {
+                setScanMissingIds(prev => {
+                    const next = new Set(prev);
+                    ids.forEach(id => next.delete(id));
+                    return next;
+                });
+                setFetchedMissingImages(prev => prev.filter(img => !ids.includes(img.id)));
+            }
+            clearSelection();
+        } finally {
+            if (activeTab === 'trash') {
+                setRemovedAction(null);
+            }
         }
-        clearSelection();
     };
 
     const handlePurgeMissing = async () => {
@@ -458,6 +474,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
                                 scrollContainerRef={scrollContainerRef as any}
                                 onRangeSelection={handleRangeAdapter}
                                 onBackgroundClick={handleBackgroundClick}
+                                busyAction={removedAction}
                             />
                         </motion.div>
                     )}

--- a/src/features/maintenance/components/MaintenanceView.tsx
+++ b/src/features/maintenance/components/MaintenanceView.tsx
@@ -21,8 +21,8 @@ interface MaintenanceViewProps {
     images: AIImage[];
     onResolveDuplicate: (keepId: string, deleteIds: string[]) => void;
     onRestoreImages: (ids: string[]) => void;
-    onMoveToTrash: (ids: string[]) => void;
-    onDeleteForever: (ids: string[]) => void;
+    onRemoveFromLibrary: (ids: string[]) => void;
+    onDeleteFile: (ids: string[]) => void;
     onEmptyTrash: () => Promise<void>;
     onGroupImages?: (ids: string[]) => void;
     onViewImage: (id: string) => void;
@@ -45,8 +45,8 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
     images,
     onResolveDuplicate,
     onRestoreImages,
-    onMoveToTrash,
-    onDeleteForever,
+    onRemoveFromLibrary,
+    onDeleteFile,
     onRegenerateThumbnails,
     maskedKeywords,
     onUpdatePrompt,
@@ -196,9 +196,9 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
         if (ids.length === 0) return;
 
         if (activeTab === 'untagged' || activeTab === 'missing') {
-            await onMoveToTrash(ids);
+            await onRemoveFromLibrary(ids);
         } else {
-            await onDeleteForever(ids);
+            await onDeleteFile(ids);
         }
 
         const scope = activeTab === 'untagged' ? untaggedScope :
@@ -221,7 +221,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
 
     const handlePurgeMissing = async () => {
         const ids = missingImages.map(i => i.id);
-        await onMoveToTrash(ids);
+        await onRemoveFromLibrary(ids);
         await refreshData('missing', false);
         setScanMissingIds(new Set());
         setFetchedMissingImages([]);
@@ -397,7 +397,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
                                 onItemClick={handleItemClickAdapter}
                                 onSelectAll={handleSelectAll}
                                 onClearSelection={clearSelection}
-                                onMoveToTrash={handleDeleteSelected}
+                                onRemoveFromLibrary={handleDeleteSelected}
                                 onViewImage={setViewingImageId}
                                 maskedKeywords={maskedKeywords}
                                 scrollContainerRef={scrollContainerRef as any}
@@ -536,9 +536,9 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
                     onRecoverMetadata={onRecoverMetadata}
                     availableTags={availableTags}
                     onOpenSettings={() => { }}
-                    onDelete={() => {
+                                    onDelete={() => {
                         if (viewingImageId) {
-                            onDeleteForever([viewingImageId]);
+                            onDeleteFile([viewingImageId]);
                             setViewingImageId(null);
                             refreshData(activeTab);
                         }

--- a/src/features/maintenance/components/MissingTab.tsx
+++ b/src/features/maintenance/components/MissingTab.tsx
@@ -81,7 +81,7 @@ export const MissingTab: React.FC<MissingTabProps> = ({
                     onClick={onDeleteSelected}
                     className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-xl text-xs font-bold transition-all flex items-center gap-2"
                 >
-                    <Trash2 className="w-4 h-4" /> Move to Trash
+                    <Trash2 className="w-4 h-4" /> Remove from Library
                     <span className="px-1.5 py-0.5 bg-white/20 rounded-md text-[9px]">{selectedIds.size}</span>
                 </button>
             ) : (
@@ -89,7 +89,7 @@ export const MissingTab: React.FC<MissingTabProps> = ({
                     onClick={onPurgeMissing}
                     className="px-4 py-2 bg-red-600/10 hover:bg-red-600/20 text-red-600 dark:text-red-400 rounded-xl text-xs font-bold transition-all flex items-center gap-2 border border-red-200 dark:border-red-900/50"
                 >
-                    <FileX className="w-4 h-4" /> Move all {images.length} to Trash
+                    <FileX className="w-4 h-4" /> Remove all {images.length} from Library
                 </button>
             )}
         </div>

--- a/src/features/maintenance/components/TrashTab.tsx
+++ b/src/features/maintenance/components/TrashTab.tsx
@@ -53,9 +53,9 @@ export const TrashTab: React.FC<TrashTabProps> = ({
                 <div className="p-6 bg-sage-500/10 rounded-full mb-6 border border-sage-500/20">
                     <Trash2 className="w-16 h-16 text-sage-500" />
                 </div>
-                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-2">Trash is Empty</h2>
+                <h2 className="text-2xl font-bold text-gray-800 dark:text-gray-200 mb-2">Removed List is Empty</h2>
                 <p className="max-w-md text-center text-gray-500 dark:text-gray-400">
-                    No soft-deleted images found. Images you delete from the gallery will appear here.
+                    No library-removed images found. Files you remove from Ambit while keeping them on disk will appear here.
                 </p>
             </div>
         );
@@ -69,19 +69,19 @@ export const TrashTab: React.FC<TrashTabProps> = ({
                         onClick={onRestoreSelected}
                         className="px-4 py-2 bg-sage-600 hover:bg-sage-500 text-white rounded-xl text-xs font-bold transition-all flex items-center gap-2"
                     >
-                        <ArchiveRestore className="w-4 h-4" /> Restore Selected
+                        <ArchiveRestore className="w-4 h-4" /> Restore to Library
                         <span className="px-1.5 py-0.5 bg-white/20 rounded-md text-[9px]">{selectedIds.size}</span>
                     </button>
                     <button
                         onClick={onDeleteSelected}
                         className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-xl text-xs font-bold transition-all flex items-center gap-2"
                     >
-                        <Trash2 className="w-4 h-4" /> Delete Forever
+                        <Trash2 className="w-4 h-4" /> Delete File
                     </button>
                 </>
             ) : (
                 <div className="px-4 py-2 text-gray-400 text-xs font-medium italic">
-                    Select images to restore or delete forever
+                    Select images to restore or delete from disk
                 </div>
             )}
         </div>
@@ -90,8 +90,8 @@ export const TrashTab: React.FC<TrashTabProps> = ({
     return (
         <div className="w-full pb-32 animate-in slide-in-from-bottom-4 flex flex-col items-stretch">
             <MaintenanceHeader
-                title="Trash Bin"
-                description={`Found ${images.length} soft-deleted images.`}
+                title="Removed from Library"
+                description={`Found ${images.length} images removed from Ambit while kept on disk.`}
                 icon={<Trash2 className="w-6 h-6" />}
                 count={images.length}
                 onSelectAll={onSelectAll}

--- a/src/features/maintenance/components/TrashTab.tsx
+++ b/src/features/maintenance/components/TrashTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useCallback } from 'react';
-import { ArchiveRestore, Trash2 } from 'lucide-react';
+import { ArchiveRestore, Loader2, Trash2 } from 'lucide-react';
 import { AIImage } from '../../../types';
 import { VirtualGrid } from '../../library/components/VirtualGrid';
 import { MaintenanceItem } from './MaintenanceItem';
@@ -18,6 +18,7 @@ interface TrashTabProps {
     scrollContainerRef: React.RefObject<HTMLElement | null>;
     onRangeSelection: (indexes: number[], isAdditive: boolean) => void;
     onBackgroundClick: () => void;
+    busyAction?: 'restoring' | 'deleting' | null;
 }
 
 export const TrashTab: React.FC<TrashTabProps> = ({
@@ -31,7 +32,8 @@ export const TrashTab: React.FC<TrashTabProps> = ({
     maskedKeywords,
     scrollContainerRef,
     onRangeSelection,
-    onBackgroundClick
+    onBackgroundClick,
+    busyAction = null
 }) => {
     const renderItem = useCallback((img: AIImage, style: React.CSSProperties, index: number) => {
         return (
@@ -67,16 +69,18 @@ export const TrashTab: React.FC<TrashTabProps> = ({
                 <>
                     <button
                         onClick={onRestoreSelected}
+                        disabled={busyAction !== null}
                         className="px-4 py-2 bg-sage-600 hover:bg-sage-500 text-white rounded-xl text-xs font-bold transition-all flex items-center gap-2"
                     >
-                        <ArchiveRestore className="w-4 h-4" /> Restore to Library
+                        {busyAction === 'restoring' ? <Loader2 className="w-4 h-4 animate-spin" /> : <ArchiveRestore className="w-4 h-4" />} {busyAction === 'restoring' ? 'Restoring...' : 'Restore to Library'}
                         <span className="px-1.5 py-0.5 bg-white/20 rounded-md text-[9px]">{selectedIds.size}</span>
                     </button>
                     <button
                         onClick={onDeleteSelected}
+                        disabled={busyAction !== null}
                         className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-xl text-xs font-bold transition-all flex items-center gap-2"
                     >
-                        <Trash2 className="w-4 h-4" /> Delete File
+                        {busyAction === 'deleting' ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />} {busyAction === 'deleting' ? 'Deleting from Disk...' : 'Delete File'}
                     </button>
                 </>
             ) : (

--- a/src/features/maintenance/components/UntaggedTab.tsx
+++ b/src/features/maintenance/components/UntaggedTab.tsx
@@ -12,7 +12,7 @@ interface UntaggedTabProps {
     onItemClick: (id: string, index: number, e: React.MouseEvent) => void;
     onSelectAll: () => void;
     onClearSelection: () => void;
-    onMoveToTrash: () => void;
+    onRemoveFromLibrary: () => void;
     onViewImage: (id: string) => void;
     maskedKeywords: string[];
     scrollContainerRef: React.RefObject<HTMLElement | null>;
@@ -28,7 +28,7 @@ export const UntaggedTab: React.FC<UntaggedTabProps> = ({
     onItemClick,
     onSelectAll,
     onClearSelection,
-    onMoveToTrash,
+    onRemoveFromLibrary,
     onViewImage,
     maskedKeywords,
     scrollContainerRef,
@@ -97,16 +97,16 @@ export const UntaggedTab: React.FC<UntaggedTabProps> = ({
     const actions = (
         <div className="flex items-center gap-2 p-1 bg-white/50 dark:bg-black/20 border border-orange-200/50 dark:border-white/5 rounded-2xl shadow-sm">
             {selectedIds.size > 0 ? (
-                <button
-                    onClick={onMoveToTrash}
+                    <button
+                    onClick={onRemoveFromLibrary}
                     className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded-xl text-xs font-bold transition-all flex items-center gap-2"
                 >
-                    <Trash2 className="w-4 h-4" /> Move to Trash
+                    <Trash2 className="w-4 h-4" /> Remove from Library
                     <span className="px-1.5 py-0.5 bg-white/20 rounded-md text-[9px]">{selectedIds.size}</span>
                 </button>
             ) : (
                 <div className="px-4 py-2 text-gray-400 text-xs font-medium italic">
-                    Select images to move to trash bin
+                    Select images to remove from Ambit while keeping the source files
                 </div>
             )}
         </div>

--- a/src/features/settings/components/GeneralTab.tsx
+++ b/src/features/settings/components/GeneralTab.tsx
@@ -21,7 +21,7 @@ export const GeneralTab: React.FC<TabProps> = React.memo(({ settings, setSetting
     const handleConfirmDeleteToggle = () => {
         const newValue = !settings.confirmDelete;
         setSettings(prev => ({ ...prev, confirmDelete: newValue }));
-        addToast(newValue ? 'Delete confirmations enabled' : 'Delete confirmations disabled', 'success');
+        addToast(newValue ? 'Removal confirmations enabled' : 'Removal confirmations disabled', 'success');
     };
 
     const handleAutoThumbnailHealingToggle = () => {
@@ -111,7 +111,7 @@ export const GeneralTab: React.FC<TabProps> = React.memo(({ settings, setSetting
                     >
                         <div>
                             <div className="text-base font-medium text-gray-900 dark:text-gray-200 group-hover:text-sage-500 transition-colors">Confirm Deletions</div>
-                            <div className="text-sm text-gray-500">Show a warning before moving files to Trash</div>
+                            <div className="text-sm text-gray-500">Show a warning before removing files from Ambit while keeping them on disk</div>
                         </div>
                         <button
                             type="button"

--- a/src/features/settings/hooks/useFoldersTabLogic.ts
+++ b/src/features/settings/hooks/useFoldersTabLogic.ts
@@ -145,14 +145,49 @@ export const useFoldersTabLogic = ({
                                 false
                             );
                             addToast(`Synced ${result.images.length} new files`, 'success');
+                            updateFolderLastScanned(id, Date.now());
                         } finally {
                             setIsImporting(false);
                             setImportProgress(null);
                         }
                     } else {
-                        addToast(`No changes detected`, 'info');
+                        const allFiles = await unwrap(commands.scanDirectoryWithStats(path));
+                        const knownCount = folder?.imageCount ?? 0;
+
+                        if (allFiles.length > knownCount) {
+                            const repairPaths = allFiles.map(f => f.path);
+                            const { setIsImporting, setImportProgress } = useLibraryStore.getState();
+                            setIsImporting(true);
+                            setImportProgress({ current: 0, total: repairPaths.length, message: 'Repairing incomplete import...' });
+
+                            try {
+                                const { getThumbnailDir } = await import('../../../services/thumbnailService');
+                                const thumbDir = await getThumbnailDir();
+                                const result = await processNativePaths(
+                                    repairPaths,
+                                    thumbDir,
+                                    (current, total, message) => {
+                                        setImportProgress({ current, total, message });
+                                    },
+                                    variant as GeneratorTool | undefined,
+                                    undefined,
+                                    false
+                                );
+                                addToast(
+                                    result.images.length > 0
+                                        ? `Repair scan imported ${result.images.length} missing files`
+                                        : 'Repair scan found no additional importable files',
+                                    result.images.length > 0 ? 'success' : 'info'
+                                );
+                            } finally {
+                                setIsImporting(false);
+                                setImportProgress(null);
+                            }
+                        } else {
+                            addToast(`No changes detected`, 'info');
+                        }
+                        updateFolderLastScanned(id, Date.now());
                     }
-                    updateFolderLastScanned(id, Date.now());
                 } else {
                     await onScanFolder([{ path, variant }]);
                     updateFolderLastScanned(id, Date.now());
@@ -192,9 +227,7 @@ export const useFoldersTabLogic = ({
             isActive: true,
             imageCount: 0,
             variant: variant,
-            // Mark this folder as intentionally queued so the generic folder monitor
-            // does not immediately trigger a second overlapping scan.
-            lastScanned: queuedAt
+            initialScanPending: true
         };
 
         setSettings(prev => ({
@@ -214,7 +247,14 @@ export const useFoldersTabLogic = ({
             try {
                 await onScanFolder(foldersToScan.map(({ path, variant }) => ({ path, variant })));
                 const completedAt = Date.now();
-                foldersToScan.forEach(folder => updateFolderLastScanned(folder.id, completedAt));
+                setSettings(prev => ({
+                    ...prev,
+                    monitoredFolders: prev.monitoredFolders.map(folder =>
+                        foldersToScan.some(pending => pending.id === folder.id)
+                            ? { ...folder, lastScanned: completedAt, initialScanPending: false }
+                            : folder
+                    )
+                }));
                 await fetchCounts();
             } catch (e) {
                 console.error('Auto-scan failed:', e);
@@ -222,7 +262,7 @@ export const useFoldersTabLogic = ({
                     ...prev,
                     monitoredFolders: prev.monitoredFolders.map(folder =>
                         foldersToScan.some(pending => pending.id === folder.id)
-                            ? { ...folder, lastScanned: undefined }
+                            ? { ...folder, lastScanned: undefined, initialScanPending: false }
                             : folder
                     )
                 }));

--- a/src/features/settings/hooks/useFoldersTabLogic.ts
+++ b/src/features/settings/hooks/useFoldersTabLogic.ts
@@ -46,7 +46,7 @@ export const useFoldersTabLogic = ({
 
     const fileInputRef = useRef<HTMLInputElement>(null);
     const resourceInputRef = useRef<HTMLInputElement>(null);
-    const pendingScansRef = useRef<{ path: string, variant?: string }[]>([]);
+    const pendingScansRef = useRef<{ id: string, path: string, variant?: string }[]>([]);
     const scanDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const updateFolderLastScanned = useSettingsStore(s => s.updateFolderLastScanned);
@@ -185,12 +185,16 @@ export const useFoldersTabLogic = ({
         }
 
         const variant = detectGeneratorVariant(normalizedNew);
+        const queuedAt = Date.now();
         const newFolder: MonitoredFolder = {
-            id: `folder_${Date.now()}`,
+            id: `folder_${queuedAt}`,
             path: normalizedNew,
             isActive: true,
             imageCount: 0,
-            variant: variant
+            variant: variant,
+            // Mark this folder as intentionally queued so the generic folder monitor
+            // does not immediately trigger a second overlapping scan.
+            lastScanned: queuedAt
         };
 
         setSettings(prev => ({
@@ -201,18 +205,27 @@ export const useFoldersTabLogic = ({
         addToast(`Added folder: ${normalizedNew}`, 'success');
 
         // Trigger scan
-        pendingScansRef.current.push({ path: normalizedNew, variant });
+        pendingScansRef.current.push({ id: newFolder.id, path: normalizedNew, variant });
         if (scanDebounceRef.current) clearTimeout(scanDebounceRef.current);
         scanDebounceRef.current = setTimeout(async () => {
             if (pendingScansRef.current.length === 0 || !onScanFolder) return;
             const foldersToScan = [...pendingScansRef.current];
             pendingScansRef.current = [];
             try {
-                await onScanFolder(foldersToScan);
-                addToast(`Scanned ${foldersToScan.length} folder(s)`, 'success');
+                await onScanFolder(foldersToScan.map(({ path, variant }) => ({ path, variant })));
+                const completedAt = Date.now();
+                foldersToScan.forEach(folder => updateFolderLastScanned(folder.id, completedAt));
                 await fetchCounts();
             } catch (e) {
                 console.error('Auto-scan failed:', e);
+                setSettings(prev => ({
+                    ...prev,
+                    monitoredFolders: prev.monitoredFolders.map(folder =>
+                        foldersToScan.some(pending => pending.id === folder.id)
+                            ? { ...folder, lastScanned: undefined }
+                            : folder
+                    )
+                }));
                 addToast('Folder scan failed', 'error');
             }
         }, 500);

--- a/src/features/viewer/components/CompareModal.tsx
+++ b/src/features/viewer/components/CompareModal.tsx
@@ -54,12 +54,15 @@ const ImageContainer = ({
         </button>
 
         {/* Image Transform */}
-        <div style={{ transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`, transition: isDraggingCanvas ? 'none' : 'transform 0.1s ease-out' }}>
+        <div
+            className="w-full h-full flex items-center justify-center p-6 box-border"
+            style={{ transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`, transition: isDraggingCanvas ? 'none' : 'transform 0.1s ease-out' }}
+        >
             <SmartImage
                 src={img.url}
                 alt={img.filename}
-                className="max-w-none max-h-[80vh]"
-                imgClassName="object-contain shadow-2xl"
+                className="w-full h-full"
+                imgClassName="w-full h-full object-contain shadow-2xl"
                 draggable={false}
                 objectFit="contain"
             />

--- a/src/features/viewer/components/SlideshowModal.tsx
+++ b/src/features/viewer/components/SlideshowModal.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { motion } from 'framer-motion';
 import { X, Play, Pause, ChevronLeft, ChevronRight, Shuffle, Clock, Maximize2, Info } from 'lucide-react';
 import { AIImage } from '../../../types';
 import { SmartImage } from '../../../features/library/components/SmartImage';
@@ -170,23 +171,16 @@ export const SlideshowModal: React.FC<SlideshowModalProps> = ({
 
       {/* Progress Bar */}
       {isPlaying && (
-        <div
+        <motion.div
           key={`${currentIndex}-${duration}-${isPlaying}`}
-          className="absolute top-0 left-0 h-1 bg-sage-500 z-50 transition-all ease-linear shadow-[0_0_10px_rgba(99,102,241,0.8)]"
+          className="absolute top-0 left-0 h-1 w-full bg-sage-500 z-[70] shadow-[0_0_10px_rgba(99,102,241,0.8)]"
+          initial={{ scaleX: 0, opacity: showHud ? 1 : 0.24 }}
+          animate={{ scaleX: 1, opacity: showHud ? 1 : 0.24 }}
+          transition={{ duration: duration / 1000, ease: 'linear' }}
           style={{
-            width: '100%',
-            transitionDuration: `${duration}ms`,
-            transformOrigin: 'left',
-            animation: `progress ${duration}ms linear forwards`
+            transformOrigin: 'left center'
           }}
-        >
-          <style>{`
-                @keyframes progress {
-                    from { transform: scaleX(0); }
-                    to { transform: scaleX(1); }
-                }
-              `}</style>
-        </div>
+        />
       )}
 
       {/* Cinematic Info Bar */}

--- a/src/features/viewer/components/ViewerToolbar.tsx
+++ b/src/features/viewer/components/ViewerToolbar.tsx
@@ -90,7 +90,7 @@ export const ViewerToolbar: React.FC<ViewerToolbarProps> = ({
                     <button
                         onClick={onDelete}
                         className="p-2.5 bg-black/50 hover:bg-red-500/20 border border-white/5 hover:border-red-500/30 rounded-full text-white/50 hover:text-red-400 transition-all backdrop-blur-md shadow-lg"
-                        title="Delete"
+                        title="Remove from Library"
                     >
                         <Trash2 className="w-5 h-5" />
                     </button>

--- a/src/features/viewer/components/metadata/MetadataInfoTab.tsx
+++ b/src/features/viewer/components/metadata/MetadataInfoTab.tsx
@@ -184,18 +184,20 @@ export const MetadataInfoTab = ({
                         <div className="flex justify-between items-center mb-2">
                             <div className="flex items-center gap-2">
                                 <h3 className="text-xs font-bold uppercase text-gray-500 tracking-wider">Positive Prompt</h3>
-                                {/* Toggle: Original / AI Generated */}
+                                {/* Toggle: Original / current saved prompt */}
                                 {image.originalMetadata && !isLoading && image.originalMetadata.positivePrompt !== image.metadata.positivePrompt && (
                                     <div className="flex gap-1 p-0.5 bg-gray-100 dark:bg-zinc-800/50 rounded-lg border border-gray-200 dark:border-white/10">
                                         <button
                                             onClick={() => setPromptValue(image.metadata.positivePrompt || '')}
                                             className={`px-2 py-0.5 text-[10px] font-bold rounded transition-all ${promptValue === image.metadata.positivePrompt ? 'bg-amethyst-500 text-white shadow' : 'text-gray-500 hover:text-amethyst-500'}`}
+                                            title="Show the current saved prompt"
                                         >
-                                            AI
+                                            Current
                                         </button>
                                         <button
                                             onClick={() => setPromptValue(image.originalMetadata?.positivePrompt || '')}
                                             className={`px-2 py-0.5 text-[10px] font-bold rounded transition-all ${promptValue === image.originalMetadata?.positivePrompt ? 'bg-sage-500 text-white shadow' : 'text-gray-500 hover:text-sage-500'}`}
+                                            title="Show the original imported prompt"
                                         >
                                             Original
                                         </button>

--- a/src/hooks/__tests__/useAppActions.test.tsx
+++ b/src/hooks/__tests__/useAppActions.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../useToast', () => ({
 
 const mockSetImages = vi.fn();
 const mockToggleFavorite = vi.fn();
-const mockRefreshCollectionThumbnails = vi.fn();
+const mockRefreshCollections = vi.fn();
 
 vi.mock('../../services/db/imageRepo', () => ({
     toggleImageFavorite: vi.fn(),
@@ -45,7 +45,7 @@ vi.mock('../../stores/settingsStore', () => ({
 
 vi.mock('../../stores/collectionStore', () => ({
     useCollectionStore: (selector: any) => selector({
-        refreshCollections: mockRefreshCollectionThumbnails,
+        refreshCollections: mockRefreshCollections,
     }),
 }));
 
@@ -120,8 +120,20 @@ describe('useAppActions', () => {
         });
 
         expect(mockSetImages).toHaveBeenCalled();
-        expect(mockRefreshCollectionThumbnails).toHaveBeenCalled();
+        expect(mockRefreshCollections).toHaveBeenCalledWith(true);
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Pinned'), 'info');
+    });
+
+    it('should show the bulk pin toast without waiting for collection refresh', async () => {
+        mockRefreshCollections.mockImplementation(() => new Promise(() => { }));
+        const { result } = renderHook(() => useAppActions(props));
+
+        await act(async () => {
+            await result.current.handleBulkPin();
+        });
+
+        expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Pinned'), 'info');
+        expect(mockRefreshCollections).toHaveBeenCalledWith(true);
     });
 
     it('should toggle privacy mode and show toast', () => {

--- a/src/hooks/__tests__/useAppActions.test.tsx
+++ b/src/hooks/__tests__/useAppActions.test.tsx
@@ -89,6 +89,17 @@ describe('useAppActions', () => {
         expect(mockModalManager.openModal).toHaveBeenCalledWith('deleteConfirm');
     });
 
+    it('should bind the requested delete target before opening confirmation', () => {
+        const { result } = renderHook(() => useAppActions(props));
+
+        act(() => {
+            result.current.requestDeleteForId('2');
+        });
+
+        expect(mockModalManager.setPendingViewerDeleteId).toHaveBeenCalledWith('2');
+        expect(mockModalManager.openModal).toHaveBeenCalledWith('deleteConfirm');
+    });
+
     it('should execute delete and clear selection', () => {
         const { result } = renderHook(() => useAppActions(props));
 
@@ -99,6 +110,23 @@ describe('useAppActions', () => {
         expect(mockFileOps.deleteImages).toHaveBeenCalledWith(['1']);
         expect(mockSetSelectedIds).toHaveBeenCalledWith(new Set());
         expect(mockModalManager.closeModal).toHaveBeenCalledWith('deleteConfirm');
+    });
+
+    it('should ignore accidental confirm click arguments when deleting multiple selected images', () => {
+        const multiSelectProps = {
+            ...props,
+            selectedIds: new Set(['1', '2']),
+        };
+        const fakeClickEvent = { type: 'click', currentTarget: {} };
+        const { result } = renderHook(() => useAppActions(multiSelectProps));
+
+        act(() => {
+            (result.current.executeDelete as unknown as (event: unknown) => void)(fakeClickEvent);
+        });
+
+        expect(mockFileOps.deleteImages).toHaveBeenCalledWith(['1', '2']);
+        expect(mockFileOps.deleteImages).not.toHaveBeenCalledWith(fakeClickEvent);
+        expect(mockSetSelectedIds).toHaveBeenCalledWith(new Set());
     });
 
     it('should handle bulk favorite', async () => {

--- a/src/hooks/__tests__/useAppHandlers.test.ts
+++ b/src/hooks/__tests__/useAppHandlers.test.ts
@@ -12,20 +12,20 @@ vi.mock('../useToast', () => ({
 }));
 
 const mockUpdateImageMetadataFields = vi.fn();
-const mockMarkAsDeleted = vi.fn();
-const mockDeleteImageFromDisk = vi.fn();
+const mockRemoveImagesFromLibrary = vi.fn();
+const mockRestoreRemovedImages = vi.fn();
+const mockDeleteRemovedImageFromDisk = vi.fn();
 const mockGetImagesByIds = vi.fn();
-const mockGetDeletedImages = vi.fn();
+const mockRebuildFacetCache = vi.fn().mockResolvedValue(0);
 
 vi.mock('../../services/db/imageRepo', () => ({
     updateImageMetadataFields: (...args: any[]) => mockUpdateImageMetadataFields(...args),
-    markAsDeleted: (...args: any[]) => mockMarkAsDeleted(...args),
-    deleteImageFromDisk: (...args: any[]) => mockDeleteImageFromDisk(...args),
+    removeImagesFromLibrary: (...args: any[]) => mockRemoveImagesFromLibrary(...args),
+    restoreRemovedImages: (...args: any[]) => mockRestoreRemovedImages(...args),
+    deleteRemovedImageFromDisk: (...args: any[]) => mockDeleteRemovedImageFromDisk(...args),
     getImagesByIds: (...args: any[]) => mockGetImagesByIds(...args),
-}));
-
-vi.mock('../../services/db/maintenanceRepo', () => ({
-    getDeletedImages: (...args: any[]) => mockGetDeletedImages(...args),
+    rebuildFacetCache: (...args: any[]) => mockRebuildFacetCache(...args),
+    rebuildFacetCacheIncremental: vi.fn().mockResolvedValue(0),
 }));
 
 describe('useAppHandlers', () => {
@@ -89,29 +89,36 @@ describe('useAppHandlers', () => {
         expect(nextState[0].groupId).toContain('stack_');
     });
 
-    it('should handle move to trash', async () => {
+    it('should handle remove from library', async () => {
         const { result } = renderHook(() => useAppHandlers(props));
 
         await act(async () => {
-            await result.current.handleMoveToTrash(['img1']);
+            await result.current.handleRemoveFromLibrary(['img1']);
         });
 
-        expect(mockMarkAsDeleted).toHaveBeenCalledWith(['img1'], true);
+        expect(mockRemoveImagesFromLibrary).toHaveBeenCalledWith(['img1']);
         expect(mockSetImages).toHaveBeenCalled();
         expect(mockRefreshMaintenanceCounts).toHaveBeenCalled();
     });
 
-    it('should handle delete forever', async () => {
+    it('should handle restore from removed list', async () => {
         const { result } = renderHook(() => useAppHandlers(props));
 
         await act(async () => {
-            await result.current.handleDeleteForever(['img1']);
+            await result.current.handleRestoreImages(['img1']);
         });
 
-        expect(mockDeleteImageFromDisk).toHaveBeenCalledWith('img1', 'img1', 'thumb1');
-        expect(mockSetImages).toHaveBeenCalled();
-        const updater = mockSetImages.mock.calls[0][0];
-        const nextState = updater(mockImages);
-        expect(nextState).toHaveLength(0);
+        expect(mockRestoreRemovedImages).toHaveBeenCalledWith(['img1']);
+        expect(mockGetImagesByIds).toHaveBeenCalledWith(['img1']);
+    });
+
+    it('should handle delete file for removed items', async () => {
+        const { result } = renderHook(() => useAppHandlers(props));
+
+        await act(async () => {
+            await result.current.handleDeleteFile(['img1']);
+        });
+
+        expect(mockDeleteRemovedImageFromDisk).toHaveBeenCalledWith('img1');
     });
 });

--- a/src/hooks/__tests__/useAppHandlers.test.ts
+++ b/src/hooks/__tests__/useAppHandlers.test.ts
@@ -14,7 +14,7 @@ vi.mock('../useToast', () => ({
 const mockUpdateImageMetadataFields = vi.fn();
 const mockRemoveImagesFromLibrary = vi.fn();
 const mockRestoreRemovedImages = vi.fn();
-const mockDeleteRemovedImageFromDisk = vi.fn();
+const mockDeleteRemovedImagesFromDisk = vi.fn();
 const mockGetImagesByIds = vi.fn();
 const mockRebuildFacetCache = vi.fn().mockResolvedValue(0);
 
@@ -22,7 +22,7 @@ vi.mock('../../services/db/imageRepo', () => ({
     updateImageMetadataFields: (...args: any[]) => mockUpdateImageMetadataFields(...args),
     removeImagesFromLibrary: (...args: any[]) => mockRemoveImagesFromLibrary(...args),
     restoreRemovedImages: (...args: any[]) => mockRestoreRemovedImages(...args),
-    deleteRemovedImageFromDisk: (...args: any[]) => mockDeleteRemovedImageFromDisk(...args),
+    deleteRemovedImagesFromDisk: (...args: any[]) => mockDeleteRemovedImagesFromDisk(...args),
     getImagesByIds: (...args: any[]) => mockGetImagesByIds(...args),
     rebuildFacetCache: (...args: any[]) => mockRebuildFacetCache(...args),
     rebuildFacetCacheIncremental: vi.fn().mockResolvedValue(0),
@@ -61,6 +61,11 @@ describe('useAppHandlers', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mockGetImagesByIds.mockResolvedValue([mockImages[0]]);
+        mockDeleteRemovedImagesFromDisk.mockResolvedValue({
+            deletedIds: ['img1'],
+            failedIds: [],
+            thumbnailWarningIds: []
+        });
     });
 
     it('should update positive prompt and call DB', async () => {
@@ -119,6 +124,21 @@ describe('useAppHandlers', () => {
             await result.current.handleDeleteFile(['img1']);
         });
 
-        expect(mockDeleteRemovedImageFromDisk).toHaveBeenCalledWith('img1');
+        expect(mockDeleteRemovedImagesFromDisk).toHaveBeenCalledWith(['img1']);
+    });
+
+    it('should show warning toast when removed delete partially fails', async () => {
+        mockDeleteRemovedImagesFromDisk.mockResolvedValue({
+            deletedIds: ['img1'],
+            failedIds: ['img2'],
+            thumbnailWarningIds: []
+        });
+        const { result } = renderHook(() => useAppHandlers(props));
+
+        await act(async () => {
+            await result.current.handleDeleteFile(['img1', 'img2']);
+        });
+
+        expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Deleted 1 file'), 'warning');
     });
 });

--- a/src/hooks/__tests__/useFileOperations.test.tsx
+++ b/src/hooks/__tests__/useFileOperations.test.tsx
@@ -63,11 +63,12 @@ vi.mock('../../services/thumbnailService', () => ({
 
 // Mock Repositories
 vi.mock('../../services/db/imageRepo', () => ({
-    markAsDeleted: vi.fn(),
-    deleteImage: vi.fn(),
+    removeImagesFromLibrary: vi.fn(),
+    deleteImageFromDisk: vi.fn(),
     updateFavorite: vi.fn(),
     updatePinned: vi.fn(),
     getImagesByIds: vi.fn().mockResolvedValue([]),
+    rebuildFacetCache: vi.fn().mockResolvedValue(0),
 }));
 
 describe('useFileOperations', () => {
@@ -110,7 +111,7 @@ describe('useFileOperations', () => {
 
     describe('deleteImages', () => {
         it('should perform soft delete and update local state', async () => {
-            const { markAsDeleted } = await import('../../services/db/imageRepo');
+            const { removeImagesFromLibrary } = await import('../../services/db/imageRepo');
             const { result } = renderHook(() => useFileOperations({
                 images: mockImages,
                 setImages: mockSetImages,
@@ -122,13 +123,14 @@ describe('useFileOperations', () => {
                 await result.current.deleteImages(['1'], false);
             });
 
-            expect(markAsDeleted).toHaveBeenCalledWith(['1'], true);
+            expect(removeImagesFromLibrary).toHaveBeenCalledWith(['1']);
             expect(mockSetImages).toHaveBeenCalled();
-            expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Moved 1 images to Trash'), 'success');
+            expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Removed 1 image from the library'), 'success');
         });
 
         it('should perform permanent delete and remove from local state', async () => {
-            const { deleteImage } = await import('../../services/db/imageRepo');
+            const { deleteImageFromDisk, getImagesByIds } = await import('../../services/db/imageRepo');
+            (getImagesByIds as any).mockResolvedValue([mockImages[1]]);
             const { result } = renderHook(() => useFileOperations({
                 images: mockImages,
                 setImages: mockSetImages,
@@ -140,9 +142,9 @@ describe('useFileOperations', () => {
                 await result.current.deleteImages(['2'], true);
             });
 
-            expect(deleteImage).toHaveBeenCalledWith('2');
+            expect(deleteImageFromDisk).toHaveBeenCalledWith('2', '2', 'thumb2');
             expect(mockSetImages).toHaveBeenCalled();
-            expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Permanently deleted 1 images'), 'success');
+            expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Moved 1 file to OS trash'), 'success');
         });
     });
 
@@ -165,6 +167,8 @@ describe('useFileOperations', () => {
         });
 
         it('should bail if no images match the IDs', async () => {
+            const { getImagesByIds } = await import('../../services/db/imageRepo');
+            (getImagesByIds as any).mockResolvedValue([]);
             const { result } = renderHook(() => useFileOperations({
                 images: mockImages,
                 setImages: mockSetImages,

--- a/src/hooks/__tests__/useFileOperations.test.tsx
+++ b/src/hooks/__tests__/useFileOperations.test.tsx
@@ -95,6 +95,7 @@ describe('useFileOperations', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockRefreshCollectionThumbnails.mockResolvedValue(undefined);
     });
 
     it('should initialize correctly', () => {
@@ -126,6 +127,26 @@ describe('useFileOperations', () => {
             expect(removeImagesFromLibrary).toHaveBeenCalledWith(['1']);
             expect(mockSetImages).toHaveBeenCalled();
             expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Removed 1 image from the library'), 'success');
+        });
+
+        it('should keep delete success even if collection thumbnail refresh fails', async () => {
+            const { removeImagesFromLibrary } = await import('../../services/db/imageRepo');
+            mockRefreshCollectionThumbnails.mockRejectedValueOnce(new Error('thumbnail refresh failed'));
+            const { result } = renderHook(() => useFileOperations({
+                images: mockImages,
+                setImages: mockSetImages,
+                refreshCollectionThumbnails: mockRefreshCollectionThumbnails,
+                settings: mockSettings,
+            }));
+
+            await act(async () => {
+                await result.current.deleteImages(['1'], false);
+            });
+
+            expect(removeImagesFromLibrary).toHaveBeenCalledWith(['1']);
+            expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Removed 1 image from the library'), 'success');
+            expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('collection thumbnails may need a refresh'), 'warning');
+            expect(mockAddToast).not.toHaveBeenCalledWith('Failed to update library state', 'error');
         });
 
         it('should perform permanent delete and remove from local state', async () => {

--- a/src/hooks/__tests__/useFolderMonitor.test.ts
+++ b/src/hooks/__tests__/useFolderMonitor.test.ts
@@ -85,6 +85,32 @@ describe('useFolderMonitor', () => {
         expect(mockAddToast).not.toHaveBeenCalled();
     });
 
+    it('should not auto-scan newly added folders whose first scan is already queued', () => {
+        const initialFolders = [{ id: '1', path: '/test1', isActive: true, imageCount: 0 }];
+        const { rerender } = renderHook(({ folders }) => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths: vi.fn(),
+            refreshMetadata: vi.fn()
+        }), {
+            initialProps: { folders: initialFolders }
+        });
+
+        vi.clearAllMocks();
+
+        rerender({
+            folders: [
+                ...initialFolders,
+                { id: '2', path: '/test2', isActive: true, imageCount: 0, initialScanPending: true }
+            ]
+        });
+
+        expect(mockOnScan).not.toHaveBeenCalled();
+        expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
     it('should detect startup scan (prevFolders empty)', () => {
         const { rerender } = renderHook(({ folders, isLoaded }) => useFolderMonitor({
             isLoaded,

--- a/src/hooks/__tests__/useFolderMonitor.test.ts
+++ b/src/hooks/__tests__/useFolderMonitor.test.ts
@@ -59,6 +59,32 @@ describe('useFolderMonitor', () => {
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('/test2'), 'info');
     });
 
+    it('should not auto-scan newly added folders that already have a scan timestamp', () => {
+        const initialFolders = [{ id: '1', path: '/test1', isActive: true, imageCount: 0 }];
+        const { rerender } = renderHook(({ folders }) => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths: vi.fn(),
+            refreshMetadata: vi.fn()
+        }), {
+            initialProps: { folders: initialFolders }
+        });
+
+        vi.clearAllMocks();
+
+        rerender({
+            folders: [
+                ...initialFolders,
+                { id: '2', path: '/test2', isActive: true, imageCount: 0, lastScanned: Date.now() }
+            ]
+        });
+
+        expect(mockOnScan).not.toHaveBeenCalled();
+        expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
     it('should detect startup scan (prevFolders empty)', () => {
         const { rerender } = renderHook(({ folders, isLoaded }) => useFolderMonitor({
             isLoaded,

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -179,6 +179,16 @@ export const useAppActions = ({
     const executeMetadataRecovery = async (style: any) => {
         const targetId = viewingImageId || (selectedImageIndex !== null ? images[selectedImageIndex]?.id : null) || (selectedIds.size > 0 ? Array.from(selectedIds)[0] : null);
         if (!targetId) return;
+
+        const { geminiApiKey } = useSettingsStore.getState();
+        if (!settings.enableAI || !geminiApiKey) {
+            closeModal('recovery');
+            modals.setInitialSettingsTab?.('intelligence');
+            openModal('settings');
+            addToast('Enable AI features and configure a Gemini API key in Settings to use Prompt Recovery.', 'info');
+            return;
+        }
+
         fileOps.recoverMetadata(targetId, style, () => closeModal('recovery'));
     };
 

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -41,9 +41,26 @@ export const useAppActions = ({
     const privacyEnabled = useSettingsStore(s => s.privacyEnabled);
     const setPrivacyEnabled = useSettingsStore(s => s.setPrivacyEnabled);
 
-    const refreshCollectionThumbnails = useCollectionStore(s => s.refreshCollections); // Placeholder or mapping
+    const refreshCollections = useCollectionStore(s => s.refreshCollections);
 
     const { openModal, closeModal, pendingViewerDeleteId, setPendingViewerDeleteId } = modals;
+
+    const persistPinChanges = React.useCallback(async (
+        ids: string[],
+        isPinned: boolean,
+        previousImages: typeof images,
+        errorMessage: string
+    ) => {
+        try {
+            const { toggleImagePin } = await import('../services/db/imageRepo');
+            await Promise.all(ids.map(id => toggleImagePin(id, isPinned)));
+            void refreshCollections(true);
+        } catch (error) {
+            console.error('[Pin] Failed to persist pin state', error);
+            setImages(previousImages);
+            addToast(errorMessage, 'error');
+        }
+    }, [refreshCollections, setImages, addToast, images]);
 
     const executeDelete = () => {
         const ids = pendingViewerDeleteId ? [pendingViewerDeleteId] : Array.from(selectedIds);
@@ -94,8 +111,10 @@ export const useAppActions = ({
         addToast(`${anyUnfavorite ? 'Favorited' : 'Unfavorited'} ${selectedIds.size} images`, 'success');
     };
 
-    const handleBulkPin = async () => {
+    const handleBulkPin = () => {
         const anyUnpinned = images.some(img => selectedIds.has(img.id) && !img.isPinned);
+        const previousImages = images;
+
         setImages(prev => {
             const updated = prev.map(img => selectedIds.has(img.id) ? { ...img, isPinned: anyUnpinned } : img);
 
@@ -111,12 +130,9 @@ export const useAppActions = ({
         });
 
         const ids = Array.from(selectedIds);
-        const { toggleImagePin } = await import('../services/db/imageRepo');
-        await Promise.all(ids.map(id => toggleImagePin(id, anyUnpinned)));
-
-        await refreshCollectionThumbnails();
-        // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
         addToast(`${anyUnpinned ? 'Pinned' : 'Unpinned'} ${selectedIds.size} images`, 'info');
+        void persistPinChanges(ids, anyUnpinned, previousImages, 'Failed to update pinned images');
+        // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
     };
 
     const handleBulkMask = async (targetId?: string, overrideValue?: boolean | null) => {
@@ -192,7 +208,9 @@ export const useAppActions = ({
         fileOps.recoverMetadata(targetId, style, () => closeModal('recovery'));
     };
 
-    const handlePinImage = async (id: string, newPinned: boolean) => {
+    const handlePinImage = (id: string, newPinned: boolean) => {
+        const previousImages = images;
+
         setImages(prev => {
             const updated = prev.map(i => i.id === id ? { ...i, isPinned: newPinned } : i);
 
@@ -205,10 +223,9 @@ export const useAppActions = ({
             return updated;
         });
 
-        await import('../services/db/imageRepo').then(db => db.toggleImagePin(id, newPinned));
-        await refreshCollectionThumbnails();
-        // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
         addToast(newPinned ? "Pinned to top" : "Unpinned", "info");
+        void persistPinChanges([id], newPinned, previousImages, 'Failed to update pinned state');
+        // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
     };
 
     const handleShortcutFavorite = () => {

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -62,12 +62,11 @@ export const useAppActions = ({
         }
     }, [refreshCollections, setImages, addToast, images]);
 
-    const executeDelete = () => {
-        const ids = pendingViewerDeleteId ? [pendingViewerDeleteId] : Array.from(selectedIds);
+    const executeDeleteByIds = React.useCallback((ids: string[], targetDeleteId: string | null = null) => {
         fileOps.deleteImages(ids);
 
-        if (pendingViewerDeleteId) {
-            const idx = images.findIndex(img => img.id === pendingViewerDeleteId);
+        if (targetDeleteId) {
+            const idx = images.findIndex(img => img.id === targetDeleteId);
             if (idx !== -1) {
                 let nextIndex: number | null = idx;
                 if (images.length === 1) nextIndex = null;
@@ -79,17 +78,25 @@ export const useAppActions = ({
         }
         closeModal('deleteConfirm');
         setPendingViewerDeleteId(null);
-    };
+    }, [fileOps, images, setSelectedImageIndex, setSelectedIds, closeModal, setPendingViewerDeleteId]);
+
+    const executeDelete = React.useCallback(() => {
+        const ids = pendingViewerDeleteId ? [pendingViewerDeleteId] : Array.from(selectedIds);
+        executeDeleteByIds(ids, pendingViewerDeleteId);
+    }, [pendingViewerDeleteId, selectedIds, executeDeleteByIds]);
+
+    const requestDeleteForId = React.useCallback((id: string) => {
+        setPendingViewerDeleteId(id);
+        if (settings.confirmDelete) {
+            openModal('deleteConfirm');
+            return;
+        }
+
+        executeDeleteByIds([id], id);
+    }, [settings.confirmDelete, openModal, setPendingViewerDeleteId, executeDeleteByIds]);
 
     const handleDeleteViewerImage = (id: string) => {
-        if (settings.confirmDelete) {
-            setPendingViewerDeleteId(id);
-            openModal('deleteConfirm');
-        } else {
-            setPendingViewerDeleteId(id);
-            // Non-ideal to use setTimeout but matches original logic for now
-            setTimeout(() => executeDelete(), 0);
-        }
+        requestDeleteForId(id);
     };
 
     const handleExportConfirm = async (filename: string, folder: string, ids?: Set<string>) => {
@@ -259,6 +266,7 @@ export const useAppActions = ({
 
     return {
         executeDelete,
+        requestDeleteForId,
         handleDeleteViewerImage,
         handleExportConfirm,
         handleBulkFavorite,

--- a/src/hooks/useAppHandlers.ts
+++ b/src/hooks/useAppHandlers.ts
@@ -1,7 +1,6 @@
 import { AIImage, GeneratorTool } from '../types';
 import { useToast } from './useToast';
-import { updateImageMetadataFields, updateImageNotesCol, rebuildFacetCacheIncremental } from '../services/db/imageRepo';
-import { urlToPath } from '../utils/pathUtils';
+import { updateImageMetadataFields, updateImageNotesCol, rebuildFacetCache, rebuildFacetCacheIncremental } from '../services/db/imageRepo';
 import { useLibraryStore } from '../stores/libraryStore';
 
 interface UseAppHandlersProps {
@@ -13,6 +12,10 @@ interface UseAppHandlersProps {
 export const useAppHandlers = ({ images, setImages, refreshMaintenanceCounts }: UseAppHandlersProps) => {
     const { addToast } = useToast();
     const incrementFacetCacheVersion = useLibraryStore(state => state.incrementFacetCacheVersion);
+
+    const refreshFacets = () => {
+        rebuildFacetCache().then(() => incrementFacetCacheVersion());
+    };
 
     const handleUpdatePrompt = async (id: string, prompt: string) => {
         const img = images.find(i => i.id === id);
@@ -95,55 +98,49 @@ export const useAppHandlers = ({ images, setImages, refreshMaintenanceCounts }: 
     };
 
     const handleResolveDuplicate = async (_keepId: string, deleteIds: string[]) => {
-        const { markAsDeleted } = await import('../services/db/imageRepo');
-        await markAsDeleted(deleteIds, true);
-        setImages(p => p.map(i => deleteIds.includes(i.id) ? { ...i, isDeleted: true } : i));
-        addToast(`Moved ${deleteIds.length} duplicates to trash`, 'success');
+        const { removeImagesFromLibrary } = await import('../services/db/imageRepo');
+        await removeImagesFromLibrary(deleteIds);
+        setImages(p => p.filter(i => !deleteIds.includes(i.id)));
+        addToast(`Removed ${deleteIds.length} duplicate${deleteIds.length === 1 ? '' : 's'} from the library`, 'success');
         refreshMaintenanceCounts();
+        refreshFacets();
     };
 
     const handleRestoreImages = async (ids: string[]) => {
-        const { markAsDeleted } = await import('../services/db/imageRepo');
-        await markAsDeleted(ids, false);
-        setImages(p => p.map(i => ids.includes(i.id) ? { ...i, isDeleted: false } : i));
-        addToast(`Restored ${ids.length} images`, 'success');
+        const { restoreRemovedImages, getImagesByIds } = await import('../services/db/imageRepo');
+        await restoreRemovedImages(ids);
+        const restoredImages = await getImagesByIds(ids);
+        setImages(p => {
+            const existingIds = new Set(p.map(image => image.id));
+            const uniqueRestored = restoredImages.filter(image => !existingIds.has(image.id));
+            return uniqueRestored.length > 0 ? [...uniqueRestored, ...p] : p;
+        });
+        addToast(`Restored ${ids.length} image${ids.length === 1 ? '' : 's'} to the library`, 'success');
         refreshMaintenanceCounts();
+        refreshFacets();
     };
 
-    const handleMoveToTrash = async (ids: string[]) => {
-        const { markAsDeleted } = await import('../services/db/imageRepo');
-        await markAsDeleted(ids, true);
-        setImages(p => p.map(i => ids.includes(i.id) ? { ...i, isDeleted: true } : i));
-        addToast(`Moved ${ids.length} images to trash`, 'success');
-        refreshMaintenanceCounts();
-    };
-
-    const handleDeleteForever = async (ids: string[]) => {
-        const { deleteImageFromDisk } = await import('../services/db/imageRepo');
-
-        // Fetch paths first to ensure we can trash them
-        const { getImagesByIds } = await import('../services/db/imageRepo');
-        const imagesToDelete = await getImagesByIds(ids);
-
-        for (const img of imagesToDelete) {
-            const path = img.id; // ID is the normalized path in this app
-            const thumbnailPath = img.thumbnailUrl ? urlToPath(img.thumbnailUrl) : null;
-            await deleteImageFromDisk(img.id, path, thumbnailPath);
-        }
-
+    const handleRemoveFromLibrary = async (ids: string[]) => {
+        const { removeImagesFromLibrary } = await import('../services/db/imageRepo');
+        await removeImagesFromLibrary(ids);
         setImages(p => p.filter(i => !ids.includes(i.id)));
-        addToast(`Permanently deleted ${ids.length} images`, 'success');
+        addToast(`Removed ${ids.length} image${ids.length === 1 ? '' : 's'} from the library`, 'success');
         refreshMaintenanceCounts();
+        refreshFacets();
+    };
+
+    const handleDeleteFile = async (ids: string[]) => {
+        const { deleteRemovedImageFromDisk } = await import('../services/db/imageRepo');
+        for (const id of ids) {
+            await deleteRemovedImageFromDisk(id);
+        }
+        addToast(`Moved ${ids.length} file${ids.length === 1 ? '' : 's'} to OS trash and removed ${ids.length === 1 ? 'it' : 'them'} from Ambit`, 'success');
+        refreshMaintenanceCounts();
+        refreshFacets();
     };
 
     const handleEmptyTrash = async () => {
-        const { getDeletedImages } = await import('../services/db/maintenanceRepo');
-        const { deleteImage } = await import('../services/db/imageRepo');
-        const deleted = await getDeletedImages();
-        const ids = deleted.map(i => i.id);
-        for (const id of ids) await deleteImage(id);
-        setImages(p => p.filter(i => !i.isDeleted));
-        addToast('Trash emptied', 'success');
+        addToast('Removed items are now handled through the Removed tab actions.', 'info');
         refreshMaintenanceCounts();
     };
 
@@ -191,8 +188,8 @@ export const useAppHandlers = ({ images, setImages, refreshMaintenanceCounts }: 
         handleGroupImages,
         handleResolveDuplicate,
         handleRestoreImages,
-        handleMoveToTrash,
-        handleDeleteForever,
+        handleRemoveFromLibrary,
+        handleDeleteFile,
         handleEmptyTrash
     };
 };

--- a/src/hooks/useAppHandlers.ts
+++ b/src/hooks/useAppHandlers.ts
@@ -130,13 +130,24 @@ export const useAppHandlers = ({ images, setImages, refreshMaintenanceCounts }: 
     };
 
     const handleDeleteFile = async (ids: string[]) => {
-        const { deleteRemovedImageFromDisk } = await import('../services/db/imageRepo');
-        for (const id of ids) {
-            await deleteRemovedImageFromDisk(id);
+        const { deleteRemovedImagesFromDisk } = await import('../services/db/imageRepo');
+        const result = await deleteRemovedImagesFromDisk(ids);
+
+        if (result.deletedIds.length > 0) {
+            if (result.failedIds.length === 0 && result.thumbnailWarningIds.length === 0) {
+                addToast(`Moved ${result.deletedIds.length} file${result.deletedIds.length === 1 ? '' : 's'} to OS trash and removed ${result.deletedIds.length === 1 ? 'it' : 'them'} from Ambit`, 'success');
+            } else {
+                addToast(
+                    `Deleted ${result.deletedIds.length} file${result.deletedIds.length === 1 ? '' : 's'} from Ambit, but ${result.failedIds.length} failed and ${result.thumbnailWarningIds.length} had thumbnail cleanup warnings.`,
+                    'warning'
+                );
+            }
+            refreshMaintenanceCounts();
+            refreshFacets();
+            return;
         }
-        addToast(`Moved ${ids.length} file${ids.length === 1 ? '' : 's'} to OS trash and removed ${ids.length === 1 ? 'it' : 'them'} from Ambit`, 'success');
-        refreshMaintenanceCounts();
-        refreshFacets();
+
+        addToast('Failed to move selected files to OS trash.', 'error');
     };
 
     const handleEmptyTrash = async () => {

--- a/src/hooks/useFolderMonitor.ts
+++ b/src/hooks/useFolderMonitor.ts
@@ -6,7 +6,6 @@ import { unwrap } from '../utils/spectaUtils';
 
 // Need to access store actions directly since we are bypassing handleImportPaths state management
 import { useLibraryStore } from '../stores/libraryStore';
-import { useWatchers } from '../contexts/WatcherContext';
 
 interface ImportOptions {
     isStartup?: boolean;
@@ -17,7 +16,7 @@ interface ImportOptions {
 interface UseFolderMonitorProps {
     isLoaded: boolean;
     monitoredFolders: MonitoredFolder[];
-    onScan: (folders: { path: string, variant?: string }[], isStartup: boolean) => void;
+    onScan: (folders: { path: string, variant?: string }[], isStartup: boolean) => Promise<void>;
     // Update signature to match new options
     handleImportPaths: (paths: string[], defaultTool?: GeneratorTool, options?: ImportOptions) => Promise<void>;
     addToast: (msg: string, type: 'info' | 'success' | 'error') => void;
@@ -78,7 +77,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     } else {
                         // Full scan usage (rare on startup if already configured)
                         console.log(`[FolderMonitor] Full Scan for ${folder.path} (first time)`);
-                        onScan([{ path: folder.path, variant: folder.variant }], true);
+                        await onScan([{ path: folder.path, variant: folder.variant }], true);
                         updateFolderLastScanned(folder.id, scanTime);
                     }
                 }
@@ -126,7 +125,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                 }
             };
 
-            performStartupScan();
+            void performStartupScan();
 
             prevFoldersRef.current = monitoredFolders;
             return;
@@ -139,20 +138,22 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
         const newFolders = currentFolders.filter(f => !prevFolders.find(pf => pf.id === f.id));
 
         if (newFolders.length > 0) {
-            const activeNew = newFolders.filter(f => f.isActive && !f.lastScanned);
+            const activeNew = newFolders.filter(f => f.isActive && !f.lastScanned && !f.initialScanPending);
 
             if (activeNew.length > 0) {
-                if (activeNew.length === 1) {
-                    addToast(`Scanning new folder: ${activeNew[0].path}`, 'info');
-                } else {
-                    addToast(`Scanning ${activeNew.length} new folders`, 'info');
-                }
+                void (async () => {
+                    if (activeNew.length === 1) {
+                        addToast(`Scanning new folder: ${activeNew[0].path}`, 'info');
+                    } else {
+                        addToast(`Scanning ${activeNew.length} new folders`, 'info');
+                    }
 
-                const scanData = activeNew.map(f => ({ path: f.path, variant: f.variant }));
-                onScan(scanData, false);
+                    const scanData = activeNew.map(f => ({ path: f.path, variant: f.variant }));
+                    await onScan(scanData, false);
 
-                // Mark them as scanned now so next startup is smart
-                activeNew.forEach(f => updateFolderLastScanned(f.id, Date.now()));
+                    const completedAt = Date.now();
+                    activeNew.forEach(f => updateFolderLastScanned(f.id, completedAt));
+                })();
             }
         }
 
@@ -205,7 +206,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     }
                 } else {
                     console.log(`[FolderMonitor] ${source}: Full scan needed for ${folder.path}`);
-                    onScan([{ path: folder.path, variant: folder.variant }], false);
+                    await onScan([{ path: folder.path, variant: folder.variant }], false);
                     updateFolderLastScanned(folder.id, scanTime);
                 }
             } catch (e) {

--- a/src/hooks/useFolderMonitor.ts
+++ b/src/hooks/useFolderMonitor.ts
@@ -139,7 +139,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
         const newFolders = currentFolders.filter(f => !prevFolders.find(pf => pf.id === f.id));
 
         if (newFolders.length > 0) {
-            const activeNew = newFolders.filter(f => f.isActive);
+            const activeNew = newFolders.filter(f => f.isActive && !f.lastScanned);
 
             if (activeNew.length > 0) {
                 if (activeNew.length === 1) {

--- a/src/hooks/useImportOps.ts
+++ b/src/hooks/useImportOps.ts
@@ -34,6 +34,12 @@ export const useImportOps = ({
     } = useLibraryStore();
     const { refreshHiddenAvailability, refreshMetadata } = useSearch();
 
+    const extractNativePaths = useCallback((files: File[]): string[] => {
+        return files
+            .map(file => (file as File & { path?: string }).path)
+            .filter((path): path is string => typeof path === 'string' && path.length > 0);
+    }, []);
+
     const commitImportResult = useCallback(async (result: ImportResult, silent = false) => {
         const { images: newImages, stats } = result;
 
@@ -82,27 +88,56 @@ export const useImportOps = ({
         if (!e.target.files) return;
         setIsImporting(true);
         try {
-            const result = await processWebFiles(Array.from(e.target.files));
-            await commitImportResult(result);
-        } catch (error) {
-            addToast("Import failed", "error");
-        } finally {
-            setIsImporting(false);
-            if (e.target) e.target.value = "";
-        }
-    }, [setIsImporting, commitImportResult, addToast]);
+            const files = Array.from(e.target.files);
+            const nativePaths = extractNativePaths(files);
 
-    const handleWebFiles = useCallback(async (files: File[]) => {
-        setIsImporting(true);
-        try {
+            if (nativePaths.length === files.length && nativePaths.length > 0) {
+                const { getThumbnailDir } = await import('../services/thumbnailService');
+                const thumbDir = await getThumbnailDir();
+                const result = await processNativePaths(nativePaths, thumbDir, (current, total, message) => {
+                    setImportProgress({ current, total, message });
+                });
+                await commitImportResult(result);
+                return;
+            }
+
             const result = await processWebFiles(files);
             await commitImportResult(result);
         } catch (error) {
             addToast("Import failed", "error");
         } finally {
             setIsImporting(false);
+            setImportProgress(null);
+            setImportAbortController(null);
+            if (e.target) e.target.value = "";
         }
-    }, [setIsImporting, commitImportResult, addToast]);
+    }, [setIsImporting, setImportProgress, setImportAbortController, extractNativePaths, commitImportResult, addToast]);
+
+    const handleWebFiles = useCallback(async (files: File[]) => {
+        setIsImporting(true);
+        try {
+            const nativePaths = extractNativePaths(files);
+
+            if (nativePaths.length === files.length && nativePaths.length > 0) {
+                const { getThumbnailDir } = await import('../services/thumbnailService');
+                const thumbDir = await getThumbnailDir();
+                const result = await processNativePaths(nativePaths, thumbDir, (current, total, message) => {
+                    setImportProgress({ current, total, message });
+                });
+                await commitImportResult(result);
+                return;
+            }
+
+            const result = await processWebFiles(files);
+            await commitImportResult(result);
+        } catch (error) {
+            addToast("Import failed", "error");
+        } finally {
+            setIsImporting(false);
+            setImportProgress(null);
+            setImportAbortController(null);
+        }
+    }, [setIsImporting, setImportProgress, setImportAbortController, extractNativePaths, commitImportResult, addToast]);
 
     const handleImportPaths = useCallback(async (paths: string[], defaultTool?: GeneratorTool, options: ImportOptions = {}) => {
         const { isStartup = false, skipStateManagement = false, onProgress: externalOnProgress } = options;

--- a/src/hooks/useImportOps.ts
+++ b/src/hooks/useImportOps.ts
@@ -311,10 +311,9 @@ export const useImportOps = ({
                 console.log(`[Resync] Found ${filesToScan.length} total files`);
             }
 
-            updateLastScanned(id, Date.now());
-
             if (filesToScan.length === 0) {
                 setImportProgress({ current: 0, total: 0, message: 'No changes detected' });
+                updateLastScanned(id, Date.now());
                 return { newFiles: 0, totalScanned: 0 };
             }
 
@@ -339,6 +338,7 @@ export const useImportOps = ({
             if (result.images.length > 0) {
                 await commitImportResult(result, true);
             }
+            updateLastScanned(id, Date.now());
 
             return { newFiles: result.images.length, totalScanned: filesToScan.length };
         } catch (e) {

--- a/src/hooks/useLibraryStatsQuery.ts
+++ b/src/hooks/useLibraryStatsQuery.ts
@@ -76,6 +76,13 @@ export const useLibraryStatsQuery = ({
         );
     }, [filters]);
 
+    // Free-text and date scopes can legitimately match images without producing
+    // trustworthy facet drill-down visibility. In those cases, showing the full
+    // facet catalog is less misleading than hiding everything.
+    const shouldUseFacetDrillDown = useMemo(() => {
+        return filters.searchQuery.trim() === '' && filters.dateRange === 'all';
+    }, [filters.searchQuery, filters.dateRange]);
+
     // Subscribe to facet cache version - when cache is rebuilt, this changes and triggers refetch
     const facetCacheVersion = useLibraryStore(s => s.facetCacheVersion);
 
@@ -99,7 +106,9 @@ export const useLibraryStatsQuery = ({
             const [facets, stats, baseValidNames] = await Promise.all([
                 getFacets(where, params, ALL_FACET_TYPES),
                 getLibraryStats(where, params, collectionId, loraName),
-                hasActiveFilters ? getValidFacetNames(filters, allCollections) : Promise.resolve(null)
+                hasActiveFilters && shouldUseFacetDrillDown
+                    ? getValidFacetNames(filters, allCollections)
+                    : Promise.resolve(null)
             ]);
 
             // 2. Disjunctive Queries: For categories in ANY mode with active selections
@@ -119,7 +128,7 @@ export const useLibraryStatsQuery = ({
 
             let finalValidNames = baseValidNames ? { ...baseValidNames } : null;
 
-            if (disjunctiveCategories.length > 0 && hasActiveFilters) {
+            if (disjunctiveCategories.length > 0 && hasActiveFilters && shouldUseFacetDrillDown) {
                 if (!finalValidNames) finalValidNames = {} as ValidFacetNames;
 
                 const extraQueries = disjunctiveCategories.map(async (cat) => {

--- a/src/hooks/useMaintenanceOps.ts
+++ b/src/hooks/useMaintenanceOps.ts
@@ -4,7 +4,9 @@ import { AIImage, AppSettings, RecoveryStyle } from '../types';
 import { useToast } from './useToast';
 import { imageToBase64 } from '../services/imageService';
 import { recoverImageMetadata } from '../services/geminiService';
+import { useLibraryStore } from '../stores/libraryStore';
 import { useSettingsStore } from '../stores/settingsStore';
+import { urlToPath } from '../utils/pathUtils';
 
 interface UseMaintenanceOpsProps {
     images: AIImage[];
@@ -21,27 +23,33 @@ export const useMaintenanceOps = ({
 }: UseMaintenanceOpsProps) => {
     const { addToast } = useToast();
     const [isRecoveringMetadata, setIsRecoveringMetadata] = useState(false);
+    const incrementFacetCacheVersion = useLibraryStore(state => state.incrementFacetCacheVersion);
 
     const deleteImages = useCallback(async (ids: string[], permanent = false) => {
         try {
-            const { markAsDeleted, deleteImage } = await import('../services/db/imageRepo');
+            const { removeImagesFromLibrary, deleteImageFromDisk, getImagesByIds, rebuildFacetCache } = await import('../services/db/imageRepo');
             if (permanent) {
-                for (const id of ids) await deleteImage(id);
+                const imagesToDelete = await getImagesByIds(ids);
+                for (const img of imagesToDelete) {
+                    const path = img.id;
+                    const thumbnailPath = img.thumbnailUrl ? urlToPath(img.thumbnailUrl) : null;
+                    await deleteImageFromDisk(img.id, path, thumbnailPath);
+                }
                 setImages(prev => prev.filter(img => !ids.includes(img.id)));
-                addToast(`Permanently deleted ${ids.length} images`, 'success');
+                addToast(`Moved ${ids.length} file${ids.length === 1 ? '' : 's'} to OS trash`, 'success');
             } else {
-                await markAsDeleted(ids, true);
-                setImages(prev => prev.map(img =>
-                    ids.includes(img.id) ? { ...img, isDeleted: true } : img
-                ));
-                addToast(`Moved ${ids.length} images to Trash`, 'success');
+                await removeImagesFromLibrary(ids);
+                setImages(prev => prev.filter(img => !ids.includes(img.id)));
+                addToast(`Removed ${ids.length} image${ids.length === 1 ? '' : 's'} from the library`, 'success');
                 await refreshCollectionThumbnails();
             }
+            await rebuildFacetCache();
+            incrementFacetCacheVersion();
         } catch (e) {
             console.error("Failed to delete images", e);
-            addToast("Failed to delete from database", "error");
+            addToast("Failed to update library state", "error");
         }
-    }, [setImages, addToast, refreshCollectionThumbnails]);
+    }, [setImages, addToast, refreshCollectionThumbnails, incrementFacetCacheVersion]);
 
     const recoverMetadata = useCallback(async (targetId: string, style: RecoveryStyle, onComplete: () => void) => {
         const img = images.find(i => i.id === targetId);

--- a/src/hooks/useMaintenanceOps.ts
+++ b/src/hooks/useMaintenanceOps.ts
@@ -26,27 +26,54 @@ export const useMaintenanceOps = ({
     const incrementFacetCacheVersion = useLibraryStore(state => state.incrementFacetCacheVersion);
 
     const deleteImages = useCallback(async (ids: string[], permanent = false) => {
+        const logPrefix = permanent ? '[MaintenanceOps] deleteFiles' : '[MaintenanceOps] removeFromLibrary';
+        let rebuildSucceeded = false;
+
         try {
             const { removeImagesFromLibrary, deleteImageFromDisk, getImagesByIds, rebuildFacetCache } = await import('../services/db/imageRepo');
             if (permanent) {
+                console.info(`${logPrefix}: fetching images`, { count: ids.length });
                 const imagesToDelete = await getImagesByIds(ids);
                 for (const img of imagesToDelete) {
                     const path = img.id;
                     const thumbnailPath = img.thumbnailUrl ? urlToPath(img.thumbnailUrl) : null;
+                    console.info(`${logPrefix}: deleting file`, { id: img.id });
                     await deleteImageFromDisk(img.id, path, thumbnailPath);
                 }
                 setImages(prev => prev.filter(img => !ids.includes(img.id)));
                 addToast(`Moved ${ids.length} file${ids.length === 1 ? '' : 's'} to OS trash`, 'success');
             } else {
+                console.info(`${logPrefix}: tombstoning images`, { count: ids.length });
                 await removeImagesFromLibrary(ids);
                 setImages(prev => prev.filter(img => !ids.includes(img.id)));
                 addToast(`Removed ${ids.length} image${ids.length === 1 ? '' : 's'} from the library`, 'success');
-                await refreshCollectionThumbnails();
             }
-            await rebuildFacetCache();
-            incrementFacetCacheVersion();
+
+            if (!permanent) {
+                try {
+                    console.info(`${logPrefix}: refreshing collection thumbnails`);
+                    await refreshCollectionThumbnails();
+                } catch (thumbnailError) {
+                    console.error(`${logPrefix}: collection thumbnail refresh failed`, thumbnailError);
+                    addToast('Removed from library, but collection thumbnails may need a refresh.', 'warning');
+                }
+            }
+
+            try {
+                console.info(`${logPrefix}: rebuilding facet cache`);
+                await rebuildFacetCache();
+                rebuildSucceeded = true;
+            } catch (facetError) {
+                console.error(`${logPrefix}: facet rebuild failed`, facetError);
+            }
+
+            if (rebuildSucceeded) {
+                incrementFacetCacheVersion();
+            } else {
+                addToast('Library update succeeded, but filters may take a moment to refresh.', 'info');
+            }
         } catch (e) {
-            console.error("Failed to delete images", e);
+            console.error(`${logPrefix}: mutation failed`, e);
             addToast("Failed to update library state", "error");
         }
     }, [setImages, addToast, refreshCollectionThumbnails, incrementFacetCacheVersion]);

--- a/src/services/db/__tests__/imageRepo.test.ts
+++ b/src/services/db/__tests__/imageRepo.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+    convertFileSrc: (path: string) => `asset://${path}`,
+}));
+
+vi.mock('../../../bindings', () => ({
+    commands: {
+        saveImagesBatch: vi.fn(),
+        moveToTrash: vi.fn(),
+        deleteThumbnail: vi.fn(),
+        rebuildFacetCache: vi.fn(),
+        rebuildFacetCacheIncremental: vi.fn(),
+    }
+}));
+
+const dispatchMock = vi.fn(async (fn: () => Promise<unknown>) => fn());
+const getDbMock = vi.fn();
+
+vi.mock('../connection', () => ({
+    dbMutex: {
+        dispatch: (...args: unknown[]) => dispatchMock(...args as [() => Promise<unknown>]),
+    },
+    getDb: () => getDbMock(),
+}));
+
+describe('imageRepo batch removal', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('chunks multi-image library removal so large selections do not exceed sqlite parameter limits', async () => {
+        const ids = Array.from({ length: 1001 }, (_, index) => `C:/images/${index}.png`);
+        const imageRowsById = new Map(ids.map((id, index) => [id, {
+            id,
+            path: id,
+            width: 512,
+            height: 512,
+            file_size: 1024 + index,
+            timestamp: 1700000000000 + index,
+            metadata_json: JSON.stringify({ model: 'test', tool: 'ComfyUI' }),
+            thumbnail_path: `C:/thumbs/${index}.webp`,
+            micro_thumbnail: null,
+            thumbnail_source: 'ambit',
+            is_favorite: 0,
+            is_pinned: 0,
+            is_missing: 0,
+            user_masked: null,
+            group_id: null,
+            board_id: null,
+            notes: null,
+            original_metadata_json: null,
+            original_parsed_json: null,
+            original_state_json: null,
+            is_corrupt: 0,
+        }]));
+        const membershipRowsById = new Map(ids.map(id => [id, [{ image_id: id, collection_id: 'collection-a' }]]));
+        const removedRows = new Map<string, { id: string; collectionIdsJson: string | null }>();
+        const deletedImageIds = new Set<string>();
+
+        const enforceParamLimit = (params: unknown[] = []) => {
+            if (params.length > 900) {
+                throw new Error(`too many SQL variables: ${params.length}`);
+            }
+        };
+
+        const db = {
+            select: vi.fn(async (sql: string, params: string[] = []) => {
+                enforceParamLimit(params);
+                if (sql.includes('FROM images')) {
+                    return params.map(id => imageRowsById.get(id)).filter(Boolean);
+                }
+                if (sql.includes('FROM collection_images')) {
+                    return params.flatMap(id => membershipRowsById.get(id) ?? []);
+                }
+                return [];
+            }),
+            execute: vi.fn(async (sql: string, params: unknown[] = []) => {
+                enforceParamLimit(params);
+
+                if (sql.includes('INSERT OR REPLACE INTO removed_images')) {
+                    removedRows.set(params[0] as string, {
+                        id: params[0] as string,
+                        collectionIdsJson: (params[22] as string | null) ?? null,
+                    });
+                    return;
+                }
+
+                if (sql.startsWith('DELETE FROM images WHERE id IN')) {
+                    for (const id of params as string[]) {
+                        deletedImageIds.add(id);
+                    }
+                }
+            }),
+        };
+
+        getDbMock.mockResolvedValue(db);
+
+        const { removeImagesFromLibrary } = await import('../imageRepo');
+
+        await expect(removeImagesFromLibrary(ids)).resolves.toBeUndefined();
+
+        expect(dispatchMock).toHaveBeenCalledTimes(1);
+        expect(removedRows.size).toBe(ids.length);
+        expect(deletedImageIds.size).toBe(ids.length);
+        expect(db.select).toHaveBeenCalled();
+        expect(db.execute).toHaveBeenCalled();
+
+        const allSelectParamCounts = db.select.mock.calls.map(([, params]) => (params as unknown[] | undefined)?.length ?? 0);
+        const allExecuteParamCounts = db.execute.mock.calls.map(([, params]) => (params as unknown[] | undefined)?.length ?? 0);
+        expect(Math.max(...allSelectParamCounts)).toBeLessThanOrEqual(900);
+        expect(Math.max(...allExecuteParamCounts)).toBeLessThanOrEqual(900);
+        expect(removedRows.get(ids[0])?.collectionIdsJson).toBe(JSON.stringify(['collection-a']));
+    });
+});

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -2,7 +2,7 @@ import { commands } from '../../bindings';
 import { unwrap } from '../../utils/spectaUtils';
 import { AIImage, GeneratorTool } from '../../types';
 import { getDb, dbMutex } from './connection';
-import { mapRowToImage, IMAGE_FIELDS_LIGHT } from './repoUtils';
+import { mapRowToImage, IMAGE_FIELDS_LIGHT, REMOVED_IMAGE_FIELDS } from './repoUtils';
 import { normalizePath, urlToPath } from '../../utils/pathUtils';
 import {
     debugLiveWatchPerf,
@@ -357,6 +357,24 @@ export const getImagesByIds = async (ids: string[]): Promise<AIImage[]> => {
     return allImages;
 };
 
+export const getRemovedImagesByIds = async (ids: string[]): Promise<AIImage[]> => {
+    if (ids.length === 0) return [];
+    const db = await getDb();
+
+    const CHUNK_SIZE = 900;
+    let allImages: AIImage[] = [];
+
+    for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+        const chunk = ids.slice(i, i + CHUNK_SIZE).map(normalizePath);
+        const placeholders = chunk.map(() => '?').join(',');
+        const query = `SELECT ${REMOVED_IMAGE_FIELDS} FROM removed_images WHERE id IN (${placeholders})`;
+        const rows = await db.select<any[]>(query, chunk);
+        allImages = [...allImages, ...rows.map(mapRowToImage)];
+    }
+
+    return allImages;
+};
+
 export const getImageWithFullMetadata = async (id: string): Promise<AIImage | null> => {
     const db = await getDb();
     const normalizedId = normalizePath(id);
@@ -427,7 +445,140 @@ export const toggleImageIntermediate = async (id: string, isIntermediate: boolea
 export const deleteImage = async (id: string) => {
     const db = await getDb();
     const normalizedId = normalizePath(id);
+    await db.execute('DELETE FROM collection_images WHERE image_id = $1', [normalizedId]);
+    await db.execute('DELETE FROM image_loras WHERE image_id = $1', [normalizedId]);
+    await db.execute('DELETE FROM image_embeddings WHERE image_id = $1', [normalizedId]);
+    await db.execute('DELETE FROM image_hypernetworks WHERE image_id = $1', [normalizedId]);
+    await db.execute('DELETE FROM image_controlnets WHERE image_id = $1', [normalizedId]);
+    await db.execute('DELETE FROM image_ipadapters WHERE image_id = $1', [normalizedId]);
     await db.execute('DELETE FROM images WHERE id = $1', [normalizedId]);
+};
+
+const removeTombstones = async (db: Awaited<ReturnType<typeof getDb>>, ids: string[]) => {
+    if (ids.length === 0) return;
+    const placeholders = ids.map(() => '?').join(',');
+    await db.execute(`DELETE FROM removed_images WHERE id IN (${placeholders})`, ids);
+};
+
+export const removeImagesFromLibrary = async (ids: string[]) => {
+    if (ids.length === 0) return;
+
+    await dbMutex.dispatch(async () => {
+        const db = await getDb();
+        const normalizedIds = ids.map(normalizePath);
+        const placeholders = normalizedIds.map(() => '?').join(',');
+
+        const rows = await db.select<any[]>(
+            `SELECT id, path, width, height, file_size, timestamp, metadata_json, thumbnail_path, micro_thumbnail, thumbnail_source,
+                    is_favorite, is_pinned, is_missing, user_masked, group_id, board_id, notes,
+                    original_metadata_json, original_parsed_json, original_state_json, is_corrupt
+             FROM images
+             WHERE id IN (${placeholders})`,
+            normalizedIds
+        );
+
+        if (rows.length === 0) return;
+
+        const membershipRows = await db.select<{ image_id: string; collection_id: string }[]>(
+            `SELECT image_id, collection_id
+             FROM collection_images
+             WHERE image_id IN (${placeholders})`,
+            normalizedIds
+        );
+
+        const memberships = membershipRows.reduce<Record<string, string[]>>((acc, row) => {
+            if (!acc[row.image_id]) acc[row.image_id] = [];
+            acc[row.image_id].push(row.collection_id);
+            return acc;
+        }, {});
+
+        const removedAt = Date.now();
+        for (const row of rows) {
+            await db.execute(
+                `INSERT OR REPLACE INTO removed_images (
+                    id, path, width, height, file_size, timestamp, metadata_json, thumbnail_path, micro_thumbnail, thumbnail_source,
+                    is_favorite, is_pinned, is_missing, user_masked, group_id, board_id, notes,
+                    original_metadata_json, original_parsed_json, original_state_json, is_corrupt, removed_at, collection_ids_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                [
+                    row.id,
+                    row.path,
+                    row.width ?? null,
+                    row.height ?? null,
+                    row.file_size ?? null,
+                    row.timestamp,
+                    row.metadata_json ?? null,
+                    row.thumbnail_path ?? null,
+                    row.micro_thumbnail ?? null,
+                    row.thumbnail_source ?? null,
+                    row.is_favorite ?? 0,
+                    row.is_pinned ?? 0,
+                    row.is_missing ?? 0,
+                    row.user_masked ?? null,
+                    row.group_id ?? null,
+                    row.board_id ?? null,
+                    row.notes ?? null,
+                    row.original_metadata_json ?? null,
+                    row.original_parsed_json ?? null,
+                    row.original_state_json ?? null,
+                    row.is_corrupt ?? 0,
+                    removedAt,
+                    memberships[row.id] ? JSON.stringify(memberships[row.id]) : null
+                ]
+            );
+        }
+
+        await db.execute(`DELETE FROM collection_images WHERE image_id IN (${placeholders})`, normalizedIds);
+        await db.execute(`DELETE FROM image_loras WHERE image_id IN (${placeholders})`, normalizedIds);
+        await db.execute(`DELETE FROM image_embeddings WHERE image_id IN (${placeholders})`, normalizedIds);
+        await db.execute(`DELETE FROM image_hypernetworks WHERE image_id IN (${placeholders})`, normalizedIds);
+        await db.execute(`DELETE FROM image_controlnets WHERE image_id IN (${placeholders})`, normalizedIds);
+        await db.execute(`DELETE FROM image_ipadapters WHERE image_id IN (${placeholders})`, normalizedIds);
+        await db.execute(`DELETE FROM images WHERE id IN (${placeholders})`, normalizedIds);
+    });
+};
+
+export const restoreRemovedImages = async (ids: string[]) => {
+    if (ids.length === 0) return;
+
+    await dbMutex.dispatch(async () => {
+        const db = await getDb();
+        const normalizedIds = ids.map(normalizePath);
+        const placeholders = normalizedIds.map(() => '?').join(',');
+        const rows = await db.select<any[]>(
+            `SELECT ${REMOVED_IMAGE_FIELDS}, collection_ids_json FROM removed_images WHERE id IN (${placeholders})`,
+            normalizedIds
+        );
+
+        if (rows.length === 0) return;
+
+        const restoredImages = rows.map(row => ({
+            ...mapRowToImage(row),
+            isDeleted: false
+        }));
+
+        await insertImagesBatch(restoredImages);
+
+        for (const row of rows) {
+            if (!row.collection_ids_json) continue;
+
+            try {
+                const collectionIds = JSON.parse(row.collection_ids_json) as string[];
+                for (const collectionId of collectionIds) {
+                    await db.execute(
+                        `INSERT OR IGNORE INTO collection_images (collection_id, image_id)
+                         SELECT ?, ?
+                         WHERE EXISTS (SELECT 1 FROM collections WHERE id = ?)`,
+                        [collectionId, row.id, collectionId]
+                    );
+                }
+            } catch (error) {
+                console.warn('[DB] Failed to restore collection membership for removed image', row.id, error);
+            }
+        }
+
+        await removeTombstones(db, normalizedIds);
+    });
 };
 
 /**
@@ -460,6 +611,37 @@ export const deleteImageFromDisk = async (id: string, path: string, thumbnailPat
 
     // 3. Delete from DB
     await deleteImage(id);
+};
+
+export const deleteRemovedImageFromDisk = async (id: string) => {
+    const normalizedId = normalizePath(id);
+    const db = await getDb();
+    const rows = await db.select<any[]>(
+        `SELECT id, path, thumbnail_path FROM removed_images WHERE id = ?`,
+        [normalizedId]
+    );
+
+    if (rows.length === 0) return;
+
+    const row = rows[0];
+
+    if (row.path) {
+        try {
+            await unwrap(commands.moveToTrash(row.path));
+        } catch (e) {
+            console.error('[Repo] Failed to move removed file to trash:', row.path, e);
+        }
+    }
+
+    if (row.thumbnail_path) {
+        try {
+            await unwrap(commands.deleteThumbnail(row.thumbnail_path));
+        } catch (e) {
+            console.warn('[Repo] Failed to trash removed thumbnail:', row.thumbnail_path, e);
+        }
+    }
+
+    await db.execute('DELETE FROM removed_images WHERE id = ?', [normalizedId]);
 };
 
 export const markAsDeleted = async (ids: string[], deleted: boolean) => {

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -11,38 +11,106 @@ import {
     liveWatchNow,
 } from '../../utils/liveWatchPerf';
 
+type PersistableImageRecord = {
+    id: string;
+    path: string;
+    width: number;
+    height: number;
+    fileSize: number;
+    timestamp: number;
+    metadataJson: string;
+    thumbnailPath: string | null;
+    microThumbnail: string | null;
+    thumbnailSource: string | null;
+    isFavorite: boolean;
+    isPinned: boolean;
+    isDeleted: boolean;
+    isMissing: boolean;
+    userMasked: boolean | null;
+    groupId: string | null;
+    boardId: string | null;
+    notes: string | null;
+    originalMetadataJson: string | null;
+    originalStateJson: string | null;
+    isCorrupt: boolean;
+};
+
+export interface DeleteRemovedImagesResult {
+    deletedIds: string[];
+    failedIds: string[];
+    thumbnailWarningIds: string[];
+}
+
+const SQLITE_PARAM_CHUNK_SIZE = 900;
+
+const chunkItems = <T>(items: T[], chunkSize = SQLITE_PARAM_CHUNK_SIZE): T[][] => {
+    const chunks: T[][] = [];
+    for (let i = 0; i < items.length; i += chunkSize) {
+        chunks.push(items.slice(i, i + chunkSize));
+    }
+    return chunks;
+};
+
+const buildPersistableImageRecord = (image: AIImage): PersistableImageRecord => ({
+    id: normalizePath(image.id),
+    path: normalizePath(image.id),
+    width: image.width,
+    height: image.height,
+    fileSize: image.fileSize || 0,
+    timestamp: image.timestamp,
+    metadataJson: JSON.stringify(image.metadata),
+    thumbnailPath: urlToPath(image.thumbnailUrl),
+    microThumbnail: image.microThumbnail || null,
+    thumbnailSource: image.thumbnailSource || null,
+    isFavorite: !!image.isFavorite,
+    isPinned: !!image.isPinned,
+    isDeleted: !!image.isDeleted,
+    isMissing: !!image.isMissing,
+    userMasked: image.userMasked === true ? true : (image.userMasked === false ? false : null),
+    groupId: image.groupId || null,
+    boardId: image.boardId || null,
+    notes: image.notes || null,
+    originalMetadataJson: image.originalChunks ? JSON.stringify(image.originalChunks) : (image.originalMetadata ? JSON.stringify(image.originalMetadata) : null),
+    originalStateJson: image.originalState ? JSON.stringify(image.originalState) : null,
+    isCorrupt: !!image.isCorrupt
+});
+
+const persistImageRecords = async (
+    records: PersistableImageRecord[],
+    db: Awaited<ReturnType<typeof getDb>>
+) => {
+    const CHUNK_SIZE = 5000;
+    if (records.length > 0) {
+        console.log(`[RepoDebug] Saving batch. First record originalMetadataJson:`, records[0].originalMetadataJson ? records[0].originalMetadataJson.substring(0, 100) : 'NULL');
+    }
+
+    for (let i = 0; i < records.length; i += CHUNK_SIZE) {
+        const chunk = records.slice(i, i + CHUNK_SIZE);
+        try {
+            const chunkStartedAt = liveWatchNow();
+            await unwrap(commands.saveImagesBatch(chunk));
+            debugLiveWatchPerf('DB image batch persisted', {
+                batchIndex: Math.floor(i / CHUNK_SIZE) + 1,
+                chunkSize: chunk.length,
+                chunkMs: elapsedMs(chunkStartedAt)
+            });
+        } catch (e) {
+            console.error('[DB] Rust batch insert failed', e);
+            throw e;
+        }
+    }
+
+    await db.execute('UPDATE images SET user_masked = NULL WHERE user_masked = 0');
+};
+
 export const insertImage = async (image: AIImage) => {
     await dbMutex.dispatch(async () => {
-        // Reuse the batch logic for single inserts to keep SQL in sync (Rust-side)
-        const record = {
-            id: normalizePath(image.id),
-            path: normalizePath(image.id),
-            width: image.width,
-            height: image.height,
-            fileSize: image.fileSize || 0,
-            timestamp: image.timestamp,
-            metadataJson: JSON.stringify(image.metadata),
-            thumbnailPath: urlToPath(image.thumbnailUrl),
-            microThumbnail: image.microThumbnail || null,
-            thumbnailSource: image.thumbnailSource || null,
-            isFavorite: !!image.isFavorite,
-            isPinned: !!image.isPinned,
-            isDeleted: !!image.isDeleted,
-            isMissing: !!image.isMissing,
-            userMasked: image.userMasked === true ? true : (image.userMasked === false ? false : null),
-            groupId: image.groupId || null,
-            boardId: image.boardId || null,
-            notes: image.notes || null,
-            originalMetadataJson: image.originalChunks ? JSON.stringify(image.originalChunks) : (image.originalMetadata ? JSON.stringify(image.originalMetadata) : null),
-            originalStateJson: image.originalState ? JSON.stringify(image.originalState) : null,
-            isCorrupt: !!image.isCorrupt
-        };
-
-        await commands.saveImagesBatch([record]);
+        const db = await getDb();
+        const record = buildPersistableImageRecord(image);
+        await persistImageRecords([record], db);
 
         // Junction Table Sync
         if (image.boardId) {
-            const db = await getDb();
             await db.execute(
                 'INSERT OR IGNORE INTO collection_images (collection_id, image_id) VALUES (?, ?)',
                 [image.boardId, record.id]
@@ -56,54 +124,12 @@ export const insertImagesBatch = async (images: AIImage[]) => {
     const insertStartedAt = liveWatchNow();
 
     await dbMutex.dispatch(async () => {
-        const records = images.map(img => ({
-            id: normalizePath(img.id),
-            path: normalizePath(img.id),
-            width: img.width,
-            height: img.height,
-            fileSize: img.fileSize || 0,
-            timestamp: img.timestamp,
-            metadataJson: JSON.stringify(img.metadata),
-            thumbnailPath: urlToPath(img.thumbnailUrl),
-            microThumbnail: img.microThumbnail || null,
-            thumbnailSource: img.thumbnailSource || null,
-            isFavorite: !!img.isFavorite,
-            isPinned: !!img.isPinned,
-            isDeleted: !!img.isDeleted,
-            isMissing: !!img.isMissing,
-            userMasked: img.userMasked === true ? true : (img.userMasked === false ? false : null),
-            groupId: img.groupId || null,
-            boardId: img.boardId || null,
-            notes: img.notes || null,
-            originalMetadataJson: img.originalChunks ? JSON.stringify(img.originalChunks) : (img.originalMetadata ? JSON.stringify(img.originalMetadata) : null),
-            originalStateJson: img.originalState ? JSON.stringify(img.originalState) : null,
-            isCorrupt: !!img.isCorrupt
-        }));
-
-        const CHUNK_SIZE = 5000;
-        if (records.length > 0) {
-            console.log(`[RepoDebug] Saving batch. First record originalMetadataJson:`, records[0].originalMetadataJson ? records[0].originalMetadataJson.substring(0, 100) : 'NULL');
-        }
-        for (let i = 0; i < records.length; i += CHUNK_SIZE) {
-            const chunk = records.slice(i, i + CHUNK_SIZE);
-            try {
-                const chunkStartedAt = liveWatchNow();
-                await unwrap(commands.saveImagesBatch(chunk));
-                debugLiveWatchPerf('DB image batch persisted', {
-                    batchIndex: Math.floor(i / CHUNK_SIZE) + 1,
-                    chunkSize: chunk.length,
-                    chunkMs: elapsedMs(chunkStartedAt)
-                });
-            } catch (e) {
-                console.error('[DB] Rust batch insert failed', e);
-                throw e;
-            }
-        }
+        const db = await getDb();
+        const records = images.map(buildPersistableImageRecord);
+        await persistImageRecords(records, db);
     });
 
-    const cleanupStartedAt = liveWatchNow();
-    const db = await getDb();
-    await db.execute('UPDATE images SET user_masked = NULL WHERE user_masked = 0');
+    const cleanupStartedAt = insertStartedAt;
     debugLiveWatchPerf('DB user_masked cleanup complete', {
         imageCount: images.length,
         cleanupMs: elapsedMs(cleanupStartedAt)
@@ -456,8 +482,11 @@ export const deleteImage = async (id: string) => {
 
 const removeTombstones = async (db: Awaited<ReturnType<typeof getDb>>, ids: string[]) => {
     if (ids.length === 0) return;
-    const placeholders = ids.map(() => '?').join(',');
-    await db.execute(`DELETE FROM removed_images WHERE id IN (${placeholders})`, ids);
+
+    for (const chunk of chunkItems(ids)) {
+        const placeholders = chunk.map(() => '?').join(',');
+        await db.execute(`DELETE FROM removed_images WHERE id IN (${placeholders})`, chunk);
+    }
 };
 
 export const removeImagesFromLibrary = async (ids: string[]) => {
@@ -465,26 +494,37 @@ export const removeImagesFromLibrary = async (ids: string[]) => {
 
     await dbMutex.dispatch(async () => {
         const db = await getDb();
-        const normalizedIds = ids.map(normalizePath);
-        const placeholders = normalizedIds.map(() => '?').join(',');
+        const normalizedIds = Array.from(new Set(ids.map(normalizePath)));
+        const rows: any[] = [];
 
-        const rows = await db.select<any[]>(
-            `SELECT id, path, width, height, file_size, timestamp, metadata_json, thumbnail_path, micro_thumbnail, thumbnail_source,
-                    is_favorite, is_pinned, is_missing, user_masked, group_id, board_id, notes,
-                    original_metadata_json, original_parsed_json, original_state_json, is_corrupt
-             FROM images
-             WHERE id IN (${placeholders})`,
-            normalizedIds
-        );
+        console.info('[Repo] removeImagesFromLibrary: loading images', { count: normalizedIds.length });
+        for (const chunk of chunkItems(normalizedIds)) {
+            const placeholders = chunk.map(() => '?').join(',');
+            const chunkRows = await db.select<any[]>(
+                `SELECT id, path, width, height, file_size, timestamp, metadata_json, thumbnail_path, micro_thumbnail, thumbnail_source,
+                        is_favorite, is_pinned, is_missing, user_masked, group_id, board_id, notes,
+                        original_metadata_json, original_parsed_json, original_state_json, is_corrupt
+                 FROM images
+                 WHERE id IN (${placeholders})`,
+                chunk
+            );
+            rows.push(...chunkRows);
+        }
 
         if (rows.length === 0) return;
 
-        const membershipRows = await db.select<{ image_id: string; collection_id: string }[]>(
-            `SELECT image_id, collection_id
-             FROM collection_images
-             WHERE image_id IN (${placeholders})`,
-            normalizedIds
-        );
+        const membershipRows: { image_id: string; collection_id: string }[] = [];
+        console.info('[Repo] removeImagesFromLibrary: loading collection memberships', { count: normalizedIds.length });
+        for (const chunk of chunkItems(normalizedIds)) {
+            const placeholders = chunk.map(() => '?').join(',');
+            const chunkMembershipRows = await db.select<{ image_id: string; collection_id: string }[]>(
+                `SELECT image_id, collection_id
+                 FROM collection_images
+                 WHERE image_id IN (${placeholders})`,
+                chunk
+            );
+            membershipRows.push(...chunkMembershipRows);
+        }
 
         const memberships = membershipRows.reduce<Record<string, string[]>>((acc, row) => {
             if (!acc[row.image_id]) acc[row.image_id] = [];
@@ -493,6 +533,7 @@ export const removeImagesFromLibrary = async (ids: string[]) => {
         }, {});
 
         const removedAt = Date.now();
+        console.info('[Repo] removeImagesFromLibrary: persisting tombstones', { count: rows.length });
         for (const row of rows) {
             await db.execute(
                 `INSERT OR REPLACE INTO removed_images (
@@ -528,13 +569,17 @@ export const removeImagesFromLibrary = async (ids: string[]) => {
             );
         }
 
-        await db.execute(`DELETE FROM collection_images WHERE image_id IN (${placeholders})`, normalizedIds);
-        await db.execute(`DELETE FROM image_loras WHERE image_id IN (${placeholders})`, normalizedIds);
-        await db.execute(`DELETE FROM image_embeddings WHERE image_id IN (${placeholders})`, normalizedIds);
-        await db.execute(`DELETE FROM image_hypernetworks WHERE image_id IN (${placeholders})`, normalizedIds);
-        await db.execute(`DELETE FROM image_controlnets WHERE image_id IN (${placeholders})`, normalizedIds);
-        await db.execute(`DELETE FROM image_ipadapters WHERE image_id IN (${placeholders})`, normalizedIds);
-        await db.execute(`DELETE FROM images WHERE id IN (${placeholders})`, normalizedIds);
+        console.info('[Repo] removeImagesFromLibrary: cleaning related tables', { count: normalizedIds.length });
+        for (const chunk of chunkItems(normalizedIds)) {
+            const placeholders = chunk.map(() => '?').join(',');
+            await db.execute(`DELETE FROM collection_images WHERE image_id IN (${placeholders})`, chunk);
+            await db.execute(`DELETE FROM image_loras WHERE image_id IN (${placeholders})`, chunk);
+            await db.execute(`DELETE FROM image_embeddings WHERE image_id IN (${placeholders})`, chunk);
+            await db.execute(`DELETE FROM image_hypernetworks WHERE image_id IN (${placeholders})`, chunk);
+            await db.execute(`DELETE FROM image_controlnets WHERE image_id IN (${placeholders})`, chunk);
+            await db.execute(`DELETE FROM image_ipadapters WHERE image_id IN (${placeholders})`, chunk);
+            await db.execute(`DELETE FROM images WHERE id IN (${placeholders})`, chunk);
+        }
     });
 };
 
@@ -543,12 +588,16 @@ export const restoreRemovedImages = async (ids: string[]) => {
 
     await dbMutex.dispatch(async () => {
         const db = await getDb();
-        const normalizedIds = ids.map(normalizePath);
-        const placeholders = normalizedIds.map(() => '?').join(',');
-        const rows = await db.select<any[]>(
-            `SELECT ${REMOVED_IMAGE_FIELDS}, collection_ids_json FROM removed_images WHERE id IN (${placeholders})`,
-            normalizedIds
-        );
+        const normalizedIds = Array.from(new Set(ids.map(normalizePath)));
+        const rows: any[] = [];
+        for (const chunk of chunkItems(normalizedIds)) {
+            const placeholders = chunk.map(() => '?').join(',');
+            const chunkRows = await db.select<any[]>(
+                `SELECT ${REMOVED_IMAGE_FIELDS}, collection_ids_json FROM removed_images WHERE id IN (${placeholders})`,
+                chunk
+            );
+            rows.push(...chunkRows);
+        }
 
         if (rows.length === 0) return;
 
@@ -556,8 +605,13 @@ export const restoreRemovedImages = async (ids: string[]) => {
             ...mapRowToImage(row),
             isDeleted: false
         }));
-
-        await insertImagesBatch(restoredImages);
+        const restoreStartedAt = liveWatchNow();
+        const records = restoredImages.map(buildPersistableImageRecord);
+        await persistImageRecords(records, db);
+        infoLiveWatchPerf('restoreRemovedImages persisted restored records', {
+            imageCount: restoredImages.length,
+            totalMs: elapsedMs(restoreStartedAt)
+        });
 
         for (const row of rows) {
             if (!row.collection_ids_json) continue;
@@ -613,35 +667,69 @@ export const deleteImageFromDisk = async (id: string, path: string, thumbnailPat
     await deleteImage(id);
 };
 
-export const deleteRemovedImageFromDisk = async (id: string) => {
-    const normalizedId = normalizePath(id);
-    const db = await getDb();
-    const rows = await db.select<any[]>(
-        `SELECT id, path, thumbnail_path FROM removed_images WHERE id = ?`,
-        [normalizedId]
-    );
+export const deleteRemovedImageFromDisk = async (id: string): Promise<DeleteRemovedImagesResult> => {
+    return deleteRemovedImagesFromDisk([id]);
+};
 
-    if (rows.length === 0) return;
-
-    const row = rows[0];
-
-    if (row.path) {
-        try {
-            await unwrap(commands.moveToTrash(row.path));
-        } catch (e) {
-            console.error('[Repo] Failed to move removed file to trash:', row.path, e);
-        }
+export const deleteRemovedImagesFromDisk = async (ids: string[]): Promise<DeleteRemovedImagesResult> => {
+    if (ids.length === 0) {
+        return { deletedIds: [], failedIds: [], thumbnailWarningIds: [] };
     }
 
-    if (row.thumbnail_path) {
-        try {
-            await unwrap(commands.deleteThumbnail(row.thumbnail_path));
-        } catch (e) {
-            console.warn('[Repo] Failed to trash removed thumbnail:', row.thumbnail_path, e);
-        }
-    }
+    const normalizedIds = Array.from(new Set(ids.map(normalizePath)));
 
-    await db.execute('DELETE FROM removed_images WHERE id = ?', [normalizedId]);
+    return dbMutex.dispatch(async () => {
+        const db = await getDb();
+        const rows: any[] = [];
+        for (const chunk of chunkItems(normalizedIds)) {
+            const placeholders = chunk.map(() => '?').join(',');
+            const chunkRows = await db.select<any[]>(
+                `SELECT id, path, thumbnail_path FROM removed_images WHERE id IN (${placeholders})`,
+                chunk
+            );
+            rows.push(...chunkRows);
+        }
+
+        if (rows.length === 0) {
+            return { deletedIds: [], failedIds: [...normalizedIds], thumbnailWarningIds: [] };
+        }
+
+        const deletedIds: string[] = [];
+        const failedIds: string[] = [];
+        const thumbnailWarningIds: string[] = [];
+
+        for (const row of rows) {
+            if (row.path) {
+                try {
+                    await unwrap(commands.moveToTrash(row.path));
+                } catch (e) {
+                    console.error('[Repo] Failed to move removed file to trash:', row.path, e);
+                    failedIds.push(row.id);
+                    continue;
+                }
+            }
+
+            if (row.thumbnail_path) {
+                try {
+                    await unwrap(commands.deleteThumbnail(row.thumbnail_path));
+                } catch (e) {
+                    console.warn('[Repo] Failed to trash removed thumbnail:', row.thumbnail_path, e);
+                    thumbnailWarningIds.push(row.id);
+                }
+            }
+
+            deletedIds.push(row.id);
+        }
+
+        if (deletedIds.length > 0) {
+            await removeTombstones(db, deletedIds);
+        }
+
+        const missingIds = normalizedIds.filter(id => !rows.some(row => row.id === id));
+        failedIds.push(...missingIds);
+
+        return { deletedIds, failedIds, thumbnailWarningIds };
+    });
 };
 
 export const markAsDeleted = async (ids: string[], deleted: boolean) => {

--- a/src/services/db/maintenanceRepo.ts
+++ b/src/services/db/maintenanceRepo.ts
@@ -2,7 +2,7 @@ import { commands } from '../../bindings';
 import { unwrap } from '../../utils/spectaUtils';
 import { AIImage } from '../../types';
 import { getDb, dbMutex } from './connection';
-import { mapRowToImage, IMAGE_FIELDS_LIGHT } from './repoUtils';
+import { mapRowToImage, IMAGE_FIELDS_LIGHT, REMOVED_IMAGE_FIELDS } from './repoUtils';
 
 /**
  * Backfill the denormalized parameter columns (steps, cfg, sampler, generation_type).
@@ -87,7 +87,7 @@ export const pruneMissingLinks = async (ids: string[]): Promise<number> => {
 
 export const getDeletedImages = async (): Promise<AIImage[]> => {
     const db = await getDb();
-    const rows = await db.select<any[]>(`SELECT ${IMAGE_FIELDS_LIGHT} FROM images WHERE is_deleted = 1 ORDER BY timestamp DESC`);
+    const rows = await db.select<any[]>(`SELECT ${REMOVED_IMAGE_FIELDS} FROM removed_images ORDER BY removed_at DESC`);
     return rows.map(mapRowToImage);
 };
 
@@ -314,7 +314,7 @@ export const getMaintenanceCounts = async () => {
             COUNT(*) FILTER (WHERE (positive_prompt IS NULL OR positive_prompt = '') AND is_deleted = 0 AND IFNULL(is_intermediate_gen, 0) = 0) as untagged,
             COUNT(*) FILTER (WHERE is_missing = 1 AND is_deleted = 0) as missing,
             COUNT(*) FILTER (WHERE IFNULL(is_intermediate_gen, 0) = 1 AND is_deleted = 0) as intermediates,
-            COUNT(*) FILTER (WHERE is_deleted = 1) as trash
+            (SELECT COUNT(*) FROM removed_images) as trash
         FROM images
     `);
 

--- a/src/services/db/repoUtils.ts
+++ b/src/services/db/repoUtils.ts
@@ -14,6 +14,13 @@ export const IMAGE_FIELDS_LIGHT = `
     images.model_name, images.model_hash, images.tool, images.resolved_model_name
 `;
 
+export const REMOVED_IMAGE_FIELDS = `
+    id, path, width, height, file_size, timestamp, thumbnail_path, micro_thumbnail, thumbnail_source,
+    is_favorite, is_pinned, 0 as is_deleted, is_missing, user_masked, group_id, board_id, notes,
+    original_metadata_json, original_parsed_json, original_state_json, is_corrupt, metadata_json,
+    NULL as model_name, NULL as model_hash, NULL as tool, NULL as resolved_model_name
+`;
+
 // Helper to keep mapping consistent
 export function mapRowToImage(row: any): AIImage {
     const normalizedPath = normalizePath(row.path);

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -35,8 +35,10 @@ const getExistingPaths = async (paths: string[]): Promise<Set<string>> => {
         const chunk = paths.slice(i, i + CHUNK_SIZE).map(normalizePath);
         const placeholders = chunk.map(() => '?').join(',');
         const rows = await db.select<{ id: string }[]>(
-            `SELECT id FROM images WHERE id IN (${placeholders})`,
-            chunk
+            `SELECT id FROM images WHERE id IN (${placeholders})
+             UNION
+             SELECT id FROM removed_images WHERE id IN (${placeholders})`,
+            [...chunk, ...chunk]
         );
         rows.forEach(r => existingSet.add(r.id));
     }

--- a/src/stores/__tests__/collectionStore.test.ts
+++ b/src/stores/__tests__/collectionStore.test.ts
@@ -1,0 +1,93 @@
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCollectionStore } from '../collectionStore';
+import { FilterState } from '../../types';
+
+const mockGetSmartCollectionCounts = vi.fn();
+
+vi.mock('../libraryStore', () => ({
+    useLibraryStore: {
+        getState: () => ({
+            isImporting: false
+        })
+    }
+}));
+
+vi.mock('../../services/db/collectionRepo', () => ({
+    getSmartCollectionCounts: mockGetSmartCollectionCounts
+}));
+
+const resetCollectionStore = () => {
+    useCollectionStore.setState(useCollectionStore.getInitialState(), true);
+};
+
+describe('collectionStore smart count refresh', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        resetCollectionStore();
+    });
+
+    it('does not reintroduce a deleted collection when stale smart counts finish later', async () => {
+        const smartFilters: FilterState = {
+            searchQuery: 'banana',
+            models: [],
+            tools: [],
+            loras: [],
+            embeddings: [],
+            hypernetworks: [],
+            samplers: [],
+            generationTypes: [],
+            controlNets: [],
+            ipAdapters: [],
+            dateRange: 'all',
+            favoritesOnly: false,
+            collectionId: null
+        };
+        mockGetSmartCollectionCounts.mockResolvedValue({ 'smart-1': 42 });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    {
+                        id: 'smart-1',
+                        name: 'Smart One',
+                        createdAt: 1,
+                        updatedAt: 1,
+                        source: 'ambit',
+                        count: 0,
+                        imageIds: [],
+                        filters: smartFilters
+                    },
+                    {
+                        id: 'static-1',
+                        name: 'Static One',
+                        createdAt: 2,
+                        updatedAt: 2,
+                        source: 'ambit',
+                        count: 3,
+                        imageIds: []
+                    }
+                ],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshSmartCounts([
+            ...useCollectionStore.getState().collections
+        ]);
+
+        act(() => {
+            useCollectionStore.setState((state) => ({
+                collections: state.collections.filter((collection) => collection.id !== 'smart-1')
+            }));
+        });
+
+        await refreshPromise;
+
+        expect(useCollectionStore.getState().collections).toEqual([
+            expect.objectContaining({
+                id: 'static-1'
+            })
+        ]);
+    });
+});

--- a/src/stores/collectionStore.ts
+++ b/src/stores/collectionStore.ts
@@ -4,6 +4,7 @@ import { Collection, SmartCollection } from '../types';
 import { appRepository } from '../services/repository';
 
 let initPromise: Promise<void> | null = null;
+let smartCountRefreshToken = 0;
 
 interface CollectionState {
     collections: Collection[];
@@ -12,7 +13,7 @@ interface CollectionState {
     // Actions
     initialize: () => Promise<void>;
     refreshCollections: (debounced?: boolean) => Promise<void>;
-    refreshSmartCounts: () => Promise<void>;
+    refreshSmartCounts: (collectionsSnapshot?: Collection[]) => Promise<void>;
     setCollections: (collections: Collection[] | ((prev: Collection[]) => Collection[])) => void;
 }
 
@@ -31,8 +32,9 @@ export const useCollectionStore = create<CollectionState>()(
                         const cols = await getAllCollectionsWithStats();
                         set({ collections: cols });
 
-                        // Lazily fetch smart counts in the background
-                        get().refreshSmartCounts();
+                        // Lazily fetch smart counts in the background without
+                        // allowing stale snapshots to overwrite newer collection state.
+                        void get().refreshSmartCounts(cols);
                     } catch (e) {
                         console.error('[CollectionStore] Failed to refresh collections', e);
                     }
@@ -52,8 +54,9 @@ export const useCollectionStore = create<CollectionState>()(
                 }
             },
 
-            refreshSmartCounts: async () => {
+            refreshSmartCounts: async (collectionsSnapshot?: Collection[]) => {
                 try {
+                    const requestToken = ++smartCountRefreshToken;
                     const { useLibraryStore } = await import('./libraryStore');
                     if (useLibraryStore.getState().isImporting) {
                         console.log('[CollectionStore] Skipping smart counts refresh - Import already in progress');
@@ -61,21 +64,26 @@ export const useCollectionStore = create<CollectionState>()(
                     }
 
                     const { getSmartCollectionCounts } = await import('../services/db/collectionRepo');
-                    const currentCols = get().collections;
+                    const currentCols = collectionsSnapshot ?? get().collections;
                     const smartCols = currentCols.filter(c => !!c.filters);
 
                     if (smartCols.length === 0) return;
 
                     const counts = await getSmartCollectionCounts(smartCols);
 
-                    // Update only the smart collection counts without replacing entire array reference
-                    set({
-                        collections: currentCols.map(c =>
+                    if (requestToken !== smartCountRefreshToken) {
+                        return;
+                    }
+
+                    // Merge counts onto the latest state instead of reusing an older
+                    // snapshot, so deletes or other collection changes are not resurrected.
+                    set((state) => ({
+                        collections: state.collections.map(c =>
                             c.filters && counts[c.id] !== undefined
                                 ? { ...c, count: counts[c.id] }
                                 : c
                         )
-                    });
+                    }));
                 } catch (e) {
                     console.error('[CollectionStore] Failed to refresh smart counts', e);
                 }
@@ -168,7 +176,7 @@ export const useCollectionStore = create<CollectionState>()(
                         set({ collections: dbCols, isLoaded: true });
 
                         // Lazily fetch smart collection counts after initial render
-                        get().refreshSmartCounts();
+                        void get().refreshSmartCounts(dbCols);
                     } catch (e) {
                         console.error('[CollectionStore] Failed to initialize', e);
                         set({ isLoaded: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,6 +201,7 @@ export interface MonitoredFolder {
   imageCount: number;
   lastScanned?: number; // Timestamp of last successful full/partial scan
   variant?: GeneratorTool; // Store the detected/assigned variant
+  initialScanPending?: boolean; // Suppress duplicate auto-scan until the first queued scan completes
 }
 
 export interface AppSettings {


### PR DESCRIPTION
﻿## Summary

This branch captures the release-prep fixes and test tracking from the staged QA pass.

## What changed

- Stabilized manual import paths and prompt-recovery gating.
- Added tombstone-backed `Remove from Library` behavior so removed files stay on disk and are not re-imported by rescans.
- Fixed Phase 3 search/viewer issues, including facet behavior, compare fit, slideshow progress, and prompt-toggle wording.
- Stabilized Phase 4 trust flows: remove, restore, delete file, context-menu targeting, multi-select delete confirmation, and interrupted-import recovery.
- Added a release test checklist with known limitations and deferred release-process work.

## Why

Release testing found several trust-sensitive issues around library removal, restore, interrupted imports, and ambiguous release readiness. These changes make the app behavior safer while keeping larger follow-up investigations separate.

## Known deferred work

- Auto-updater signing and artifact validation.
- `0.4.0` version/tag/release-please alignment.
- Production performance and pinning stalls.
- Duplicate detection redesign for same-binary renamed files.
- Search/smart collection loading UX polish.

## Validation

- `pnpm run build`
- `pnpm run test:rust` during Phase 0
- Focused Vitest runs for import, app actions, app handlers, folder monitor, global modals, confirm dialog, and image repo batch removal
- Manual packaged-app testing through Phase 1-6 release-pass flows

## Notes

This is intentionally a draft PR because release-process blockers remain outside this branch.
