### PR TITLE
[codex] Harden monitored folder catch-up imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -218,7 +218,7 @@ export default function App() {
     useFolderMonitor({
         isLoaded,
         monitoredFolders: settings.monitoredFolders,
-        onScan: (folders) => fileOps.handleImportFolders(folders),
+        onScan: (folders, isStartup) => fileOps.handleImportFolders(folders, isStartup),
         handleImportPaths: fileOps.handleImportPaths,
         addToast,
         refreshMetadata,

--- a/src/components/GlobalModals.tsx
+++ b/src/components/GlobalModals.tsx
@@ -12,6 +12,7 @@ import { DonationModal } from './ui/DonationModal';
 import { CollectionEditorModal } from '../features/collections/components/CollectionEditorModal';
 import { AIImage, AppSettings } from '../types';
 import { AppUpdaterStatus } from '../hooks/useAppUpdater';
+import type { ImportResult } from '../services/importService';
 
 interface GlobalModalsProps {
     modals: Record<string, boolean>;
@@ -52,7 +53,7 @@ interface GlobalModalsProps {
     filters?: any;
     collectionToEditId?: string | null;
     onSaveCollectionFilters?: (id: string, filters: any) => void;
-    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<void>;
+    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>;
     onInvokeSync?: () => Promise<void>; // Trigger InvokeAI database sync
     hasPendingUpdate: boolean;
     pendingUpdateVersion: string | null;

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -530,6 +530,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     const { processTargetedFiles } = await import('../services/importService');
                     const result = await processTargetedFiles(nextBatch, {
                         forceRescan: true,
+                        waitForStableFiles: true,
                         onProgress: (current, total, message) => {
                             updateLiveWatchSession({
                                 source: 'generic',
@@ -564,22 +565,8 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         });
                     }
 
-                    if (result.handledPaths.length > 0) {
-                        // Keep the catch-up cursor aligned only for files we actually handled.
-                        const { updateFolderLastScanned } = useSettingsStore.getState();
-                        const monitoredFolders = settingsRef.current.monitoredFolders || [];
-                        const now = Date.now();
-                        const updatedFolderIds = new Set<string>();
-
-                        result.handledPaths.forEach(path => {
-                            const lowerPath = path.toLowerCase();
-                            const folder = monitoredFolders.find(f => lowerPath.startsWith(f.path.replace(/\\/g, '/').toLowerCase()));
-                            if (folder && !updatedFolderIds.has(folder.id)) {
-                                updatedFolderIds.add(folder.id);
-                                updateFolderLastScanned(folder.id, now);
-                            }
-                        });
-                    }
+                    // Targeted watcher events do not prove the whole folder has been swept.
+                    // The startup/catch-up scanner owns the monitored-folder cursor.
 
                     infoLiveWatchPerf('Targeted live cycle complete', {
                         cycleId: cyclePerfContext?.cycleId,

--- a/src/features/settings/components/ConnectionsTab.tsx
+++ b/src/features/settings/components/ConnectionsTab.tsx
@@ -3,12 +3,13 @@ import { useState, useEffect } from 'react';
 import { Folder, DatabaseZap, Palette, FlaskConical } from 'lucide-react';
 import { AppSettings } from '../../../types';
 import { FoldersTab, InvokeAITab, A1111Tab, ComfyUITab } from './';
+import type { ImportResult } from '../../../services/importService';
 
 interface ConnectionsTabProps {
     settings: AppSettings;
     setSettings: React.Dispatch<React.SetStateAction<AppSettings>>;
     initialSubTab?: 'folders' | 'invokeai' | 'a1111' | 'comfyui';
-    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<void>;
+    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>;
     onInvokeSync?: () => Promise<void>; // Trigger InvokeAI database sync
     onClose?: () => void;
 }

--- a/src/features/settings/components/FoldersTab.tsx
+++ b/src/features/settings/components/FoldersTab.tsx
@@ -10,11 +10,12 @@ import { useMetadataRefresh } from '../../../hooks/useMetadataRefresh';
 import { useLibraryContext } from '../../../contexts/LibraryContext';
 import { useToast } from '../../../hooks/useToast';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
+import type { ImportResult } from '../../../services/importService';
 
 interface TabProps {
     settings: AppSettings;
     setSettings: React.Dispatch<React.SetStateAction<AppSettings>>;
-    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<void>;
+    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>;
     onInvokeSync?: () => Promise<void>;
 }
 

--- a/src/features/settings/components/SettingsModal.tsx
+++ b/src/features/settings/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import { GeneralTab, PrivacyTab, IntelligenceTab, DevTab, AdvancedTab, Connectio
 import { APP_NAME } from '../../../constants/app';
 import { AppUpdaterStatus } from '../../../hooks/useAppUpdater';
 import { useAppVersion } from '../../../hooks/useAppVersion';
+import type { ImportResult } from '../../../services/importService';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -15,7 +16,7 @@ interface SettingsModalProps {
   onSave: (settings: AppSettings) => void;
   canCheckForUpdates: boolean;
   initialTab?: 'general' | 'folders' | 'privacy' | 'experiments' | 'intelligence' | 'invokeai' | 'a1111' | 'comfyui' | 'dev';
-  onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<void>;
+  onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>;
   onInvokeSync?: () => Promise<void>; // Trigger InvokeAI database sync
   hasPendingUpdate: boolean;
   pendingUpdateVersion: string | null;

--- a/src/features/settings/hooks/useFoldersTabLogic.ts
+++ b/src/features/settings/hooks/useFoldersTabLogic.ts
@@ -7,7 +7,7 @@ import { useLibraryStore } from '../../../stores/libraryStore';
 import { commands } from '../../../bindings';
 import { normalizePath } from '../../../utils/pathUtils';
 import { unwrap } from '../../../utils/spectaUtils';
-import { scanResourceThumbnails, processNativePaths } from '../../../services/importService';
+import { scanResourceThumbnails, processNativePaths, type ImportResult } from '../../../services/importService';
 
 // Helper to detect generator from path
 const detectGeneratorVariant = (path: string): GeneratorTool => {
@@ -29,7 +29,7 @@ const getInvokeRootPath = (path: string): string => {
 interface UseFoldersTabLogicProps {
     settings: AppSettings;
     setSettings: React.Dispatch<React.SetStateAction<AppSettings>>;
-    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<void>;
+    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>;
     onInvokeSync?: () => Promise<void>;
 }
 
@@ -54,6 +54,9 @@ export const useFoldersTabLogic = ({
         isScanningDiscovery, setIsScanningDiscovery,
         discoveryScanProgress, isPopulatingThumbnails
     } = useLibraryStore();
+
+    const isCompleteImport = (result: ImportResult | void): result is ImportResult =>
+        !!result && result.failedPaths.length === 0;
 
     const fetchCounts = useCallback(async () => {
         if (!settings.monitoredFolders.length && !settings.invokeAiPath) return;
@@ -142,10 +145,16 @@ export const useFoldersTabLogic = ({
                                 },
                                 variant as GeneratorTool | undefined,
                                 undefined,
-                                false
+                                false,
+                                true,
+                                true
                             );
                             addToast(`Synced ${result.images.length} new files`, 'success');
-                            updateFolderLastScanned(id, Date.now());
+                            if (result.failedPaths.length === 0) {
+                                updateFolderLastScanned(id, Date.now());
+                            } else {
+                                console.warn(`[Resync] Keeping cursor unchanged for ${path}; ${result.failedPaths.length} file(s) failed.`);
+                            }
                         } finally {
                             setIsImporting(false);
                             setImportProgress(null);
@@ -157,6 +166,7 @@ export const useFoldersTabLogic = ({
                         if (allFiles.length > knownCount) {
                             const repairPaths = allFiles.map(f => f.path);
                             const { setIsImporting, setImportProgress } = useLibraryStore.getState();
+                            let repairFailedCount = 0;
                             setIsImporting(true);
                             setImportProgress({ current: 0, total: repairPaths.length, message: 'Repairing incomplete import...' });
 
@@ -173,6 +183,7 @@ export const useFoldersTabLogic = ({
                                     undefined,
                                     false
                                 );
+                                repairFailedCount = result.failedPaths.length;
                                 addToast(
                                     result.images.length > 0
                                         ? `Repair scan imported ${result.images.length} missing files`
@@ -183,15 +194,25 @@ export const useFoldersTabLogic = ({
                                 setIsImporting(false);
                                 setImportProgress(null);
                             }
+                            if (repairFailedCount === 0) {
+                                updateFolderLastScanned(id, Date.now());
+                            } else {
+                                console.warn(`[Resync] Keeping cursor unchanged for ${path}; ${repairFailedCount} repair file(s) failed.`);
+                            }
                         } else {
                             addToast(`No changes detected`, 'info');
+                            updateFolderLastScanned(id, Date.now());
                         }
-                        updateFolderLastScanned(id, Date.now());
                     }
                 } else {
-                    await onScanFolder([{ path, variant }]);
-                    updateFolderLastScanned(id, Date.now());
-                    addToast(`Rescan complete`, 'success');
+                    const result = await onScanFolder([{ path, variant }]);
+                    if (isCompleteImport(result)) {
+                        updateFolderLastScanned(id, Date.now());
+                        addToast(`Rescan complete`, 'success');
+                    } else {
+                        console.warn(`[Resync] Keeping cursor unchanged for ${path}; full scan did not fully complete.`);
+                        addToast(`Rescan completed with import errors`, 'warning');
+                    }
                 }
             }
             await fetchCounts();
@@ -245,16 +266,28 @@ export const useFoldersTabLogic = ({
             const foldersToScan = [...pendingScansRef.current];
             pendingScansRef.current = [];
             try {
-                await onScanFolder(foldersToScan.map(({ path, variant }) => ({ path, variant })));
-                const completedAt = Date.now();
-                setSettings(prev => ({
-                    ...prev,
-                    monitoredFolders: prev.monitoredFolders.map(folder =>
-                        foldersToScan.some(pending => pending.id === folder.id)
-                            ? { ...folder, lastScanned: completedAt, initialScanPending: false }
-                            : folder
-                    )
-                }));
+                const result = await onScanFolder(foldersToScan.map(({ path, variant }) => ({ path, variant })));
+                if (isCompleteImport(result)) {
+                    const completedAt = Date.now();
+                    setSettings(prev => ({
+                        ...prev,
+                        monitoredFolders: prev.monitoredFolders.map(folder =>
+                            foldersToScan.some(pending => pending.id === folder.id)
+                                ? { ...folder, lastScanned: completedAt, initialScanPending: false }
+                                : folder
+                        )
+                    }));
+                } else {
+                    setSettings(prev => ({
+                        ...prev,
+                        monitoredFolders: prev.monitoredFolders.map(folder =>
+                            foldersToScan.some(pending => pending.id === folder.id)
+                                ? { ...folder, lastScanned: undefined, initialScanPending: false }
+                                : folder
+                        )
+                    }));
+                    addToast('Folder scan completed with import errors', 'warning');
+                }
                 await fetchCounts();
             } catch (e) {
                 console.error('Auto-scan failed:', e);

--- a/src/hooks/useFolderMonitor.ts
+++ b/src/hooks/useFolderMonitor.ts
@@ -7,19 +7,22 @@ import { unwrap } from '../utils/spectaUtils';
 // Need to access store actions directly since we are bypassing handleImportPaths state management
 import { useLibraryStore } from '../stores/libraryStore';
 import { isBrowserMockMode } from '../services/runtime';
+import type { ImportResult } from '../services/importService';
 
 interface ImportOptions {
     isStartup?: boolean;
     skipStateManagement?: boolean;
     onProgress?: (current: number, total: number, message?: string) => void;
+    forceRescan?: boolean;
+    waitForStableFiles?: boolean;
 }
 
 interface UseFolderMonitorProps {
     isLoaded: boolean;
     monitoredFolders: MonitoredFolder[];
-    onScan: (folders: { path: string, variant?: string }[], isStartup: boolean) => Promise<void>;
+    onScan: (folders: { path: string, variant?: string }[], isStartup: boolean) => Promise<ImportResult | void>;
     // Update signature to match new options
-    handleImportPaths: (paths: string[], defaultTool?: GeneratorTool, options?: ImportOptions) => Promise<void>;
+    handleImportPaths: (paths: string[], defaultTool?: GeneratorTool, options?: ImportOptions) => Promise<ImportResult | void>;
     addToast: (msg: string, type: 'info' | 'success' | 'error') => void;
     refreshMetadata: () => Promise<void>;
     invokeAiPath?: string;
@@ -31,6 +34,14 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
     const hasScannedOnStartup = useRef(false);
     const updateFolderLastScanned = useSettingsStore(s => s.updateFolderLastScanned);
     const browserMockMode = isBrowserMockMode();
+
+    const isCompleteImport = (result: ImportResult | void): result is ImportResult =>
+        !!result && result.failedPaths.length === 0;
+
+    const warnCursorHeld = (source: string, folderId: string, result: ImportResult | void) => {
+        const failedCount = result ? result.failedPaths.length : null;
+        console.warn(`[FolderMonitor] ${source}: Keeping folder cursor unchanged for ${folderId}; ${failedCount ?? 'unknown'} path(s) were not fully handled.`);
+    };
 
     useEffect(() => {
         if (browserMockMode) {
@@ -68,12 +79,11 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     if (folder.lastScanned) {
                         try {
                             console.log(`[FolderMonitor] Smart Scan for ${folder.path}`);
-                            // Cast because bindings aren't regenerated yet
-                            const newFiles = await unwrap((commands as any).scanDirectorySince(folder.path, folder.lastScanned)) as { path: string }[];
+                            const newFiles = await unwrap(commands.scanDirectorySince(folder.path, folder.lastScanned));
 
                             if (newFiles && newFiles.length > 0) {
                                 console.log(`[FolderMonitor] Found ${newFiles.length} new files in ${folder.path}`);
-                                const paths = newFiles.map((f: any) => f.path);
+                                const paths = newFiles.map(f => f.path);
                                 tasks.push({ paths, variant: folder.variant, folderId: folder.id });
                                 totalFilesFound += paths.length;
                             } else {
@@ -86,8 +96,12 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     } else {
                         // Full scan usage (rare on startup if already configured)
                         console.log(`[FolderMonitor] Full Scan for ${folder.path} (first time)`);
-                        await onScan([{ path: folder.path, variant: folder.variant }], true);
-                        updateFolderLastScanned(folder.id, scanTime);
+                        const result = await onScan([{ path: folder.path, variant: folder.variant }], true);
+                        if (isCompleteImport(result)) {
+                            updateFolderLastScanned(folder.id, scanTime);
+                        } else {
+                            warnCursorHeld('Startup full scan', folder.id, result);
+                        }
                     }
                 }
                 console.info('[Startup Catch-up] Folder scan phase complete.', {
@@ -107,9 +121,11 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
 
                     for (const task of tasks) {
                         // We use skipStateManagement: true to prevent handleImportPaths from resetting our global progress
-                        await handleImportPaths(task.paths, task.variant, {
+                        const result = await handleImportPaths(task.paths, task.variant, {
                             isStartup: true,
                             skipStateManagement: true,
+                            forceRescan: true,
+                            waitForStableFiles: true,
                             onProgress: (current, total, message) => {
                                 // Add accumulated count from previous batches
                                 const actualCurrent = globalCurrent + current;
@@ -122,7 +138,11 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                         });
                         globalCurrent += task.paths.length;
                         // ONLY update once successfully imported
-                        updateFolderLastScanned(task.folderId, scanTime);
+                        if (isCompleteImport(result)) {
+                            updateFolderLastScanned(task.folderId, scanTime);
+                        } else {
+                            warnCursorHeld('Startup incremental scan', task.folderId, result);
+                        }
                     }
 
                     setIsImporting(false);
@@ -176,10 +196,14 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     }
 
                     const scanData = activeNew.map(f => ({ path: f.path, variant: f.variant }));
-                    await onScan(scanData, false);
+                    const result = await onScan(scanData, false);
 
-                    const completedAt = Date.now();
-                    activeNew.forEach(f => updateFolderLastScanned(f.id, completedAt));
+                    if (isCompleteImport(result)) {
+                        const completedAt = Date.now();
+                        activeNew.forEach(f => updateFolderLastScanned(f.id, completedAt));
+                    } else {
+                        activeNew.forEach(f => warnCursorHeld('New folder scan', f.id, result));
+                    }
                 })();
             }
         }
@@ -220,23 +244,27 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
     const performUnifiedScan = async (folders: MonitoredFolder[], source: string) => {
         const { setIsImporting, setImportProgress } = useLibraryStore.getState();
         let totalFilesFound = 0;
-        const tasks: any[] = [];
+        const tasks: { paths: string[], variant: GeneratorTool | undefined, folderId: string }[] = [];
         const scanTime = Date.now();
 
         for (const folder of folders) {
             try {
                 if (folder.lastScanned) {
-                    const newFiles = await unwrap((commands as any).scanDirectorySince(folder.path, folder.lastScanned)) as { path: string }[];
+                    const newFiles = await unwrap(commands.scanDirectorySince(folder.path, folder.lastScanned));
                     if (newFiles.length > 0) {
-                        tasks.push({ paths: newFiles.map((f: any) => f.path), variant: folder.variant, folderId: folder.id });
+                        tasks.push({ paths: newFiles.map(f => f.path), variant: folder.variant, folderId: folder.id });
                         totalFilesFound += newFiles.length;
                     } else {
                         updateFolderLastScanned(folder.id, scanTime);
                     }
                 } else {
                     console.log(`[FolderMonitor] ${source}: Full scan needed for ${folder.path}`);
-                    await onScan([{ path: folder.path, variant: folder.variant }], false);
-                    updateFolderLastScanned(folder.id, scanTime);
+                    const result = await onScan([{ path: folder.path, variant: folder.variant }], false);
+                    if (isCompleteImport(result)) {
+                        updateFolderLastScanned(folder.id, scanTime);
+                    } else {
+                        warnCursorHeld(`${source} full scan`, folder.id, result);
+                    }
                 }
             } catch (e) {
                 console.error(`[FolderMonitor] ${source} failed for ${folder.path}`, e);
@@ -248,8 +276,10 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
             setImportProgress({ current: 0, total: totalFilesFound, message: `${source}: Importing images...` });
             let currentCount = 0;
             for (const task of tasks) {
-                await handleImportPaths(task.paths, task.variant, {
+                const result = await handleImportPaths(task.paths, task.variant, {
                     skipStateManagement: true,
+                    forceRescan: true,
+                    waitForStableFiles: true,
                     onProgress: (c, t, m) => setImportProgress({ 
                         current: currentCount + c, 
                         total: totalFilesFound, 
@@ -257,7 +287,11 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     })
                 });
                 currentCount += task.paths.length;
-                updateFolderLastScanned(task.folderId, scanTime);
+                if (isCompleteImport(result)) {
+                    updateFolderLastScanned(task.folderId, scanTime);
+                } else {
+                    warnCursorHeld(`${source} incremental scan`, task.folderId, result);
+                }
             }
             setIsImporting(false);
             setImportProgress(null);

--- a/src/hooks/useImportOps.ts
+++ b/src/hooks/useImportOps.ts
@@ -12,6 +12,8 @@ interface ImportOptions {
     isStartup?: boolean;
     skipStateManagement?: boolean;
     onProgress?: (current: number, total: number, message?: string) => void;
+    forceRescan?: boolean;
+    waitForStableFiles?: boolean;
 }
 
 interface UseImportOpsProps {
@@ -140,7 +142,13 @@ export const useImportOps = ({
     }, [setIsImporting, setImportProgress, setImportAbortController, extractNativePaths, commitImportResult, addToast]);
 
     const handleImportPaths = useCallback(async (paths: string[], defaultTool?: GeneratorTool, options: ImportOptions = {}) => {
-        const { isStartup = false, skipStateManagement = false, onProgress: externalOnProgress } = options;
+        const {
+            isStartup = false,
+            skipStateManagement = false,
+            onProgress: externalOnProgress,
+            forceRescan = false,
+            waitForStableFiles = isStartup
+        } = options;
 
         if (paths.length === 0 && isStartup) return;
 
@@ -159,8 +167,18 @@ export const useImportOps = ({
                 }
             };
 
-            const result = await processNativePaths(paths, thumbDir, onProgress, defaultTool, abortCtrl.signal, isStartup);
+            const result = await processNativePaths(
+                paths,
+                thumbDir,
+                onProgress,
+                defaultTool,
+                abortCtrl.signal,
+                isStartup,
+                forceRescan,
+                waitForStableFiles
+            );
             await commitImportResult(result, isStartup);
+            return result;
         } catch (error) {
             console.error("Import error", error);
             if (!isStartup) addToast("Import failed or cancelled", "error");
@@ -208,6 +226,7 @@ export const useImportOps = ({
                     addToast('No images found in selected folders', 'info');
                 }
             }
+            return result;
         } catch (error) {
             console.error('[ImportFolders] Error:', error);
             if (!isStartup) addToast('Import failed', 'error');
@@ -332,7 +351,7 @@ export const useImportOps = ({
                 variant as GeneratorTool | undefined,
                 abortCtrl.signal,
                 false,
-                false
+                isIncremental
             );
 
             if (result.images.length > 0) {

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -66,6 +66,7 @@ export interface ImportOptions {
     isStartup?: boolean;
     forceRescan?: boolean;
     skipThumbnail?: boolean;
+    waitForStableFiles?: boolean;
     perfContext?: TargetedLiveSyncPerfContext;
 }
 
@@ -73,6 +74,54 @@ interface FileEntry {
     path: string;
     modified: number;
     size: number;
+}
+
+const FILE_STABILITY_POLL_MS = 500;
+const FILE_STABILITY_MAX_POLLS = 12;
+const FILE_STABILITY_REQUIRED_POLLS = 2;
+
+const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+async function waitForStableFileSizes(
+    paths: string[],
+    onProgress?: (current: number, total: number, message?: string) => void
+) {
+    if (paths.length === 0) return;
+
+    const states = new Map<string, { size: number; stablePolls: number }>();
+    let pendingPaths = [...paths];
+
+    for (let poll = 0; poll < FILE_STABILITY_MAX_POLLS && pendingPaths.length > 0; poll++) {
+        onProgress?.(0, paths.length, `Waiting for ${pendingPaths.length} file(s) to finish writing...`);
+
+        let sizes: number[] = [];
+        try {
+            sizes = await unwrap(commands.getFileSizesBulk(pendingPaths));
+        } catch (error) {
+            console.warn('[Import] File stability probe failed; retrying before import.', error);
+            await delay(FILE_STABILITY_POLL_MS);
+            continue;
+        }
+
+        pendingPaths = pendingPaths.filter((path, index) => {
+            const size = sizes[index] ?? 0;
+            const previous = states.get(path);
+            const stablePolls = size > 0 && previous?.size === size
+                ? previous.stablePolls + 1
+                : 0;
+
+            states.set(path, { size, stablePolls });
+            return stablePolls < FILE_STABILITY_REQUIRED_POLLS;
+        });
+
+        if (pendingPaths.length > 0) {
+            await delay(FILE_STABILITY_POLL_MS);
+        }
+    }
+
+    if (pendingPaths.length > 0) {
+        console.warn(`[Import] ${pendingPaths.length} file(s) did not stabilize before import; continuing.`);
+    }
 }
 
 const mapMetadata = (meta: any) => ({
@@ -95,7 +144,7 @@ async function processFileEntries(
     options: ImportOptions = {},
     defaultTool?: GeneratorTool
 ): Promise<{ images: AIImage[]; handledPaths: string[]; failedPaths: string[] }> {
-    const { onProgress, abortSignal, forceRescan, skipThumbnail = true, perfContext } = options;
+    const { onProgress, abortSignal, forceRescan, skipThumbnail = true, waitForStableFiles, perfContext } = options;
     const newImages: AIImage[] = [];
     const handledPaths: string[] = [];
     const failedPaths: string[] = [];
@@ -139,6 +188,10 @@ async function processFileEntries(
             totalMs: elapsedMs(importStartedAt)
         });
         return { images: [], handledPaths, failedPaths };
+    }
+
+    if (waitForStableFiles) {
+        await waitForStableFileSizes(pathsToProcess, onProgress);
     }
 
     const BATCH_SIZE = 300;
@@ -523,7 +576,8 @@ export const processNativePaths = async (
     defaultTool?: GeneratorTool,
     abortSignal?: AbortSignal,
     isStartup: boolean = false,
-    forceRescan: boolean = false
+    forceRescan: boolean = false,
+    waitForStableFiles: boolean = isStartup
 ): Promise<ImportResult> => {
 
     // Convert string[] list to typed inputs for unified processor
@@ -537,6 +591,7 @@ export const processNativePaths = async (
         abortSignal,
         isStartup,
         forceRescan,
+        waitForStableFiles,
         skipThumbnail: false
     });
 };
@@ -592,4 +647,3 @@ export const scanResourceThumbnails = async (paths: string[]): Promise<{ found: 
         return { found: 0, updated: 0 };
     }
 };
-


### PR DESCRIPTION
## Summary

- Add a file-size stability wait before live/startup targeted imports so ComfyUI images are less likely to be parsed before writes finish.
- Keep monitored-folder `lastScanned` cursors unchanged when full or incremental imports report failed paths.
- Stop advancing monitored-folder cursors from targeted watcher events; startup/catch-up sweeps own the durable cursor.
- Forward the startup scan flag correctly from `App.tsx` into folder imports.

## Root Cause

Watcher events can arrive before an image writer has fully closed the file. If the targeted live import fails or partially imports that path and the folder cursor advances anyway, startup catch-up can skip the missed image on the next run.

## Validation

- `pnpm run build`
- `pnpm exec vitest run src/hooks/__tests__/useFolderMonitor.test.ts src/contexts/__tests__/LibraryIntegration.test.tsx`
- `pnpm exec tsc --noEmit` was also checked; it still reports pre-existing repository type errors outside this patch path.