### PR TITLE
[codex] show image skeletons during placeholder queries

### DIFF
--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -81,9 +81,9 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         data: queryData,
         fetchNextPage,
         hasNextPage,
-        isFetching,
         isFetchingNextPage,
-        isLoading: isQueryLoading
+        isLoading: isQueryLoading,
+        isPlaceholderData
     } = useImagesQuery({
         filters,
         sortOption,
@@ -315,7 +315,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                 queryClient.invalidateQueries({ queryKey: ['images'] });
                 queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
             },
-            isFiltering: isQueryLoading,
+            isFiltering: isQueryLoading || isPlaceholderData,
             activeSqlWhere,
             activeSqlParams,
             refreshMetadata,


### PR DESCRIPTION
## Summary

- Show the image grid loading skeleton while React Query is serving placeholder data for a changed image query.
- Preserve the existing infinite-scroll footer spinner for next-page loads.
- Merge the latest `origin/main`, including the upstream Tauri `default-run = "app"` fix for the `cargo run` binary-selection error.

## Root Cause

The image query intentionally keeps previous pages as placeholder data during search and filter changes. `SearchContext` only exposed `isLoading` as `isFiltering`, so the grid kept rendering stale images while the new query was in progress.

## Validation

- `pnpm exec vitest run src/contexts/__tests__/SearchContext.test.tsx src/components/__tests__/AppLayout.test.tsx`
- `pnpm run build`