### PR TITLE
[codex] adjust database backup defaults

### DIFF
--- a/src-tauri/src/db/backup.rs
+++ b/src-tauri/src/db/backup.rs
@@ -4,7 +4,7 @@ use crate::db::{configure_connection, resolve_db_path};
 use chrono::{DateTime, Local};
 use std::fs;
 
-const BACKUP_RETENTION_COUNT: usize = 5;
+const BACKUP_RETENTION_COUNT: usize = 3;
 
 #[derive(serde::Serialize, specta::Type, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -123,17 +123,21 @@ pub fn run() {
                 }
             });
 
-            // 2. Run auto-backup check in background
-            let handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                // Wait a bit for app to settle
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                match db::backup::check_and_run_autobackup(handle).await {
-                    Ok(Some(info)) => log::info!("[Backup] Auto-backup created: {}", info.name),
-                    Ok(None) => log::info!("[Backup] Auto-backup skipped (recent backup exists)"),
-                    Err(e) => log::error!("[Backup] Auto-backup failed: {}", e),
-                }
-            });
+            // 2. Run auto-backup check in background for production builds only.
+            if cfg!(debug_assertions) {
+                log::info!("[Backup] Auto-backup skipped in development build");
+            } else {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    // Wait a bit for app to settle
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    match db::backup::check_and_run_autobackup(handle).await {
+                        Ok(Some(info)) => log::info!("[Backup] Auto-backup created: {}", info.name),
+                        Ok(None) => log::info!("[Backup] Auto-backup skipped (recent backup exists)"),
+                        Err(e) => log::error!("[Backup] Auto-backup failed: {}", e),
+                    }
+                });
+            }
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/src/features/settings/components/BackupSettings.tsx
+++ b/src/features/settings/components/BackupSettings.tsx
@@ -105,7 +105,7 @@ export const BackupSettings: React.FC = () => {
                         <p>No backups found</p>
                     </div>
                 ) : (
-                    backups.slice(0, 5).map((backup) => (
+                    backups.slice(0, 3).map((backup) => (
                         <div key={backup.name} className="flex items-center justify-between p-3 bg-gray-50 dark:bg-black/20 rounded-lg border border-transparent hover:border-gray-200 dark:hover:border-white/10 transition-colors group">
                             <div className="flex items-center gap-3">
                                 <div className="p-2 bg-white dark:bg-white/5 rounded-md text-sage-600 dark:text-sage-400">
@@ -122,9 +122,9 @@ export const BackupSettings: React.FC = () => {
                         </div>
                     ))
                 )}
-                {backups.length > 5 && (
+                {backups.length > 3 && (
                     <div className="text-center text-xs text-gray-500 pt-2">
-                        + {backups.length - 5} more archived backups
+                        + {backups.length - 3} more archived backups
                     </div>
                 )}
             </div>
@@ -132,8 +132,8 @@ export const BackupSettings: React.FC = () => {
             <div className="mt-4 flex items-start gap-2 p-3 bg-blue-50 dark:bg-blue-900/10 text-blue-700 dark:text-blue-300 rounded-lg text-xs">
                 <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
                 <p>
-                    Backups are created automatically once every 24 hours. The last 5 auto-backups are kept.
-                    Manual backups are kept indefinitely. To restore, please manually replace the <code>images.db</code> file.
+                    Production builds create backups automatically once every 24 hours. The newest 3 backups are kept.
+                    Development builds only create backups when you use Backup Now. To restore, please manually replace the <code>images.db</code> file.
                 </p>
             </div>
         </section>


### PR DESCRIPTION
## Summary

- Disable automatic startup database backups for development/debug builds while keeping manual backups available.
- Reduce database backup retention from 5 files to 3 files.
- Update the settings UI copy and displayed backup list to match the new retention behavior.

## Why

Development builds were creating automatic backups even when database backup behavior was not being tested, which can waste disk space. Production still keeps automatic daily backup protection, but with a smaller retention window.

## Validation

- `pnpm run test:rust`
- `pnpm run build`