### PR TITLE
Add backend Smart Thumbnail optimizer

### DIFF
--- a/src-tauri/src/db/commands/image_commands.rs
+++ b/src-tauri/src/db/commands/image_commands.rs
@@ -118,8 +118,10 @@ fn save_images_batch_inner(
         use crate::metadata::CURRENT_PARSER_VERSION;
 
         let mut stmt = tx.prepare_cached(
-            "INSERT INTO images (id, path, width, height, file_size, file_hash, timestamp, metadata_json, thumbnail_path, micro_thumbnail, thumbnail_source, is_favorite, is_pinned, is_deleted, is_missing, user_masked, group_id, board_id, notes, original_metadata_json, original_state_json, is_corrupt, model_hash, model_name, tool, resolved_model_name, steps, cfg, sampler, generation_type, parser_version, original_parsed_json, positive_prompt, negative_prompt)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
+            "INSERT INTO images (id, path, width, height, file_size, file_hash, timestamp, metadata_json, thumbnail_path, micro_thumbnail, thumbnail_source, thumbnail_version, is_favorite, is_pinned, is_deleted, is_missing, user_masked, group_id, board_id, notes, original_metadata_json, original_state_json, is_corrupt, model_hash, model_name, tool, resolved_model_name, steps, cfg, sampler, generation_type, parser_version, original_parsed_json, positive_prompt, negative_prompt)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+                    CASE WHEN ?11 = 'ambit' AND ?9 IS NOT NULL AND ?9 != '' AND ?2 != ?9 THEN 1 ELSE 0 END,
+                    ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22,
                     json_extract(?8, '$.modelHash'),
                     json_extract(?8, '$.model'),
                     json_extract(?8, '$.tool'),
@@ -141,7 +143,34 @@ fn save_images_batch_inner(
                     metadata_json=excluded.metadata_json,
                     thumbnail_path=COALESCE(NULLIF(excluded.thumbnail_path, ''), images.thumbnail_path),
                     micro_thumbnail=COALESCE(excluded.micro_thumbnail, images.micro_thumbnail),
-                    thumbnail_source=COALESCE(excluded.thumbnail_source, images.thumbnail_source),
+                    thumbnail_source=CASE
+                        WHEN NULLIF(excluded.thumbnail_path, '') IS NOT NULL
+                             AND images.thumbnail_path IS NOT excluded.thumbnail_path THEN excluded.thumbnail_source
+                        ELSE images.thumbnail_source
+                    END,
+                    thumbnail_version=CASE
+                        WHEN NULLIF(excluded.thumbnail_path, '') IS NOT NULL
+                             AND images.thumbnail_path IS NOT excluded.thumbnail_path
+                             AND excluded.thumbnail_source = 'ambit' THEN excluded.thumbnail_version
+                        WHEN NULLIF(excluded.thumbnail_path, '') IS NOT NULL
+                             AND images.thumbnail_path IS NOT excluded.thumbnail_path THEN 0
+                        ELSE images.thumbnail_version
+                    END,
+                    thumbnail_failure_count=CASE
+                        WHEN NULLIF(excluded.thumbnail_path, '') IS NOT NULL
+                             AND images.thumbnail_path IS NOT excluded.thumbnail_path THEN 0
+                        ELSE images.thumbnail_failure_count
+                    END,
+                    thumbnail_last_error=CASE
+                        WHEN NULLIF(excluded.thumbnail_path, '') IS NOT NULL
+                             AND images.thumbnail_path IS NOT excluded.thumbnail_path THEN NULL
+                        ELSE images.thumbnail_last_error
+                    END,
+                    thumbnail_last_attempt_at=CASE
+                        WHEN NULLIF(excluded.thumbnail_path, '') IS NOT NULL
+                             AND images.thumbnail_path IS NOT excluded.thumbnail_path THEN NULL
+                        ELSE images.thumbnail_last_attempt_at
+                    END,
                     is_favorite=excluded.is_favorite,
                     is_pinned=excluded.is_pinned,
                     group_id=COALESCE(images.group_id, excluded.group_id),
@@ -166,6 +195,7 @@ fn save_images_batch_inner(
                     OR images.timestamp != excluded.timestamp
                     OR images.file_size != excluded.file_size
                     OR images.file_hash IS NOT excluded.file_hash
+                    OR (NULLIF(excluded.thumbnail_path, '') IS NOT NULL AND images.thumbnail_path IS NOT excluded.thumbnail_path)
                     OR images.is_favorite IS NOT excluded.is_favorite
                     OR images.is_pinned IS NOT excluded.is_pinned
                     OR images.board_id IS NOT excluded.board_id
@@ -610,6 +640,48 @@ mod tests {
         }
     }
 
+    fn apply_all_migrations(conn: &Connection) {
+        for migration in init_db() {
+            conn.execute_batch(&migration.sql)
+                .expect("apply migrations");
+        }
+    }
+
+    fn fetch_thumbnail_state(
+        conn: &Connection,
+        id: &str,
+    ) -> (
+        String,
+        Option<String>,
+        i64,
+        i64,
+        Option<String>,
+        Option<i64>,
+    ) {
+        conn.query_row(
+            "SELECT thumbnail_path,
+                    thumbnail_source,
+                    thumbnail_version,
+                    thumbnail_failure_count,
+                    thumbnail_last_error,
+                    thumbnail_last_attempt_at
+             FROM images
+             WHERE id = ?1",
+            params![id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )
+        .expect("thumbnail state")
+    }
+
     #[test]
     fn upsert_updates_live_sync_controlled_fields_even_when_metadata_is_unchanged() {
         let conn = Connection::open_in_memory().expect("in-memory db");
@@ -759,13 +831,86 @@ mod tests {
     }
 
     #[test]
+    fn save_images_batch_resets_stale_ambit_source_when_external_thumbnail_replaces_path() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        apply_all_migrations(&conn);
+
+        let initial = create_image_record("img-source", 100, 200, "{}");
+        super::save_images_batch_inner(&conn, &[initial]).expect("initial save");
+
+        let mut external = create_image_record("img-source", 101, 201, "{}");
+        external.thumbnail_path = "C:/invoke/img-source.webp".to_string();
+        external.thumbnail_source = None;
+
+        super::save_images_batch_inner(&conn, &[external]).expect("external update");
+
+        let row = fetch_thumbnail_state(&conn, "img-source");
+        assert_eq!(row.0, "C:/invoke/img-source.webp");
+        assert_eq!(row.1, None);
+        assert_eq!(row.2, 0);
+    }
+
+    #[test]
+    fn save_images_batch_preserves_thumbnail_source_when_path_is_unchanged() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        apply_all_migrations(&conn);
+
+        let initial = create_image_record("img-same", 100, 200, "{}");
+        let unchanged_path = initial.thumbnail_path.clone();
+        super::save_images_batch_inner(&conn, &[initial]).expect("initial save");
+
+        let mut update = create_image_record("img-same", 101, 201, "{}");
+        update.thumbnail_path = unchanged_path;
+        update.thumbnail_source = None;
+
+        super::save_images_batch_inner(&conn, &[update]).expect("same path update");
+
+        let row = fetch_thumbnail_state(&conn, "img-same");
+        assert_eq!(row.1.as_deref(), Some("ambit"));
+        assert_eq!(row.2, 1);
+    }
+
+    #[test]
+    fn save_images_batch_marks_ambit_replacement_current_and_clears_failure_metadata() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        apply_all_migrations(&conn);
+
+        let mut initial = create_image_record("img-fixed", 100, 200, "{}");
+        initial.thumbnail_path = "C:/invoke/img-fixed.webp".to_string();
+        initial.thumbnail_source = Some("invokeai".to_string());
+        super::save_images_batch_inner(&conn, &[initial]).expect("initial external save");
+
+        conn.execute(
+            "UPDATE images
+             SET thumbnail_version = 0,
+                 thumbnail_failure_count = 2,
+                 thumbnail_last_error = 'decode failed',
+                 thumbnail_last_attempt_at = 42
+             WHERE id = 'img-fixed'",
+            [],
+        )
+        .expect("mark failure");
+
+        let mut repaired = create_image_record("img-fixed", 101, 201, "{}");
+        repaired.thumbnail_path = "C:/thumbs/img-fixed-repaired.webp".to_string();
+        repaired.thumbnail_source = Some("ambit".to_string());
+
+        super::save_images_batch_inner(&conn, &[repaired]).expect("ambit repair");
+
+        let row = fetch_thumbnail_state(&conn, "img-fixed");
+        assert_eq!(row.0, "C:/thumbs/img-fixed-repaired.webp");
+        assert_eq!(row.1.as_deref(), Some("ambit"));
+        assert_eq!(row.2, 1);
+        assert_eq!(row.3, 0);
+        assert_eq!(row.4, None);
+        assert_eq!(row.5, None);
+    }
+
+    #[test]
     fn save_images_batch_replaces_existing_junction_rows_when_metadata_changes() {
         let conn = Connection::open_in_memory().expect("in-memory db");
 
-        for migration in init_db() {
-            conn.execute_batch(&migration.sql)
-                .expect("apply migrations");
-        }
+        apply_all_migrations(&conn);
 
         let initial_metadata = r#"{
             "model": "Base Model",

--- a/src-tauri/src/db/migrations/m55_manual_thumbnail_lookup_index.rs
+++ b/src-tauri/src/db/migrations/m55_manual_thumbnail_lookup_index.rs
@@ -1,0 +1,52 @@
+use tauri_plugin_sql::{Migration, MigrationKind};
+
+/// Migration 55: Add index for manual thumbnail lookup during facet rebuilds.
+pub fn migration55() -> Migration {
+    Migration {
+        version: 55,
+        description: "add_manual_thumbnail_lookup_index",
+        sql: r#"
+            CREATE INDEX IF NOT EXISTS idx_images_thumbnail_path_lookup_v1
+                ON images(thumbnail_path)
+                WHERE thumbnail_path IS NOT NULL AND thumbnail_path != '';
+        "#,
+        kind: MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration55;
+
+    #[test]
+    fn migration_adds_manual_thumbnail_lookup_index() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "
+            CREATE TABLE images (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL,
+                thumbnail_path TEXT,
+                thumbnail_source TEXT
+            );
+            ",
+        )
+        .expect("setup schema");
+
+        conn.execute_batch(migration55().sql)
+            .expect("apply migration");
+
+        let index_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name = 'idx_images_thumbnail_path_lookup_v1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("index count");
+
+        assert_eq!(index_count, 1);
+    }
+}

--- a/src-tauri/src/db/migrations/m56_thumbnail_optimization.rs
+++ b/src-tauri/src/db/migrations/m56_thumbnail_optimization.rs
@@ -1,0 +1,78 @@
+use tauri_plugin_sql::Migration;
+
+pub fn migration56() -> Migration {
+    Migration {
+        version: 56,
+        description: "add_thumbnail_optimization_queue_metadata",
+        sql: r#"
+            ALTER TABLE images ADD COLUMN thumbnail_version INTEGER NOT NULL DEFAULT 1;
+            ALTER TABLE images ADD COLUMN thumbnail_failure_count INTEGER NOT NULL DEFAULT 0;
+            ALTER TABLE images ADD COLUMN thumbnail_last_error TEXT;
+            ALTER TABLE images ADD COLUMN thumbnail_last_attempt_at INTEGER;
+        "#,
+        kind: tauri_plugin_sql::MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration56;
+
+    #[test]
+    fn migration_adds_queue_columns_without_startup_queue_work() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "
+            CREATE TABLE images (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL,
+                thumbnail_path TEXT,
+                thumbnail_source TEXT,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                is_missing INTEGER NOT NULL DEFAULT 0,
+                is_intermediate_gen INTEGER NOT NULL DEFAULT 0,
+                is_corrupt INTEGER DEFAULT 0,
+                timestamp INTEGER NOT NULL
+            );
+
+            INSERT INTO images (id, path, thumbnail_path, thumbnail_source, timestamp)
+            VALUES
+                ('ambit', 'C:/library/ambit.png', 'C:/thumbs/ambit.webp', 'ambit', 2),
+                ('invoke', 'C:/library/invoke.png', 'C:/invoke/thumb.webp', 'invokeai', 1);
+            ",
+        )
+        .expect("setup schema");
+
+        conn.execute_batch(migration56().sql)
+            .expect("apply migration");
+
+        let ambit_version: i64 = conn
+            .query_row(
+                "SELECT thumbnail_version FROM images WHERE id = 'ambit'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("ambit version");
+        let invoke_version: i64 = conn
+            .query_row(
+                "SELECT thumbnail_version FROM images WHERE id = 'invoke'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("invoke version");
+        let index_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name = 'idx_images_thumbnail_optimization_queue_v1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("index count");
+
+        assert_eq!(ambit_version, 1);
+        assert_eq!(invoke_version, 1);
+        assert_eq!(index_count, 0);
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -21,6 +21,8 @@ pub mod m51_file_hash;
 pub mod m52_thumbnail_privacy;
 pub mod m53_live_facet_indexes;
 pub mod m54_resource_junction_covering_indexes;
+pub mod m55_manual_thumbnail_lookup_index;
+pub mod m56_thumbnail_optimization;
 
 pub fn init_db() -> Vec<Migration> {
     get_migrations()
@@ -51,6 +53,8 @@ pub fn get_migrations() -> Vec<Migration> {
     migrations.push(m52_thumbnail_privacy::migration52());
     migrations.push(m53_live_facet_indexes::migration53());
     migrations.push(m54_resource_junction_covering_indexes::migration54());
+    migrations.push(m55_manual_thumbnail_lookup_index::migration55());
+    migrations.push(m56_thumbnail_optimization::migration56());
 
     migrations.sort_by_key(|m| m.version);
 
@@ -62,7 +66,7 @@ mod tests {
     use super::get_migrations;
 
     #[test]
-    fn migrations_include_mainline_49_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_and_resource_indexes_54(
+    fn migrations_include_mainline_49_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_resource_indexes_54_manual_thumbnail_55_and_thumbnail_optimization_56(
     ) {
         let versions: Vec<i64> = get_migrations()
             .iter()
@@ -75,6 +79,8 @@ mod tests {
         assert!(versions.contains(&52));
         assert!(versions.contains(&53));
         assert!(versions.contains(&54));
+        assert!(versions.contains(&55));
+        assert!(versions.contains(&56));
     }
 
     #[test]
@@ -100,7 +106,7 @@ mod tests {
     }
 
     #[test]
-    fn database_at_mainline_49_has_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_and_resource_indexes_54_pending(
+    fn database_at_mainline_49_has_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_resource_indexes_54_manual_thumbnail_55_and_thumbnail_optimization_56_pending(
     ) {
         let migrations = get_migrations();
         let has_49 = migrations.iter().any(|migration| migration.version == 49);
@@ -111,6 +117,6 @@ mod tests {
             .collect();
 
         assert!(has_49);
-        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54]);
+        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54, 55, 56]);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,11 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         scanner::show_in_folder,
         scanner::scan_directory_with_stats,
         scanner::scan_directory_since,
+        thumb::optimizer::start_thumbnail_optimization_job,
+        thumb::optimizer::cancel_thumbnail_optimization_job,
+        thumb::optimizer::set_thumbnail_optimization_throttled,
+        thumb::optimizer::get_thumbnail_optimization_failures,
+        thumb::optimizer::retry_failed_thumbnail_optimizations,
         // watcher commands
         watcher::start_native_folder_watcher,
         // metadata commands
@@ -97,6 +102,7 @@ pub fn run() {
 
     // Check for deferred purge request BEFORE initializing the database
     check_and_execute_deferred_purge();
+    repair_known_migration_metadata();
 
     let log_level = std::env::var("RUST_LOG")
         .unwrap_or_else(|_| "info".to_string())
@@ -124,6 +130,7 @@ pub fn run() {
         .manage(ModelDiscoveryState::default())
         .manage(ReparseState::default())
         .manage(FileHashBackfillState::default())
+        .manage(thumb::optimizer::ThumbnailOptimizationState::default())
         .invoke_handler(builder.invoke_handler())
         .setup(|app| {
             app.handle()
@@ -245,6 +252,175 @@ fn check_and_execute_deferred_purge() {
             }
             if shm_path.exists() {
                 let _ = std::fs::remove_file(&shm_path);
+            }
+        }
+    }
+}
+
+/// Repair historical migration metadata for a known development/mainline collision.
+///
+/// Version 55 shipped as `add_manual_thumbnail_lookup_index` before this branch briefly
+/// reused 55 for thumbnail optimization metadata. SQLx validates migration checksums before
+/// applying new migrations, so databases with the already-applied manual lookup index must
+/// keep version 55 mapped to that same semantic migration. This only updates the checksum
+/// when the migration row and the index both prove that the manual lookup migration ran.
+#[cfg(not(test))]
+fn repair_known_migration_metadata() {
+    use sha2::{Digest, Sha384};
+
+    let mut paths_to_check = Vec::new();
+
+    if let Some(config_dir) = dirs::config_dir() {
+        paths_to_check.push(config_dir.join("com.ambit.app"));
+        paths_to_check.push(config_dir.join("com.ambit.dev"));
+        paths_to_check.push(config_dir.join("com.ambit.alpha"));
+        paths_to_check.push(config_dir.join("com.tauri.dev"));
+    }
+    if let Some(data_local_dir) = dirs::data_local_dir() {
+        paths_to_check.push(data_local_dir.join("com.ambit.app"));
+        paths_to_check.push(data_local_dir.join("com.ambit.dev"));
+        paths_to_check.push(data_local_dir.join("com.ambit.alpha"));
+        paths_to_check.push(data_local_dir.join("com.tauri.dev"));
+    }
+
+    let migration55 = db::migrations::m55_manual_thumbnail_lookup_index::migration55();
+    let expected_m55_checksum = Sha384::digest(migration55.sql.as_bytes()).to_vec();
+    let migration56 = db::migrations::m56_thumbnail_optimization::migration56();
+    let expected_m56_checksum = Sha384::digest(migration56.sql.as_bytes()).to_vec();
+
+    for app_dir in paths_to_check {
+        let db_path = app_dir.join("images.db");
+        if !db_path.exists() {
+            continue;
+        }
+
+        let Ok(conn) = rusqlite::Connection::open(&db_path) else {
+            continue;
+        };
+
+        let has_migrations_table = conn
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sqlite_master
+                 WHERE type = 'table'
+                   AND name = '_sqlx_migrations'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(0);
+
+        if has_migrations_table == 0 {
+            continue;
+        }
+
+        let applied_55 = conn.query_row(
+            "SELECT description, checksum
+             FROM _sqlx_migrations
+             WHERE version = 55",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        );
+
+        if let Ok((description, checksum)) = applied_55 {
+            if description == "add_manual_thumbnail_lookup_index"
+                && checksum != expected_m55_checksum
+            {
+                let has_manual_index = conn
+                    .query_row(
+                        "SELECT COUNT(*)
+                         FROM sqlite_master
+                         WHERE type = 'index'
+                           AND name = 'idx_images_thumbnail_path_lookup_v1'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .unwrap_or(0);
+
+                if has_manual_index > 0 {
+                    match conn.execute(
+                        "UPDATE _sqlx_migrations
+                         SET checksum = ?1
+                         WHERE version = 55
+                           AND description = 'add_manual_thumbnail_lookup_index'",
+                        rusqlite::params![&expected_m55_checksum],
+                    ) {
+                        Ok(updated) if updated > 0 => {
+                            println!(
+                                "[DB] Repaired checksum for migration 55 add_manual_thumbnail_lookup_index at {:?}",
+                                db_path
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            eprintln!(
+                                "[DB] Failed to repair migration 55 checksum at {:?}: {}",
+                                db_path, error
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let applied_56 = conn.query_row(
+            "SELECT description, checksum
+             FROM _sqlx_migrations
+             WHERE version = 56",
+            [],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+        );
+
+        let Ok((description_56, checksum_56)) = applied_56 else {
+            continue;
+        };
+
+        if description_56 != "add_thumbnail_optimization_queue_metadata"
+            || checksum_56 == expected_m56_checksum
+        {
+            continue;
+        }
+
+        let required_columns = [
+            "thumbnail_version",
+            "thumbnail_failure_count",
+            "thumbnail_last_error",
+            "thumbnail_last_attempt_at",
+        ];
+        let has_thumbnail_columns = required_columns.iter().all(|column| {
+            conn.query_row(
+                "SELECT COUNT(*)
+                 FROM pragma_table_info('images')
+                 WHERE name = ?1",
+                [*column],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(0)
+                > 0
+        });
+
+        if !has_thumbnail_columns {
+            continue;
+        }
+
+        match conn.execute(
+            "UPDATE _sqlx_migrations
+             SET checksum = ?1
+             WHERE version = 56
+               AND description = 'add_thumbnail_optimization_queue_metadata'",
+            rusqlite::params![&expected_m56_checksum],
+        ) {
+            Ok(updated) if updated > 0 => {
+                println!(
+                    "[DB] Repaired checksum for migration 56 add_thumbnail_optimization_queue_metadata at {:?}",
+                    db_path
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!(
+                    "[DB] Failed to repair migration 56 checksum at {:?}: {}",
+                    db_path, error
+                );
             }
         }
     }

--- a/src-tauri/src/thumb/mod.rs
+++ b/src-tauri/src/thumb/mod.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
+pub mod optimizer;
+
 #[derive(Debug, Clone)]
 pub struct ThumbnailResult {
     pub thumbnail_path: String,
@@ -12,6 +14,10 @@ pub struct ThumbnailResult {
     /// Original image dimensions (width, height).
     /// Only available when thumbnail was freshly generated (not cached).
     pub original_dimensions: Option<(u32, u32)>,
+    /// Whether the destination thumbnail file already existed.
+    pub was_cached: bool,
+    /// Time spent generating the thumbnail file. Cached hits report 0.
+    pub processing_ms: u128,
 }
 
 pub fn get_thumbnail_path(path: &str, thumbnail_dir: &str) -> PathBuf {
@@ -33,11 +39,17 @@ pub fn generate_thumbnail(path: &str, thumbnail_dir: &str) -> Result<ThumbnailRe
         }
     }
 
+    let mut was_cached = false;
+    let mut processing_ms = 0;
+
     let generated_thumbnail_path = if thumb_path.exists() {
         // Thumbnail cached - dimensions not available without reading original file
         // Scanner will handle this case with a separate dimension read
+        was_cached = true;
         thumb_path.to_string_lossy().to_string()
     } else {
+        let generation_started_at = std::time::Instant::now();
+
         // Need to generate - we'll capture dimensions from the decoded image
         let reader = Reader::open(path)
             .map_err(|e| format!("Failed to open image: {}", e))?
@@ -64,6 +76,8 @@ pub fn generate_thumbnail(path: &str, thumbnail_dir: &str) -> Result<ThumbnailRe
         fs::write(&thumb_path, &*webp_data)
             .map_err(|e| format!("Failed to save thumbnail: {}", e))?;
 
+        processing_ms = generation_started_at.elapsed().as_millis();
+
         thumb_path.to_string_lossy().to_string()
     };
 
@@ -75,5 +89,7 @@ pub fn generate_thumbnail(path: &str, thumbnail_dir: &str) -> Result<ThumbnailRe
         thumbnail_path: generated_thumbnail_path,
         micro_thumbnail: None, // Always returning None now
         original_dimensions,
+        was_cached,
+        processing_ms,
     })
 }

--- a/src-tauri/src/thumb/optimizer.rs
+++ b/src-tauri/src/thumb/optimizer.rs
@@ -1,0 +1,1542 @@
+use rayon::prelude::*;
+use rusqlite::{params, Connection};
+use std::fs;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tauri::Emitter;
+
+const CURRENT_THUMBNAIL_VERSION: i64 = 1;
+const FAILURE_BACKOFF_MS: i64 = 60 * 60 * 1000;
+const DB_FLUSH_LIMIT: usize = 100;
+const DB_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+const PROGRESS_EMIT_INTERVAL: Duration = Duration::from_secs(1);
+const THROTTLED_WORKER_CHUNK_SIZE: usize = 4;
+const THROTTLED_CHUNK_SLEEP: Duration = Duration::from_millis(250);
+const MAX_FAILURE_DIAGNOSTIC_LIMIT: usize = 50;
+
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub enum ThumbnailOptimizationProfile {
+    Quiet,
+    Balanced,
+    Fast,
+}
+
+impl ThumbnailOptimizationProfile {
+    fn worker_count(self) -> usize {
+        let available = std::thread::available_parallelism()
+            .map(|threads| threads.get())
+            .unwrap_or(2);
+
+        match self {
+            Self::Quiet => 1,
+            Self::Balanced => std::cmp::max(1, std::cmp::min(6, available / 2)),
+            Self::Fast => std::cmp::max(1, std::cmp::min(12, available.saturating_sub(1))),
+        }
+    }
+
+    fn fetch_limit(self) -> usize {
+        match self {
+            Self::Quiet => 100,
+            Self::Balanced => 500,
+            Self::Fast => 1000,
+        }
+    }
+
+    fn worker_chunk_size(self) -> usize {
+        match self {
+            Self::Quiet => 8,
+            Self::Balanced => 24,
+            Self::Fast => 48,
+        }
+    }
+
+    fn idle_yield(self) -> Duration {
+        match self {
+            Self::Quiet => Duration::from_millis(250),
+            Self::Balanced => Duration::from_millis(50),
+            Self::Fast => Duration::from_millis(0),
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailOptimizationConfig {
+    pub thumbnail_dir: String,
+    pub include_upgradeable: bool,
+    pub profile: ThumbnailOptimizationProfile,
+}
+
+#[derive(Clone, Debug, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailOptimizationProgress {
+    pub checked: usize,
+    pub total: usize,
+    pub optimized: usize,
+    pub reused: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub images_per_second: f64,
+    pub batch_ms: u64,
+    pub db_ms: u64,
+    pub encode_ms: u64,
+    pub profile: ThumbnailOptimizationProfile,
+    pub phase: String,
+    pub message: String,
+    pub is_throttled: bool,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailOptimizationResult {
+    pub checked: usize,
+    pub optimized: usize,
+    pub reused: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub was_cancelled: bool,
+    pub duration_ms: u64,
+}
+
+#[derive(Clone, Debug, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailOptimizationFailure {
+    pub id: String,
+    pub path: String,
+    pub thumbnail_path: Option<String>,
+    pub failure_count: i64,
+    pub last_error: Option<String>,
+    pub last_attempt_at: Option<i64>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ThumbnailOptimizationFailureList {
+    pub failures: Vec<ThumbnailOptimizationFailure>,
+}
+
+pub struct ThumbnailOptimizationState {
+    pub is_cancelled: Arc<AtomicBool>,
+    pub is_running: Arc<AtomicBool>,
+    pub is_throttled: Arc<AtomicBool>,
+}
+
+impl Default for ThumbnailOptimizationState {
+    fn default() -> Self {
+        Self {
+            is_cancelled: Arc::new(AtomicBool::new(false)),
+            is_running: Arc::new(AtomicBool::new(false)),
+            is_throttled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ThumbnailCandidate {
+    id: String,
+    path: String,
+    timestamp: i64,
+}
+
+#[derive(Clone, Debug)]
+struct ThumbnailCursor {
+    timestamp: i64,
+    id: String,
+}
+
+#[derive(Clone, Debug)]
+enum ThumbnailItemResult {
+    Success {
+        id: String,
+        thumbnail_path: String,
+        micro_thumbnail: Option<String>,
+        reused: bool,
+        processing_ms: u128,
+    },
+    Failed {
+        id: String,
+        error: String,
+    },
+    Skipped,
+}
+
+#[derive(Default)]
+struct BatchStats {
+    checked: usize,
+    optimized: usize,
+    reused: usize,
+    failed: usize,
+    skipped: usize,
+    encode_ms: u128,
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn start_thumbnail_optimization_job(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, ThumbnailOptimizationState>,
+    config: ThumbnailOptimizationConfig,
+) -> Result<ThumbnailOptimizationResult, String> {
+    if state.is_running.swap(true, Ordering::SeqCst) {
+        return Err("Thumbnail optimization is already running".to_string());
+    }
+
+    state.is_cancelled.store(false, Ordering::SeqCst);
+    state.is_throttled.store(false, Ordering::SeqCst);
+    let is_cancelled = state.is_cancelled.clone();
+    let is_running = state.is_running.clone();
+    let is_throttled = state.is_throttled.clone();
+
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        let result = run_thumbnail_optimization_job(app, is_cancelled, is_throttled, config);
+        is_running.store(false, Ordering::SeqCst);
+        result
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    result
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub fn cancel_thumbnail_optimization_job(state: tauri::State<'_, ThumbnailOptimizationState>) {
+    if request_thumbnail_cancellation(state.is_cancelled.as_ref()) {
+        log::info!("[ThumbnailOptimization] Cancellation requested");
+    }
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub fn set_thumbnail_optimization_throttled(
+    state: tauri::State<'_, ThumbnailOptimizationState>,
+    throttled: bool,
+) {
+    let previous = state.is_throttled.swap(throttled, Ordering::SeqCst);
+    if previous != throttled {
+        let status = if throttled { "enabled" } else { "disabled" };
+        log::info!("[ThumbnailOptimization] Throttling {status}");
+    }
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn get_thumbnail_optimization_failures(
+    app: tauri::AppHandle,
+    limit: usize,
+) -> Result<ThumbnailOptimizationFailureList, String> {
+    let db_path = crate::db::resolve_db_path(&app)?;
+    let capped_limit = limit.clamp(1, MAX_FAILURE_DIAGNOSTIC_LIMIT);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
+        crate::db::configure_connection(&conn).map_err(|e| e.to_string())?;
+        get_thumbnail_optimization_failures_for_conn(&conn, capped_limit)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn retry_failed_thumbnail_optimizations(app: tauri::AppHandle) -> Result<usize, String> {
+    let db_path = crate::db::resolve_db_path(&app)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
+        crate::db::configure_connection(&conn).map_err(|e| e.to_string())?;
+        retry_failed_thumbnail_optimizations_for_conn(&conn)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+fn run_thumbnail_optimization_job(
+    app: tauri::AppHandle,
+    is_cancelled: Arc<AtomicBool>,
+    is_throttled: Arc<AtomicBool>,
+    config: ThumbnailOptimizationConfig,
+) -> Result<ThumbnailOptimizationResult, String> {
+    let started_at = Instant::now();
+    let db_path = crate::db::resolve_db_path(&app)?;
+    let mut conn = Connection::open(&db_path).map_err(|e| e.to_string())?;
+    crate::db::configure_connection(&conn).map_err(|e| e.to_string())?;
+    conn.busy_timeout(Duration::from_secs(60))
+        .map_err(|e| e.to_string())?;
+
+    let worker_count = config.profile.worker_count();
+    let fetch_limit = config.profile.fetch_limit();
+    let worker_chunk_size = config.profile.worker_chunk_size();
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(worker_count)
+        .stack_size(8 * 1024 * 1024)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    log::info!(
+        "[ThumbnailOptimization] Starting job. profile={:?}, workers={}, fetch_limit={}, worker_chunk_size={}, include_upgradeable={}",
+        config.profile,
+        worker_count,
+        fetch_limit,
+        worker_chunk_size,
+        config.include_upgradeable
+    );
+
+    let mut result = ThumbnailOptimizationResult::default();
+    emit_progress(
+        &app,
+        &build_progress_payload(&result, started_at, config.profile, 0, 0, 0, false),
+    );
+
+    let stale_thumbnail_count = mark_current_ambit_thumbnails_stale_if_cache_missing_or_empty(
+        &conn,
+        &config.thumbnail_dir,
+    )?;
+    if stale_thumbnail_count > 0 {
+        log::info!(
+            "[ThumbnailOptimization] Thumbnail cache is missing or empty; marked {} Ambit thumbnails for regeneration",
+            stale_thumbnail_count
+        );
+    }
+
+    ensure_thumbnail_queue_index(&conn)?;
+
+    let mut cursor: Option<ThumbnailCursor> = None;
+    let mut pending_results: Vec<ThumbnailItemResult> = Vec::with_capacity(DB_FLUSH_LIMIT);
+    let mut last_progress_at = Instant::now();
+    let mut last_flush_at = Instant::now();
+    let mut last_batch_ms = 0;
+    let mut last_db_ms = 0;
+    let mut encode_ms_since_progress = 0_u128;
+
+    while !is_cancelled.load(Ordering::SeqCst) {
+        let candidates = fetch_thumbnail_candidates(
+            &conn,
+            config.include_upgradeable,
+            cursor.as_ref(),
+            fetch_limit,
+            unix_time_ms(),
+        )?;
+
+        if candidates.is_empty() {
+            break;
+        }
+
+        if let Some(last) = candidates.last() {
+            cursor = Some(ThumbnailCursor {
+                timestamp: last.timestamp,
+                id: last.id.clone(),
+            });
+        }
+
+        let mut index = 0;
+        while index < candidates.len() && !is_cancelled.load(Ordering::SeqCst) {
+            let throttled = is_throttled.load(Ordering::SeqCst);
+            let chunk_size = if throttled {
+                THROTTLED_WORKER_CHUNK_SIZE
+            } else {
+                worker_chunk_size
+            };
+            let end = std::cmp::min(index + chunk_size, candidates.len());
+            let chunk_started_at = Instant::now();
+
+            process_candidate_chunk(
+                &pool,
+                &candidates[index..end],
+                &config.thumbnail_dir,
+                is_cancelled.as_ref(),
+                |item| {
+                    encode_ms_since_progress += accumulate_thumbnail_result(&mut result, &item);
+
+                    if !matches!(item, ThumbnailItemResult::Skipped) {
+                        pending_results.push(item);
+                    }
+
+                    if pending_results.len() >= DB_FLUSH_LIMIT
+                        || last_flush_at.elapsed() >= DB_FLUSH_INTERVAL
+                    {
+                        last_db_ms = flush_pending_thumbnail_results(
+                            &mut conn,
+                            &mut pending_results,
+                            unix_time_ms(),
+                        )?;
+                        last_flush_at = Instant::now();
+                    }
+
+                    if last_progress_at.elapsed() >= PROGRESS_EMIT_INTERVAL {
+                        emit_progress(
+                            &app,
+                            &build_progress_payload(
+                                &result,
+                                started_at,
+                                config.profile,
+                                last_batch_ms,
+                                last_db_ms,
+                                millis_to_u64(encode_ms_since_progress),
+                                is_throttled.load(Ordering::SeqCst),
+                            ),
+                        );
+                        encode_ms_since_progress = 0;
+                        last_progress_at = Instant::now();
+                    }
+
+                    Ok(())
+                },
+            )?;
+
+            last_batch_ms = elapsed_ms(chunk_started_at);
+            index = end;
+
+            if is_throttled.load(Ordering::SeqCst) {
+                std::thread::sleep(THROTTLED_CHUNK_SLEEP);
+            }
+        }
+
+        if pending_results.len() >= DB_FLUSH_LIMIT || last_flush_at.elapsed() >= DB_FLUSH_INTERVAL {
+            last_db_ms =
+                flush_pending_thumbnail_results(&mut conn, &mut pending_results, unix_time_ms())?;
+            last_flush_at = Instant::now();
+        }
+
+        let yield_duration = config.profile.idle_yield();
+        if !yield_duration.is_zero() && !is_throttled.load(Ordering::SeqCst) {
+            std::thread::sleep(yield_duration);
+        }
+    }
+
+    last_db_ms = flush_pending_thumbnail_results(&mut conn, &mut pending_results, unix_time_ms())?;
+    result.was_cancelled = is_cancelled.load(Ordering::SeqCst);
+    result.duration_ms = elapsed_ms(started_at);
+    let completion_images_per_second = if result.duration_ms > 0 {
+        result.checked as f64 / (result.duration_ms as f64 / 1000.0)
+    } else {
+        0.0
+    };
+
+    emit_progress(
+        &app,
+        &build_progress_payload(
+            &result,
+            started_at,
+            config.profile,
+            last_batch_ms,
+            last_db_ms,
+            millis_to_u64(encode_ms_since_progress),
+            is_throttled.load(Ordering::SeqCst),
+        ),
+    );
+
+    log::info!(
+        "[ThumbnailOptimization] Complete. checked={}, optimized={}, reused={}, failed={}, skipped={}, cancelled={}, duration_ms={}, images_per_second={:.2}",
+        result.checked,
+        result.optimized,
+        result.reused,
+        result.failed,
+        result.skipped,
+        result.was_cancelled,
+        result.duration_ms,
+        completion_images_per_second
+    );
+
+    emit_complete(&app, &result);
+    Ok(result)
+}
+
+fn request_thumbnail_cancellation(is_cancelled: &AtomicBool) -> bool {
+    !is_cancelled.swap(true, Ordering::SeqCst)
+}
+
+fn get_thumbnail_optimization_failures_for_conn(
+    conn: &Connection,
+    limit: usize,
+) -> Result<ThumbnailOptimizationFailureList, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT id,
+                    path,
+                    thumbnail_path,
+                    COALESCE(thumbnail_failure_count, 0) AS failure_count,
+                    thumbnail_last_error,
+                    thumbnail_last_attempt_at
+             FROM images
+             WHERE is_deleted = 0
+               AND is_missing = 0
+               AND COALESCE(thumbnail_failure_count, 0) > 0
+             ORDER BY COALESCE(thumbnail_last_attempt_at, 0) DESC, id ASC
+             LIMIT ?1",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let failures = stmt
+        .query_map(params![limit as i64], |row| {
+            Ok(ThumbnailOptimizationFailure {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                thumbnail_path: row.get(2)?,
+                failure_count: row.get(3)?,
+                last_error: row.get(4)?,
+                last_attempt_at: row.get(5)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, rusqlite::Error>>()
+        .map_err(|e| e.to_string())?;
+
+    Ok(ThumbnailOptimizationFailureList { failures })
+}
+
+fn retry_failed_thumbnail_optimizations_for_conn(conn: &Connection) -> Result<usize, String> {
+    conn.execute(
+        "UPDATE images
+         SET thumbnail_failure_count = 0,
+             thumbnail_last_error = NULL,
+             thumbnail_last_attempt_at = NULL
+         WHERE is_deleted = 0
+           AND is_missing = 0
+           AND COALESCE(thumbnail_failure_count, 0) > 0",
+        [],
+    )
+    .map_err(|e| e.to_string())
+}
+
+fn mark_current_ambit_thumbnails_stale_if_cache_missing_or_empty(
+    conn: &Connection,
+    thumbnail_dir: &str,
+) -> Result<usize, String> {
+    if !thumbnail_cache_is_missing_or_empty(thumbnail_dir) {
+        return Ok(0);
+    }
+
+    conn.execute(
+        "UPDATE images
+         SET thumbnail_version = 0
+         WHERE thumbnail_source = 'ambit'
+           AND COALESCE(thumbnail_version, 0) >= ?1
+           AND thumbnail_path IS NOT NULL
+           AND thumbnail_path != ''
+           AND path != thumbnail_path",
+        params![CURRENT_THUMBNAIL_VERSION],
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn thumbnail_cache_is_missing_or_empty(thumbnail_dir: &str) -> bool {
+    let thumbnail_dir = Path::new(thumbnail_dir);
+    if !thumbnail_dir.exists() {
+        return true;
+    }
+
+    let entries = match fs::read_dir(thumbnail_dir) {
+        Ok(entries) => entries,
+        Err(error) => {
+            log::warn!(
+                "[ThumbnailOptimization] Could not inspect thumbnail cache directory: {}",
+                error
+            );
+            return false;
+        }
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("webp"))
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn ensure_thumbnail_queue_index(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        "
+        CREATE INDEX IF NOT EXISTS idx_images_thumbnail_optimization_queue_v1
+            ON images(
+                is_deleted,
+                is_missing,
+                is_corrupt,
+                is_intermediate_gen,
+                thumbnail_version,
+                thumbnail_failure_count,
+                thumbnail_last_attempt_at,
+                timestamp DESC,
+                id DESC
+            );
+        ",
+    )
+    .map_err(|error| error.to_string())
+}
+
+fn process_candidate_chunk<F>(
+    pool: &rayon::ThreadPool,
+    candidates: &[ThumbnailCandidate],
+    thumbnail_dir: &str,
+    is_cancelled: &AtomicBool,
+    mut handle_result: F,
+) -> Result<(), String>
+where
+    F: FnMut(ThumbnailItemResult) -> Result<(), String>,
+{
+    let (sender, receiver) = mpsc::channel();
+    let mut stream_error: Option<String> = None;
+    let mut worker_error: Option<String> = None;
+
+    std::thread::scope(|scope| {
+        let worker = scope.spawn(move || {
+            pool.install(|| {
+                candidates
+                    .par_iter()
+                    .for_each_with(sender, |sender, candidate| {
+                        let item =
+                            optimize_thumbnail_candidate(candidate, thumbnail_dir, is_cancelled);
+                        let _ = sender.send(item);
+                    });
+            });
+        });
+
+        for item in receiver {
+            if let Err(error) = handle_result(item) {
+                stream_error = Some(error);
+                break;
+            }
+        }
+
+        if worker.join().is_err() {
+            worker_error = Some("thumbnail worker panicked".to_string());
+        }
+    });
+
+    if let Some(error) = stream_error {
+        return Err(error);
+    }
+
+    if let Some(error) = worker_error {
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+fn accumulate_thumbnail_result(
+    result: &mut ThumbnailOptimizationResult,
+    item: &ThumbnailItemResult,
+) -> u128 {
+    match item {
+        ThumbnailItemResult::Success {
+            reused,
+            processing_ms,
+            ..
+        } => {
+            result.checked += 1;
+            result.optimized += 1;
+            if *reused {
+                result.reused += 1;
+            }
+            *processing_ms
+        }
+        ThumbnailItemResult::Failed { .. } => {
+            result.checked += 1;
+            result.failed += 1;
+            0
+        }
+        ThumbnailItemResult::Skipped => {
+            result.skipped += 1;
+            0
+        }
+    }
+}
+
+fn flush_pending_thumbnail_results(
+    conn: &mut Connection,
+    pending_results: &mut Vec<ThumbnailItemResult>,
+    attempted_at_ms: i64,
+) -> Result<u64, String> {
+    if pending_results.is_empty() {
+        return Ok(0);
+    }
+
+    let db_started_at = Instant::now();
+    persist_thumbnail_results(conn, pending_results, attempted_at_ms)?;
+    pending_results.clear();
+    Ok(elapsed_ms(db_started_at))
+}
+
+fn build_progress_payload(
+    result: &ThumbnailOptimizationResult,
+    started_at: Instant,
+    profile: ThumbnailOptimizationProfile,
+    batch_ms: u64,
+    db_ms: u64,
+    encode_ms: u64,
+    is_throttled: bool,
+) -> ThumbnailOptimizationProgress {
+    let elapsed_seconds = started_at.elapsed().as_secs_f64();
+    let images_per_second = if elapsed_seconds > 0.0 {
+        result.checked as f64 / elapsed_seconds
+    } else {
+        0.0
+    };
+
+    ThumbnailOptimizationProgress {
+        checked: result.checked,
+        total: 0,
+        optimized: result.optimized,
+        reused: result.reused,
+        failed: result.failed,
+        skipped: result.skipped,
+        images_per_second,
+        batch_ms,
+        db_ms,
+        encode_ms,
+        profile,
+        phase: if is_throttled {
+            "throttled".to_string()
+        } else {
+            "running".to_string()
+        },
+        message: format_thumbnail_progress_message(result),
+        is_throttled,
+    }
+}
+
+fn format_thumbnail_progress_message(result: &ThumbnailOptimizationResult) -> String {
+    if result.checked == 0 {
+        return "Checking library thumbnails...".to_string();
+    }
+
+    if result.failed > 0 {
+        return format!(
+            "Optimized {} thumbnails; {} need attention",
+            result.optimized, result.failed
+        );
+    }
+
+    format!("Optimized {} thumbnails", result.optimized)
+}
+
+fn optimize_thumbnail_candidate(
+    candidate: &ThumbnailCandidate,
+    thumbnail_dir: &str,
+    is_cancelled: &AtomicBool,
+) -> ThumbnailItemResult {
+    if is_cancelled.load(Ordering::SeqCst) {
+        return ThumbnailItemResult::Skipped;
+    }
+
+    match super::generate_thumbnail(&candidate.path, thumbnail_dir) {
+        Ok(thumbnail) => ThumbnailItemResult::Success {
+            id: candidate.id.clone(),
+            thumbnail_path: thumbnail.thumbnail_path,
+            micro_thumbnail: thumbnail.micro_thumbnail,
+            reused: thumbnail.was_cached,
+            processing_ms: thumbnail.processing_ms,
+        },
+        Err(error) => ThumbnailItemResult::Failed {
+            id: candidate.id.clone(),
+            error,
+        },
+    }
+}
+
+fn persist_thumbnail_results(
+    conn: &mut Connection,
+    results: &[ThumbnailItemResult],
+    attempted_at_ms: i64,
+) -> Result<BatchStats, String> {
+    let mut stats = BatchStats::default();
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+
+    {
+        let mut success_stmt = tx
+            .prepare_cached(
+                "UPDATE images
+                 SET thumbnail_path = ?1,
+                     micro_thumbnail = COALESCE(?2, micro_thumbnail),
+                     thumbnail_source = 'ambit',
+                     thumbnail_version = ?3,
+                     thumbnail_failure_count = 0,
+                     thumbnail_last_error = NULL,
+                     thumbnail_last_attempt_at = NULL
+                 WHERE id = ?4",
+            )
+            .map_err(|e| e.to_string())?;
+
+        let mut failure_stmt = tx
+            .prepare_cached(
+                "UPDATE images
+                 SET thumbnail_failure_count = COALESCE(thumbnail_failure_count, 0) + 1,
+                     thumbnail_last_error = ?1,
+                     thumbnail_last_attempt_at = ?2
+                 WHERE id = ?3",
+            )
+            .map_err(|e| e.to_string())?;
+
+        for item in results {
+            match item {
+                ThumbnailItemResult::Success {
+                    id,
+                    thumbnail_path,
+                    micro_thumbnail,
+                    reused,
+                    processing_ms,
+                } => {
+                    success_stmt
+                        .execute(params![
+                            thumbnail_path,
+                            micro_thumbnail,
+                            CURRENT_THUMBNAIL_VERSION,
+                            id
+                        ])
+                        .map_err(|e| e.to_string())?;
+                    stats.checked += 1;
+                    stats.optimized += 1;
+                    if *reused {
+                        stats.reused += 1;
+                    }
+                    stats.encode_ms += *processing_ms;
+                }
+                ThumbnailItemResult::Failed { id, error } => {
+                    failure_stmt
+                        .execute(params![error, attempted_at_ms, id])
+                        .map_err(|e| e.to_string())?;
+                    stats.checked += 1;
+                    stats.failed += 1;
+                }
+                ThumbnailItemResult::Skipped => {
+                    stats.skipped += 1;
+                }
+            }
+        }
+    }
+
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(stats)
+}
+
+fn fetch_thumbnail_candidates(
+    conn: &Connection,
+    include_upgradeable: bool,
+    cursor: Option<&ThumbnailCursor>,
+    limit: usize,
+    now_ms: i64,
+) -> Result<Vec<ThumbnailCandidate>, String> {
+    let mut query = format!(
+        "SELECT id, path, COALESCE(timestamp, 0) AS timestamp
+         FROM images
+         WHERE {}",
+        thumbnail_queue_condition(include_upgradeable, now_ms)
+    );
+
+    if cursor.is_some() {
+        query.push_str(" AND (timestamp < ?1 OR (timestamp = ?1 AND id < ?2))");
+        query.push_str(" ORDER BY timestamp DESC, id DESC LIMIT ?3");
+    } else {
+        query.push_str(" ORDER BY timestamp DESC, id DESC LIMIT ?1");
+    }
+
+    let mut stmt = conn.prepare(&query).map_err(|e| e.to_string())?;
+
+    let rows = if let Some(cursor) = cursor {
+        stmt.query_map(params![cursor.timestamp, cursor.id, limit as i64], |row| {
+            Ok(ThumbnailCandidate {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                timestamp: row.get(2)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, rusqlite::Error>>()
+        .map_err(|e| e.to_string())?
+    } else {
+        stmt.query_map(params![limit as i64], |row| {
+            Ok(ThumbnailCandidate {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                timestamp: row.get(2)?,
+            })
+        })
+        .map_err(|e| e.to_string())?
+        .collect::<Result<Vec<_>, rusqlite::Error>>()
+        .map_err(|e| e.to_string())?
+    };
+
+    Ok(rows)
+}
+
+fn thumbnail_queue_condition(include_upgradeable: bool, now_ms: i64) -> String {
+    let retry_cutoff_ms = now_ms - FAILURE_BACKOFF_MS;
+    let missing_thumbnail =
+        "(path = thumbnail_path OR thumbnail_path IS NULL OR thumbnail_path = '')";
+    let outdated_ambit = format!(
+        "(thumbnail_source = 'ambit' AND COALESCE(thumbnail_version, 0) < {})",
+        CURRENT_THUMBNAIL_VERSION
+    );
+    let upgradeable = if include_upgradeable {
+        " OR (
+            thumbnail_path IS NOT NULL
+            AND thumbnail_path != ''
+            AND path != thumbnail_path
+            AND (thumbnail_source IS NULL OR thumbnail_source != 'ambit')
+        )"
+    } else {
+        ""
+    };
+
+    format!(
+        "is_deleted = 0
+         AND is_missing = 0
+         AND IFNULL(is_intermediate_gen, 0) = 0
+         AND (is_corrupt = 0 OR is_corrupt IS NULL)
+         AND path NOT LIKE 'blob:%'
+         AND path NOT LIKE 'data:%'
+         AND (
+             COALESCE(thumbnail_failure_count, 0) = 0
+             OR thumbnail_last_attempt_at IS NULL
+             OR thumbnail_last_attempt_at <= {retry_cutoff_ms}
+         )
+         AND ({missing_thumbnail} OR {outdated_ambit}{upgradeable})"
+    )
+}
+
+fn emit_progress(app: &tauri::AppHandle, progress: &ThumbnailOptimizationProgress) {
+    let _ = app.emit("thumbnail-optimization-progress", progress.clone());
+}
+
+fn emit_complete(app: &tauri::AppHandle, result: &ThumbnailOptimizationResult) {
+    let _ = app.emit("thumbnail-optimization-complete", result.clone());
+}
+
+fn unix_time_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn elapsed_ms(started_at: Instant) -> u64 {
+    millis_to_u64(started_at.elapsed().as_millis())
+}
+
+fn millis_to_u64(value: u128) -> u64 {
+    std::cmp::min(value, u64::MAX as u128) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn setup_queue_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "
+            CREATE TABLE images (
+                id TEXT PRIMARY KEY,
+                path TEXT NOT NULL,
+                thumbnail_path TEXT,
+                micro_thumbnail TEXT,
+                thumbnail_source TEXT,
+                thumbnail_version INTEGER NOT NULL DEFAULT 0,
+                thumbnail_failure_count INTEGER NOT NULL DEFAULT 0,
+                thumbnail_last_error TEXT,
+                thumbnail_last_attempt_at INTEGER,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                is_missing INTEGER NOT NULL DEFAULT 0,
+                is_intermediate_gen INTEGER NOT NULL DEFAULT 0,
+                is_corrupt INTEGER DEFAULT 0,
+                timestamp INTEGER NOT NULL
+            );
+            ",
+        )
+        .expect("schema");
+        conn
+    }
+
+    fn insert_image(
+        conn: &Connection,
+        id: &str,
+        thumbnail_path: Option<&str>,
+        thumbnail_source: Option<&str>,
+        thumbnail_version: i64,
+        timestamp: i64,
+    ) {
+        conn.execute(
+            "INSERT INTO images (
+                id, path, thumbnail_path, thumbnail_source, thumbnail_version, timestamp
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id,
+                format!("C:/library/{id}.png"),
+                thumbnail_path,
+                thumbnail_source,
+                thumbnail_version,
+                timestamp
+            ],
+        )
+        .expect("insert image");
+    }
+
+    fn temp_thumbnail_dir(name: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "ambit-thumb-optimizer-{}-{}",
+            std::process::id(),
+            name
+        ))
+    }
+
+    #[test]
+    fn profiles_split_queue_fetch_from_worker_chunk_size() {
+        assert_eq!(ThumbnailOptimizationProfile::Quiet.fetch_limit(), 100);
+        assert_eq!(ThumbnailOptimizationProfile::Balanced.fetch_limit(), 500);
+        assert_eq!(ThumbnailOptimizationProfile::Fast.fetch_limit(), 1000);
+
+        assert_eq!(ThumbnailOptimizationProfile::Quiet.worker_chunk_size(), 8);
+        assert_eq!(
+            ThumbnailOptimizationProfile::Balanced.worker_chunk_size(),
+            24
+        );
+        assert_eq!(ThumbnailOptimizationProfile::Fast.worker_chunk_size(), 48);
+        assert_eq!(THROTTLED_WORKER_CHUNK_SIZE, 4);
+    }
+
+    #[test]
+    fn progress_payload_is_unknown_total_and_can_update_before_db_flush() {
+        let started_at = Instant::now();
+        let mut result = ThumbnailOptimizationResult::default();
+        let item = ThumbnailItemResult::Success {
+            id: "early".to_string(),
+            thumbnail_path: "C:/thumbs/early.webp".to_string(),
+            micro_thumbnail: None,
+            reused: false,
+            processing_ms: 15,
+        };
+
+        let encode_ms = accumulate_thumbnail_result(&mut result, &item);
+        let progress = build_progress_payload(
+            &result,
+            started_at,
+            ThumbnailOptimizationProfile::Balanced,
+            12,
+            0,
+            millis_to_u64(encode_ms),
+            true,
+        );
+
+        assert_eq!(progress.checked, 1);
+        assert_eq!(progress.optimized, 1);
+        assert_eq!(progress.total, 0);
+        assert_eq!(progress.encode_ms, 15);
+        assert!(progress.is_throttled);
+        assert_eq!(progress.phase, "throttled");
+    }
+
+    #[test]
+    fn failure_diagnostics_return_active_failed_rows_ordered_by_recent_attempt() {
+        let conn = setup_queue_db();
+        insert_image(&conn, "older", None, None, 0, 10);
+        insert_image(
+            &conn,
+            "newer",
+            Some("C:/thumbs/newer.webp"),
+            Some("ambit"),
+            1,
+            20,
+        );
+        insert_image(&conn, "deleted", None, None, 0, 30);
+        insert_image(&conn, "missing", None, None, 0, 40);
+        insert_image(&conn, "ok", None, None, 0, 50);
+
+        conn.execute_batch(
+            "
+            UPDATE images
+            SET thumbnail_failure_count = 1,
+                thumbnail_last_error = 'old decode failed',
+                thumbnail_last_attempt_at = 100
+            WHERE id = 'older';
+
+            UPDATE images
+            SET thumbnail_failure_count = 2,
+                thumbnail_last_error = 'new decode failed',
+                thumbnail_last_attempt_at = 200
+            WHERE id = 'newer';
+
+            UPDATE images
+            SET thumbnail_failure_count = 1,
+                thumbnail_last_error = 'deleted decode failed',
+                thumbnail_last_attempt_at = 300,
+                is_deleted = 1
+            WHERE id = 'deleted';
+
+            UPDATE images
+            SET thumbnail_failure_count = 1,
+                thumbnail_last_error = 'missing decode failed',
+                thumbnail_last_attempt_at = 400,
+                is_missing = 1
+            WHERE id = 'missing';
+            ",
+        )
+        .expect("mark failures");
+
+        let failures =
+            get_thumbnail_optimization_failures_for_conn(&conn, 1).expect("failure diagnostics");
+
+        assert_eq!(failures.failures.len(), 1);
+        assert_eq!(failures.failures[0].id, "newer");
+        assert_eq!(
+            failures.failures[0].thumbnail_path.as_deref(),
+            Some("C:/thumbs/newer.webp")
+        );
+        assert_eq!(failures.failures[0].failure_count, 2);
+        assert_eq!(
+            failures.failures[0].last_error.as_deref(),
+            Some("new decode failed")
+        );
+        assert_eq!(failures.failures[0].last_attempt_at, Some(200));
+    }
+
+    #[test]
+    fn retry_failed_thumbnail_optimizations_clears_only_failure_metadata() {
+        let conn = setup_queue_db();
+        insert_image(
+            &conn,
+            "failed",
+            Some("C:/thumbs/failed.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            20,
+        );
+        insert_image(&conn, "ok", Some("C:/thumbs/ok.webp"), Some("ambit"), 1, 10);
+
+        conn.execute(
+            "UPDATE images
+             SET thumbnail_failure_count = 3,
+                 thumbnail_last_error = 'decode failed',
+                 thumbnail_last_attempt_at = 123
+             WHERE id = 'failed'",
+            [],
+        )
+        .expect("mark failed");
+
+        let updated = retry_failed_thumbnail_optimizations_for_conn(&conn).expect("retry failures");
+        assert_eq!(updated, 1);
+
+        let row = conn
+            .query_row(
+                "SELECT thumbnail_path, thumbnail_source, thumbnail_version,
+                        thumbnail_failure_count, thumbnail_last_error, thumbnail_last_attempt_at
+                 FROM images
+                 WHERE id = 'failed'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<i64>>(5)?,
+                    ))
+                },
+            )
+            .expect("failed row");
+
+        assert_eq!(row.0.as_deref(), Some("C:/thumbs/failed.webp"));
+        assert_eq!(row.1.as_deref(), Some("ambit"));
+        assert_eq!(row.2, CURRENT_THUMBNAIL_VERSION);
+        assert_eq!(row.3, 0);
+        assert_eq!(row.4, None);
+        assert_eq!(row.5, None);
+
+        let ok_failure_count: i64 = conn
+            .query_row(
+                "SELECT thumbnail_failure_count FROM images WHERE id = 'ok'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("ok failure count");
+        assert_eq!(ok_failure_count, 0);
+    }
+
+    #[test]
+    fn pending_results_flush_and_clear_on_completion_or_cancel() {
+        let mut conn = setup_queue_db();
+        insert_image(&conn, "pending", None, None, 0, 20);
+        let mut pending = vec![ThumbnailItemResult::Success {
+            id: "pending".to_string(),
+            thumbnail_path: "C:/thumbs/pending.webp".to_string(),
+            micro_thumbnail: Some("micro".to_string()),
+            reused: true,
+            processing_ms: 7,
+        }];
+
+        let _db_ms =
+            flush_pending_thumbnail_results(&mut conn, &mut pending, 100).expect("flush pending");
+
+        assert!(pending.is_empty());
+
+        let row: (String, String, i64) = conn
+            .query_row(
+                "SELECT thumbnail_path, thumbnail_source, thumbnail_version
+                 FROM images WHERE id = 'pending'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("row");
+
+        assert_eq!(row.0, "C:/thumbs/pending.webp");
+        assert_eq!(row.1, "ambit");
+        assert_eq!(row.2, CURRENT_THUMBNAIL_VERSION);
+    }
+
+    #[test]
+    fn optimizer_creates_queue_index_idempotently() {
+        let conn = setup_queue_db();
+
+        ensure_thumbnail_queue_index(&conn).expect("create index");
+        ensure_thumbnail_queue_index(&conn).expect("create index again");
+
+        let index_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM sqlite_master
+                 WHERE type = 'index'
+                   AND name = 'idx_images_thumbnail_optimization_queue_v1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("index count");
+
+        assert_eq!(index_count, 1);
+    }
+
+    #[test]
+    fn cancellation_transition_is_reported_once() {
+        let is_cancelled = AtomicBool::new(false);
+
+        assert!(request_thumbnail_cancellation(&is_cancelled));
+        assert!(!request_thumbnail_cancellation(&is_cancelled));
+    }
+
+    #[test]
+    fn empty_or_missing_thumbnail_cache_is_detected() {
+        let missing_dir = temp_thumbnail_dir("missing-cache");
+        let _ = fs::remove_dir_all(&missing_dir);
+        assert!(thumbnail_cache_is_missing_or_empty(
+            &missing_dir.to_string_lossy()
+        ));
+
+        let empty_dir = temp_thumbnail_dir("empty-cache");
+        let _ = fs::remove_dir_all(&empty_dir);
+        fs::create_dir_all(&empty_dir).expect("create empty cache dir");
+        assert!(thumbnail_cache_is_missing_or_empty(
+            &empty_dir.to_string_lossy()
+        ));
+
+        let non_empty_dir = temp_thumbnail_dir("non-empty-cache");
+        let _ = fs::remove_dir_all(&non_empty_dir);
+        fs::create_dir_all(&non_empty_dir).expect("create non-empty cache dir");
+        fs::write(non_empty_dir.join("existing.webp"), b"not a real webp").expect("write marker");
+        assert!(!thumbnail_cache_is_missing_or_empty(
+            &non_empty_dir.to_string_lossy()
+        ));
+
+        let _ = fs::remove_dir_all(&empty_dir);
+        let _ = fs::remove_dir_all(&non_empty_dir);
+    }
+
+    #[test]
+    fn empty_cache_marks_current_ambit_rows_stale_for_rebuild() {
+        let conn = setup_queue_db();
+        insert_image(
+            &conn,
+            "current",
+            Some("C:/thumbs/current.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            20,
+        );
+        let empty_dir = temp_thumbnail_dir("mark-stale-cache");
+        let _ = fs::remove_dir_all(&empty_dir);
+        fs::create_dir_all(&empty_dir).expect("create empty cache dir");
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch before mark");
+        assert!(rows.is_empty());
+
+        let marked = mark_current_ambit_thumbnails_stale_if_cache_missing_or_empty(
+            &conn,
+            &empty_dir.to_string_lossy(),
+        )
+        .expect("mark stale");
+        assert_eq!(marked, 1);
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch after mark");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "current");
+
+        let version: i64 = conn
+            .query_row(
+                "SELECT thumbnail_version FROM images WHERE id = 'current'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("version");
+        assert_eq!(version, 0);
+
+        let _ = fs::remove_dir_all(&empty_dir);
+    }
+
+    #[test]
+    fn non_empty_cache_does_not_mark_current_ambit_rows_stale() {
+        let conn = setup_queue_db();
+        insert_image(
+            &conn,
+            "current",
+            Some("C:/thumbs/current.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            20,
+        );
+        let non_empty_dir = temp_thumbnail_dir("skip-mark-cache");
+        let _ = fs::remove_dir_all(&non_empty_dir);
+        fs::create_dir_all(&non_empty_dir).expect("create cache dir");
+        fs::write(non_empty_dir.join("existing.webp"), b"not a real webp").expect("write marker");
+
+        let marked = mark_current_ambit_thumbnails_stale_if_cache_missing_or_empty(
+            &conn,
+            &non_empty_dir.to_string_lossy(),
+        )
+        .expect("mark stale");
+        assert_eq!(marked, 0);
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch candidates");
+        assert!(rows.is_empty());
+
+        let version: i64 = conn
+            .query_row(
+                "SELECT thumbnail_version FROM images WHERE id = 'current'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("version");
+        assert_eq!(version, CURRENT_THUMBNAIL_VERSION);
+
+        let _ = fs::remove_dir_all(&non_empty_dir);
+    }
+
+    #[test]
+    fn interrupted_cache_rebuild_resumes_remaining_stale_rows() {
+        let mut conn = setup_queue_db();
+        insert_image(
+            &conn,
+            "first",
+            Some("C:/thumbs/first.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            30,
+        );
+        insert_image(
+            &conn,
+            "second",
+            Some("C:/thumbs/second.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            20,
+        );
+        insert_image(
+            &conn,
+            "third",
+            Some("C:/thumbs/third.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            10,
+        );
+        let empty_dir = temp_thumbnail_dir("resume-cache");
+        let _ = fs::remove_dir_all(&empty_dir);
+        fs::create_dir_all(&empty_dir).expect("create empty cache dir");
+
+        let marked = mark_current_ambit_thumbnails_stale_if_cache_missing_or_empty(
+            &conn,
+            &empty_dir.to_string_lossy(),
+        )
+        .expect("mark stale");
+        assert_eq!(marked, 3);
+
+        persist_thumbnail_results(
+            &mut conn,
+            &[ThumbnailItemResult::Success {
+                id: "first".to_string(),
+                thumbnail_path: "C:/thumbs/first.webp".to_string(),
+                micro_thumbnail: None,
+                reused: false,
+                processing_ms: 15,
+            }],
+            100,
+        )
+        .expect("persist first success");
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch candidates");
+        let ids: Vec<String> = rows.into_iter().map(|row| row.id).collect();
+        assert_eq!(ids, vec!["second", "third"]);
+
+        let _ = fs::remove_dir_all(&empty_dir);
+    }
+
+    #[test]
+    fn queue_selects_missing_and_outdated_without_external_upgrades() {
+        let conn = setup_queue_db();
+        insert_image(&conn, "missing", None, None, 0, 40);
+        insert_image(
+            &conn,
+            "outdated",
+            Some("C:/thumbs/outdated.webp"),
+            Some("ambit"),
+            0,
+            30,
+        );
+        insert_image(
+            &conn,
+            "external",
+            Some("C:/invoke/thumb.webp"),
+            Some("invokeai"),
+            0,
+            20,
+        );
+        insert_image(
+            &conn,
+            "current",
+            Some("C:/thumbs/current.webp"),
+            Some("ambit"),
+            CURRENT_THUMBNAIL_VERSION,
+            10,
+        );
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch candidates");
+        let ids: Vec<String> = rows.into_iter().map(|row| row.id).collect();
+
+        assert_eq!(ids, vec!["missing", "outdated"]);
+    }
+
+    #[test]
+    fn queue_includes_external_thumbnails_when_upgrade_mode_is_enabled() {
+        let conn = setup_queue_db();
+        insert_image(
+            &conn,
+            "external",
+            Some("C:/invoke/thumb.webp"),
+            Some("invokeai"),
+            0,
+            20,
+        );
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, true, None, 10, 10_000).expect("fetch candidates");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "external");
+    }
+
+    #[test]
+    fn queue_skips_recent_failures_until_backoff_expires() {
+        let conn = setup_queue_db();
+        insert_image(&conn, "failed", None, None, 0, 20);
+        conn.execute(
+            "UPDATE images
+             SET thumbnail_failure_count = 1,
+                 thumbnail_last_attempt_at = ?1
+             WHERE id = 'failed'",
+            params![10_000 - 10],
+        )
+        .expect("mark failed");
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch candidates");
+        assert!(rows.is_empty());
+
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000 + FAILURE_BACKOFF_MS + 1)
+                .expect("fetch after backoff");
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn success_clears_failure_metadata() {
+        let mut conn = setup_queue_db();
+        insert_image(&conn, "fixed", None, None, 0, 20);
+        conn.execute(
+            "UPDATE images
+             SET thumbnail_failure_count = 2,
+                 thumbnail_last_error = 'decode failed',
+                 thumbnail_last_attempt_at = 42
+             WHERE id = 'fixed'",
+            [],
+        )
+        .expect("mark failed");
+
+        let stats = persist_thumbnail_results(
+            &mut conn,
+            &[ThumbnailItemResult::Success {
+                id: "fixed".to_string(),
+                thumbnail_path: "C:/thumbs/fixed.webp".to_string(),
+                micro_thumbnail: None,
+                reused: false,
+                processing_ms: 25,
+            }],
+            100,
+        )
+        .expect("persist success");
+
+        assert_eq!(stats.checked, 1);
+        assert_eq!(stats.optimized, 1);
+
+        let row: (String, String, i64, i64, Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT thumbnail_path, thumbnail_source, thumbnail_version,
+                        thumbnail_failure_count, thumbnail_last_error, thumbnail_last_attempt_at
+                 FROM images WHERE id = 'fixed'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .expect("row");
+
+        assert_eq!(row.0, "C:/thumbs/fixed.webp");
+        assert_eq!(row.1, "ambit");
+        assert_eq!(row.2, CURRENT_THUMBNAIL_VERSION);
+        assert_eq!(row.3, 0);
+        assert_eq!(row.4, None);
+        assert_eq!(row.5, None);
+    }
+
+    #[test]
+    fn cancelled_items_are_skipped_before_processing() {
+        let conn = setup_queue_db();
+        insert_image(&conn, "missing", None, None, 0, 20);
+        let rows =
+            fetch_thumbnail_candidates(&conn, false, None, 10, 10_000).expect("fetch candidates");
+        let is_cancelled = AtomicBool::new(true);
+
+        let result = optimize_thumbnail_candidate(&rows[0], "C:/thumbs", &is_cancelled);
+
+        assert!(matches!(result, ThumbnailItemResult::Skipped));
+    }
+}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -370,6 +370,36 @@ async scanDirectorySince(path: string, since: number) : Promise<Result<FileEntry
     else return { status: "error", error: e  as any };
 }
 },
+async startThumbnailOptimizationJob(config: ThumbnailOptimizationConfig) : Promise<Result<ThumbnailOptimizationResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("start_thumbnail_optimization_job", { config }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async cancelThumbnailOptimizationJob() : Promise<void> {
+    await TAURI_INVOKE("cancel_thumbnail_optimization_job");
+},
+async setThumbnailOptimizationThrottled(throttled: boolean) : Promise<void> {
+    await TAURI_INVOKE("set_thumbnail_optimization_throttled", { throttled });
+},
+async getThumbnailOptimizationFailures(limit: number) : Promise<Result<ThumbnailOptimizationFailureList, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_thumbnail_optimization_failures", { limit }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async retryFailedThumbnailOptimizations() : Promise<Result<number, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("retry_failed_thumbnail_optimizations") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async startNativeFolderWatcher(paths: string[]) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_native_folder_watcher", { paths }) };
@@ -536,6 +566,11 @@ thumbnailSource: string | null; chunks: Partial<{ [key in string]: string }>; me
  * Error message if scan failed or resulted in a partial result
  */
 error: string | null }
+export type ThumbnailOptimizationConfig = { thumbnailDir: string; includeUpgradeable: boolean; profile: ThumbnailOptimizationProfile }
+export type ThumbnailOptimizationFailure = { id: string; path: string; thumbnailPath: string | null; failureCount: number; lastError: string | null; lastAttemptAt: number | null }
+export type ThumbnailOptimizationFailureList = { failures: ThumbnailOptimizationFailure[] }
+export type ThumbnailOptimizationProfile = "quiet" | "balanced" | "fast"
+export type ThumbnailOptimizationResult = { checked: number; optimized: number; reused: number; failed: number; skipped: number; wasCancelled: boolean; durationMs: number }
 export type ThumbnailScanResult = { found: number; updated: number }
 /**
  * Valid facet names result - used for drill-down filtering

--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -3,6 +3,11 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Loader2, X, Info, Sparkles, Minus, Fingerprint, Search } from 'lucide-react';
 import { useLibraryStore } from '../../stores/libraryStore';
 import { commands } from '../../bindings';
+import {
+    THUMBNAIL_QUEUE_COMPLETE_FOOTER,
+    THUMBNAIL_QUEUE_FAILURE_FOOTER,
+    THUMBNAIL_QUEUE_RUNNING_FOOTER
+} from '../../hooks/thumbnailQueueProgress';
 
 export const ActivityDock: React.FC = () => {
     const {
@@ -91,8 +96,9 @@ export const ActivityDock: React.FC = () => {
         label = "Smart Fill";
     } else if (isBackgroundActive) {
         progress = backgroundHealingProgress;
-        label = "Auto-Optimizing";
+        label = "Smart Thumbnails";
         isLowPriority = true;
+        footerMessage = THUMBNAIL_QUEUE_RUNNING_FOOTER;
     } else if (isRefreshActive) {
         progress = refreshProgress;
         label = "Refreshing Metadata";
@@ -113,7 +119,14 @@ export const ActivityDock: React.FC = () => {
     const total = progress?.total || 0;
     const message = progress?.message || (isLiveWatchActive ? liveWatchSession.message || '' : '');
     const percent = isLiveWatchSummary ? 100 : total > 0 ? Math.round((current / total) * 100) : (active ? 0 : 0);
+    const smartThumbnailHasFailures = isBackgroundActive && message.includes('need attention');
+    const smartThumbnailIsComplete = isBackgroundActive && total > 0 && current >= total;
+    const visibleFooterMessage = smartThumbnailHasFailures
+        ? THUMBNAIL_QUEUE_FAILURE_FOOTER
+        : (smartThumbnailIsComplete ? THUMBNAIL_QUEUE_COMPLETE_FOOTER : footerMessage);
+    const progressCountLabel = total > 0 && !isLiveWatchActive && !isBackgroundActive ? `${current.toLocaleString()} / ${total.toLocaleString()}` : null;
     const showIndeterminateProgress = total === 0 && active && (!isLiveWatchActive || !isLiveWatchSummary);
+    const showPercent = !isLiveWatchActive && !isBackgroundActive && total > 0;
     const accentClasses = isLiveWatchTone || isLowPriority
         ? {
             iconText: 'text-violet-600 dark:text-violet-400',
@@ -178,7 +191,7 @@ export const ActivityDock: React.FC = () => {
                                         <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-500 italic opacity-80 leading-none mb-1">Background Activity</h4>
                                         <p className="text-sm font-bold text-gray-900 dark:text-white flex items-center gap-2">
                                             {label}
-                                            {total > 0 && !isLiveWatchActive && <span className="text-xs font-medium text-gray-400 font-mono tracking-tight">{current.toLocaleString()} / {total.toLocaleString()}</span>}
+                                            {progressCountLabel && <span className="text-xs font-medium text-gray-400 font-mono tracking-tight">{progressCountLabel}</span>}
                                         </p>
                                     </motion.div>
                                 </div>
@@ -222,7 +235,7 @@ export const ActivityDock: React.FC = () => {
                                     <p className="text-[11px] font-medium text-gray-500 dark:text-gray-400 truncate flex-1 pr-4 h-4 leading-4">
                                         {message || "Starting work..."}
                                     </p>
-                                    {!isLiveWatchActive && (
+                                    {showPercent && (
                                         <span className={`text-[11px] font-black font-mono italic ${accentClasses.percentText}`}>
                                             {percent}%
                                         </span>
@@ -234,7 +247,7 @@ export const ActivityDock: React.FC = () => {
                             <motion.div layout="position" className="pt-2 border-t border-black/5 dark:border-white/5 flex items-center justify-between gap-2">
                                 <div className="flex items-center gap-2">
                                     <Info className="w-3 h-3 text-gray-400" />
-                                    <span className="text-[9px] text-gray-500 font-medium">{footerMessage}</span>
+                                    <span className="text-[9px] text-gray-500 font-medium">{visibleFooterMessage}</span>
                                 </div>
 
                                 {supportsCancel && (

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -35,6 +35,7 @@ const resetLibraryStore = () => {
         lastMissingScanResult: null,
         isBackgroundHealingActive: false,
         backgroundHealingProgress: null,
+        backgroundHealingDetails: null,
         backgroundHealingPaused: false,
         isRefreshingMetadata: false,
         refreshProgress: null,
@@ -96,6 +97,64 @@ describe('ActivityDock', () => {
         expect(screen.getByText('3 / 12')).toBeTruthy();
         expect(screen.getByText('Checking file paths for missing images...')).toBeTruthy();
         expect(screen.getByText('Cancel')).toBeTruthy();
+    });
+
+    it('renders running smart thumbnail progress without repeated checked counts', () => {
+        useLibraryStore.setState({
+            isBackgroundHealingActive: true,
+            backgroundHealingProgress: {
+                current: 340,
+                total: 0,
+                message: 'Optimized 340 thumbnails'
+            }
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Smart Thumbnails')).toBeTruthy();
+        expect(screen.getByText('Optimized 340 thumbnails')).toBeTruthy();
+        expect(screen.getByText('Runs at low priority and throttles while you browse.')).toBeTruthy();
+        expect(screen.queryByText('340 checked')).toBeNull();
+        expect(screen.queryByText('340 / 340')).toBeNull();
+        expect(screen.queryByText('0%')).toBeNull();
+        expect(screen.queryByText('100%')).toBeNull();
+        expect(screen.queryByText('Cancel')).toBeNull();
+    });
+
+    it('renders completed smart thumbnail progress without generic count or percent chrome', () => {
+        useLibraryStore.setState({
+            isBackgroundHealingActive: true,
+            backgroundHealingProgress: {
+                current: 340,
+                total: 340,
+                message: 'Finished: 340 thumbnails optimized'
+            }
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Smart Thumbnails')).toBeTruthy();
+        expect(screen.getByText('Finished: 340 thumbnails optimized')).toBeTruthy();
+        expect(screen.getByText('Library thumbnails are up to date.')).toBeTruthy();
+        expect(screen.queryByText('340 checked')).toBeNull();
+        expect(screen.queryByText('340 / 340')).toBeNull();
+        expect(screen.queryByText('100%')).toBeNull();
+    });
+
+    it('renders smart thumbnail failure footer when files need attention', () => {
+        useLibraryStore.setState({
+            isBackgroundHealingActive: true,
+            backgroundHealingProgress: {
+                current: 340,
+                total: 0,
+                message: 'Optimized 338 thumbnails; 2 need attention'
+            }
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Optimized 338 thumbnails; 2 need attention')).toBeTruthy();
+        expect(screen.getByText('Some files may be corrupt or unavailable.')).toBeTruthy();
     });
 
     it('renders a unified Live Watch card without cancel controls during active live work', () => {

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -7,7 +7,7 @@ import { useCollectionStore } from '../stores/collectionStore';
 import { useSearchStore } from '../stores/searchStore';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSettingsStore } from '../stores/settingsStore';
-import { FacetType, MetadataRefreshScope } from '../types';
+import { AppSettings, FacetType, MetadataRefreshScope } from '../types';
 import { isInvokeDbSnapshotCurrent, readInvokeDbSnapshotState } from '../services/invoke/dbSnapshot';
 import {
     debugLiveWatchPerf,
@@ -756,7 +756,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             const legacyState = await appRepository.load();
 
             // Define clean settings
-            const cleanSettings = {
+            const cleanSettings: AppSettings = {
                 ...legacyState.settings,
                 lastSyncedAt: null,
                 monitoredFolders: [],
@@ -766,6 +766,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 resourceFolders: [], // Clear added model/lora folders
                 importIntermediates: false,
                 enableAutoThumbnailHealing: true, // Reset to default (True) so next run is fresh
+                thumbnailOptimizationProfile: 'balanced',
                 hasCompletedOnboarding: false // Optional: Reset onboarding for factory reset feel
             };
 

--- a/src/features/settings/components/GeneralTab.tsx
+++ b/src/features/settings/components/GeneralTab.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
-import { Moon, Sun } from 'lucide-react';
+import { AlertTriangle, ChevronDown, Loader2, Moon, RefreshCw, Sun } from 'lucide-react';
+import {
+    commands,
+    type ThumbnailOptimizationFailure
+} from '../../../bindings';
 import { useToast } from '../../../hooks/useToast';
+import {
+    useLibraryStore,
+    type ThumbnailOptimizationDetails,
+    type ThumbnailOptimizationRunSummary
+} from '../../../stores/libraryStore';
 import { AppSettings } from '../../../types';
+import { unwrap } from '../../../utils/spectaUtils';
 
 const LibraryHealth = React.lazy(() => import('../../maintenance/components/LibraryHealth').then(module => ({ default: module.LibraryHealth })));
 
@@ -10,8 +20,109 @@ interface TabProps {
     setSettings: React.Dispatch<React.SetStateAction<AppSettings>>;
 }
 
+type ThumbnailFailureLoadState = 'idle' | 'loading' | 'ready' | 'error';
+
+const THUMBNAIL_PROFILE_OPTIONS: {
+    id: NonNullable<AppSettings['thumbnailOptimizationProfile']>;
+    label: string;
+}[] = [
+        { id: 'quiet', label: 'Quiet' },
+        { id: 'balanced', label: 'Balanced' },
+        { id: 'fast', label: 'Fast' },
+    ];
+
+const NUMBER_FORMATTER = new Intl.NumberFormat();
+const THUMBNAIL_FAILURE_LIMIT = 50;
+const formatNumber = (value: number): string => NUMBER_FORMATTER.format(value);
+const formatRate = (value: number): string => value > 0 ? `${value.toFixed(value >= 10 ? 0 : 1)}/s` : '0/s';
+const formatDuration = (durationMs: number): string => {
+    const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
+};
+const getFileNameFromPath = (path: string): string => {
+    const normalized = path.replace(/\\/g, '/');
+    return normalized.split('/').filter(Boolean).pop() ?? path;
+};
+const formatAttemptTime = (timestamp: number | null): string => {
+    if (!timestamp) return 'Unknown time';
+    return new Date(timestamp).toLocaleString();
+};
+
+const getThumbnailMetricValue = (
+    details: ThumbnailOptimizationDetails | null,
+    lastRun: ThumbnailOptimizationRunSummary | null,
+    field: 'imagesPerSecond' | 'optimized' | 'reused' | 'failed' | 'skipped'
+): number => details?.[field] ?? lastRun?.[field] ?? 0;
+
+const getSmartThumbnailStatus = (
+    details: ThumbnailOptimizationDetails | null,
+    isActive: boolean,
+    isPaused: boolean
+): string => {
+    if (isPaused) return 'Paused';
+    if (details?.isThrottled) return 'Throttled';
+    if (isActive) return 'Running';
+    return 'Idle';
+};
+
 export const GeneralTab: React.FC<TabProps> = React.memo(({ settings, setSettings }) => {
     const { addToast } = useToast();
+    const [failurePanelOpen, setFailurePanelOpen] = React.useState(false);
+    const [thumbnailFailures, setThumbnailFailures] = React.useState<ThumbnailOptimizationFailure[]>([]);
+    const [failureLoadState, setFailureLoadState] = React.useState<ThumbnailFailureLoadState>('idle');
+    const [failureLoadError, setFailureLoadError] = React.useState<string | null>(null);
+    const [isRetryingFailures, setIsRetryingFailures] = React.useState(false);
+    const thumbnailDetails = useLibraryStore(s => s.backgroundHealingDetails);
+    const lastThumbnailRun = useLibraryStore(s => s.lastBackgroundHealingRun);
+    const isBackgroundHealingActive = useLibraryStore(s => s.isBackgroundHealingActive);
+    const backgroundHealingPaused = useLibraryStore(s => s.backgroundHealingPaused);
+    const requestThumbnailOptimizationRun = useLibraryStore(s => s.requestThumbnailOptimizationRun);
+    const smartThumbnailStatus = getSmartThumbnailStatus(
+        thumbnailDetails,
+        isBackgroundHealingActive,
+        backgroundHealingPaused
+    );
+    const showLastThumbnailRun = !thumbnailDetails && Boolean(lastThumbnailRun);
+    const failedThumbnailCount = getThumbnailMetricValue(thumbnailDetails, lastThumbnailRun, 'failed');
+    const hasKnownThumbnailFailures = failedThumbnailCount > 0;
+    const canRetryThumbnailFailures = failureLoadState === 'ready'
+        && thumbnailFailures.length > 0
+        && !isBackgroundHealingActive
+        && !isRetryingFailures;
+
+    const loadThumbnailFailures = React.useCallback(async () => {
+        setFailureLoadState('loading');
+        setFailureLoadError(null);
+
+        try {
+            const result = await unwrap(commands.getThumbnailOptimizationFailures(THUMBNAIL_FAILURE_LIMIT));
+            setThumbnailFailures(result.failures);
+            setFailureLoadState('ready');
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            setThumbnailFailures([]);
+            setFailureLoadError(message);
+            setFailureLoadState('error');
+        }
+    }, []);
+
+    React.useEffect(() => {
+        if (!failurePanelOpen || failureLoadState !== 'idle') {
+            return;
+        }
+
+        void loadThumbnailFailures();
+    }, [
+        failureLoadState,
+        failurePanelOpen,
+        loadThumbnailFailures
+    ]);
 
     const handleThemeToggle = () => {
         const newTheme = settings.theme === 'dark' ? 'light' : 'dark';
@@ -29,6 +140,37 @@ export const GeneralTab: React.FC<TabProps> = React.memo(({ settings, setSetting
         const newValue = !settings.enableAutoThumbnailHealing;
         setSettings(prev => ({ ...prev, enableAutoThumbnailHealing: newValue }));
         addToast(newValue ? 'Smart optimization enabled' : 'Smart optimization disabled', 'success');
+    };
+
+    const handleToggleFailures = () => {
+        setFailurePanelOpen(open => {
+            const nextOpen = !open;
+            if (nextOpen && failureLoadState === 'error') {
+                setFailureLoadState('idle');
+            }
+            return nextOpen;
+        });
+    };
+
+    const handleRetryFailedThumbnails = async () => {
+        setIsRetryingFailures(true);
+
+        try {
+            const retryCount = await unwrap(commands.retryFailedThumbnailOptimizations());
+            await loadThumbnailFailures();
+            requestThumbnailOptimizationRun();
+            addToast(
+                retryCount === 1
+                    ? 'Queued 1 thumbnail for retry'
+                    : `Queued ${formatNumber(retryCount)} thumbnails for retry`,
+                'success'
+            );
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            addToast(`Failed to retry thumbnails: ${message}`, 'error');
+        } finally {
+            setIsRetryingFailures(false);
+        }
     };
 
     return (
@@ -68,7 +210,7 @@ export const GeneralTab: React.FC<TabProps> = React.memo(({ settings, setSetting
                         <div className="flex items-center gap-2">
                             <div className="text-base font-medium text-gray-900 dark:text-gray-200 group-hover:text-sage-500 transition-colors">Smart Thumbnail Optimization</div>
                         </div>
-                        <div className="text-sm text-gray-500">Automatically optimize thumbnails in the background</div>
+                        <div className="text-sm text-gray-500">Optimizes thumbnails automatically in the background</div>
                     </div>
                     <button
                         type="button"
@@ -80,27 +222,144 @@ export const GeneralTab: React.FC<TabProps> = React.memo(({ settings, setSetting
 
                 {
                     settings.enableAutoThumbnailHealing && (
-                        <div
-                            onClick={() => {
-                                const newValue = !settings.enforceHighQualityThumbnails;
-                                setSettings(prev => ({ ...prev, enforceHighQualityThumbnails: newValue }));
-                                addToast(newValue ? 'High quality enforcement enabled' : 'High quality enforcement disabled', 'success');
-                            }}
-                            className="flex items-center justify-between cursor-pointer group mb-6 ml-4 pl-4 border-l-2 border-gray-100 dark:border-white/10 animate-in slide-in-from-left-2 fade-in duration-300"
-                        >
-                            <div>
-                                <div className="flex items-center gap-2">
-                                    <div className="text-sm font-medium text-gray-800 dark:text-gray-300 group-hover:text-sage-500 transition-colors">Upgrade Existing Thumbnails</div>
-                                    <span className="text-[10px] font-bold bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-300 px-1.5 py-0.5 rounded">Slow</span>
-                                </div>
-                                <div className="text-xs text-gray-400 mt-0.5">Re-generate "fast" or external thumbnails with high-quality versions</div>
-                            </div>
-                            <button
-                                type="button"
-                                className={`w-10 h-6 rounded-full relative transition-colors ${settings.enforceHighQualityThumbnails ? 'bg-violet-500' : 'bg-gray-200 dark:bg-white/10'}`}
+                        <div className="mb-6 ml-4 pl-4 border-l-2 border-gray-100 dark:border-white/10 animate-in slide-in-from-left-2 fade-in duration-300 space-y-5">
+                            <div
+                                onClick={() => {
+                                    const newValue = !settings.enforceHighQualityThumbnails;
+                                    setSettings(prev => ({ ...prev, enforceHighQualityThumbnails: newValue }));
+                                    addToast(newValue ? 'High quality enforcement enabled' : 'High quality enforcement disabled', 'success');
+                                }}
+                                className="flex items-center justify-between cursor-pointer group"
                             >
-                                <div className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow-sm transition-all ${settings.enforceHighQualityThumbnails ? 'left-5' : 'left-1'}`} />
-                            </button>
+                                <div>
+                                    <div className="flex items-center gap-2">
+                                        <div className="text-sm font-medium text-gray-800 dark:text-gray-300 group-hover:text-sage-500 transition-colors">Upgrade Existing Thumbnails</div>
+                                        <span className="text-[10px] font-bold bg-violet-100 dark:bg-violet-900/30 text-violet-600 dark:text-violet-300 px-1.5 py-0.5 rounded">Slow</span>
+                                    </div>
+                                    <div className="text-xs text-gray-400 mt-0.5">Re-generate "fast" or external thumbnails with high-quality versions</div>
+                                </div>
+                                <button
+                                    type="button"
+                                    className={`w-10 h-6 rounded-full relative transition-colors ${settings.enforceHighQualityThumbnails ? 'bg-violet-500' : 'bg-gray-200 dark:bg-white/10'}`}
+                                >
+                                    <div className={`absolute top-1 w-4 h-4 bg-white rounded-full shadow-sm transition-all ${settings.enforceHighQualityThumbnails ? 'left-5' : 'left-1'}`} />
+                                </button>
+                            </div>
+
+                            <div className="flex items-center justify-between gap-4">
+                                <div>
+                                    <div className="text-sm font-medium text-gray-800 dark:text-gray-300">Background Speed</div>
+                                    <div className="text-xs text-gray-400 mt-0.5">Controls CPU use while Ambit is idle</div>
+                                </div>
+                                <div className="inline-flex rounded-lg border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-black/20 p-0.5">
+                                    {THUMBNAIL_PROFILE_OPTIONS.map(option => {
+                                        const isActive = (settings.thumbnailOptimizationProfile ?? 'balanced') === option.id;
+                                        return (
+                                            <button
+                                                key={option.id}
+                                                type="button"
+                                                onClick={() => {
+                                                    setSettings(prev => ({ ...prev, thumbnailOptimizationProfile: option.id }));
+                                                    addToast(`Thumbnail speed set to ${option.label}`, 'success');
+                                                }}
+                                                className={`px-2.5 py-1 text-xs font-bold rounded-md transition-colors ${isActive
+                                                    ? 'bg-white dark:bg-white/10 text-gray-900 dark:text-white shadow-sm'
+                                                    : 'text-gray-500 hover:text-gray-900 dark:hover:text-gray-200'
+                                                    }`}
+                                            >
+                                                {option.label}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+
+                            <div className="border-t border-gray-100 dark:border-white/10 pt-4">
+                                <div className="flex items-center justify-between gap-3">
+                                    <div className="text-sm font-medium text-gray-800 dark:text-gray-300">Smart Thumbnail Status</div>
+                                    <div className="text-xs font-bold text-gray-600 dark:text-gray-300">{smartThumbnailStatus}</div>
+                                </div>
+                                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+                                    {showLastThumbnailRun && lastThumbnailRun && (
+                                        <span>Last run {formatDuration(lastThumbnailRun.durationMs)}</span>
+                                    )}
+                                    <span>Speed {formatRate(getThumbnailMetricValue(thumbnailDetails, lastThumbnailRun, 'imagesPerSecond'))}</span>
+                                    <span>Optimized {formatNumber(getThumbnailMetricValue(thumbnailDetails, lastThumbnailRun, 'optimized'))}</span>
+                                    <span>Reused {formatNumber(getThumbnailMetricValue(thumbnailDetails, lastThumbnailRun, 'reused'))}</span>
+                                    <span>Failed {formatNumber(failedThumbnailCount)}</span>
+                                    <span>Skipped {formatNumber(getThumbnailMetricValue(thumbnailDetails, lastThumbnailRun, 'skipped'))}</span>
+                                </div>
+                                <div className="mt-3">
+                                    <button
+                                        type="button"
+                                        onClick={handleToggleFailures}
+                                        className={`inline-flex items-center gap-1.5 text-xs font-bold transition-colors ${hasKnownThumbnailFailures
+                                            ? 'text-amber-600 hover:text-amber-700 dark:text-amber-300 dark:hover:text-amber-200'
+                                            : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+                                            }`}
+                                    >
+                                        <AlertTriangle className="w-3.5 h-3.5" />
+                                        {failurePanelOpen ? 'Hide failures' : (hasKnownThumbnailFailures ? 'View failures' : 'Check failures')}
+                                        <ChevronDown className={`w-3.5 h-3.5 transition-transform ${failurePanelOpen ? 'rotate-180' : ''}`} />
+                                    </button>
+
+                                    {failurePanelOpen && (
+                                        <div className="mt-3 space-y-3 border-l border-amber-200 dark:border-amber-400/20 pl-3">
+                                            <div className="flex items-center justify-between gap-3">
+                                                <div className="text-xs font-medium text-gray-700 dark:text-gray-300">Recent thumbnail failures</div>
+                                                <button
+                                                    type="button"
+                                                    onClick={handleRetryFailedThumbnails}
+                                                    disabled={!canRetryThumbnailFailures}
+                                                    className="inline-flex items-center gap-1.5 text-xs font-bold text-gray-700 dark:text-gray-200 hover:text-sage-600 dark:hover:text-sage-300 disabled:opacity-50 disabled:hover:text-gray-700 dark:disabled:hover:text-gray-200 transition-colors"
+                                                >
+                                                    {isRetryingFailures ? (
+                                                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                                                    ) : (
+                                                        <RefreshCw className="w-3.5 h-3.5" />
+                                                    )}
+                                                    Retry all
+                                                </button>
+                                            </div>
+
+                                            {failureLoadState === 'loading' && (
+                                                <div className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                                                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                                                    Loading failures...
+                                                </div>
+                                            )}
+
+                                            {failureLoadState === 'error' && (
+                                                <div className="text-xs text-amber-600 dark:text-amber-300">
+                                                    Failed to load thumbnail failures: {failureLoadError}
+                                                </div>
+                                            )}
+
+                                            {failureLoadState === 'ready' && thumbnailFailures.length === 0 && (
+                                                <div className="text-xs text-gray-500 dark:text-gray-400">No thumbnail failures found.</div>
+                                            )}
+
+                                            {failureLoadState === 'ready' && thumbnailFailures.length > 0 && (
+                                                <div className="max-h-56 overflow-y-auto space-y-2 pr-1">
+                                                    {thumbnailFailures.map(failure => (
+                                                        <div key={failure.id} className="text-xs">
+                                                            <div className="font-medium text-gray-800 dark:text-gray-200 truncate" title={failure.path}>
+                                                                {getFileNameFromPath(failure.path)}
+                                                            </div>
+                                                            <div className="text-gray-500 dark:text-gray-400 break-all">{failure.path}</div>
+                                                            <div className="mt-0.5 flex flex-wrap gap-x-3 gap-y-0.5 text-gray-400">
+                                                                <span>Attempts {formatNumber(failure.failureCount)}</span>
+                                                                <span>{formatAttemptTime(failure.lastAttemptAt)}</span>
+                                                                <span className="text-amber-600 dark:text-amber-300">{failure.lastError ?? 'Unknown error'}</span>
+                                                            </div>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
                         </div>
                     )
                 }

--- a/src/features/settings/components/__tests__/GeneralTab.test.tsx
+++ b/src/features/settings/components/__tests__/GeneralTab.test.tsx
@@ -1,0 +1,213 @@
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { fireEvent, render, screen, waitFor } from '../../../../test/testUtils';
+import { useLibraryStore } from '../../../../stores/libraryStore';
+import { GeneralTab } from '../GeneralTab';
+import type { AppSettings } from '../../../../types';
+
+const mockAddToast = vi.fn();
+vi.mock('../../../../hooks/useToast', () => ({
+    useToast: () => ({
+        addToast: mockAddToast
+    })
+}));
+
+const createSettings = (): AppSettings => ({
+    hasCompletedOnboarding: true,
+    theme: 'dark',
+    thumbnailSize: 200,
+    autoCheckForUpdates: true,
+    confirmDelete: true,
+    defaultTheaterMode: false,
+    monitoredFolders: [],
+    maskedKeywords: [],
+    maskingMode: 'blur',
+    enableAI: false,
+    enableAutoThumbnailHealing: true,
+    enforceHighQualityThumbnails: false,
+    thumbnailOptimizationProfile: 'balanced',
+    logLevel: 'info'
+});
+
+describe('GeneralTab Smart Thumbnail details', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(invoke).mockReset();
+        useLibraryStore.setState(useLibraryStore.getInitialState(), true);
+    });
+
+    it('renders active optimizer status and metrics without an ETA', () => {
+        useLibraryStore.setState({
+            isBackgroundHealingActive: true,
+            backgroundHealingPaused: false,
+            backgroundHealingDetails: {
+                checked: 1489,
+                optimized: 1489,
+                reused: 233,
+                failed: 2,
+                skipped: 11,
+                imagesPerSecond: 12.4,
+                batchMs: 210,
+                dbMs: 32,
+                encodeMs: 1120,
+                profile: 'balanced',
+                phase: 'throttled',
+                isThrottled: true
+            }
+        });
+
+        render(<GeneralTab settings={createSettings()} setSettings={vi.fn()} />);
+
+        expect(screen.getByText('Smart Thumbnail Status')).toBeTruthy();
+        expect(screen.getByText('Throttled')).toBeTruthy();
+        expect(screen.getByText(/Speed\s+12\/s/)).toBeTruthy();
+        expect(screen.getByText(/Optimized\s+1,489/)).toBeTruthy();
+        expect(screen.getByText(/Reused\s+233/)).toBeTruthy();
+        expect(screen.getByText(/Failed\s+2/)).toBeTruthy();
+        expect(screen.getByText(/Skipped\s+11/)).toBeTruthy();
+        expect(screen.queryByText(/eta/i)).toBeNull();
+    });
+
+    it('keeps the last completed run visible when the optimizer is idle', () => {
+        useLibraryStore.setState({
+            isBackgroundHealingActive: false,
+            backgroundHealingPaused: false,
+            backgroundHealingDetails: null,
+            lastBackgroundHealingRun: {
+                checked: 25000,
+                optimized: 25000,
+                reused: 0,
+                failed: 0,
+                skipped: 0,
+                imagesPerSecond: 59.52,
+                durationMs: 420000,
+                completedAt: 1777824000000,
+                profile: 'fast'
+            }
+        });
+
+        render(<GeneralTab settings={createSettings()} setSettings={vi.fn()} />);
+
+        expect(screen.getByText('Idle')).toBeTruthy();
+        expect(screen.getByText(/Last run\s+7m 0s/)).toBeTruthy();
+        expect(screen.getByText(/Speed\s+60\/s/)).toBeTruthy();
+        expect(screen.getByText(/Optimized\s+25,000/)).toBeTruthy();
+        expect(screen.queryByText(/eta/i)).toBeNull();
+    });
+
+    it('lazy loads failed thumbnail details and retries all failures', async () => {
+        vi.mocked(invoke)
+            .mockResolvedValueOnce({
+                failures: [
+                    {
+                        id: 'img-failed',
+                        path: 'C:/library/failed-image.png',
+                        thumbnailPath: 'C:/thumbs/failed-image.webp',
+                        failureCount: 2,
+                        lastError: 'Failed to decode image',
+                        lastAttemptAt: 1777824000000
+                    }
+                ]
+            })
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce({ failures: [] });
+
+        useLibraryStore.setState({
+            isBackgroundHealingActive: false,
+            backgroundHealingPaused: false,
+            backgroundHealingDetails: null,
+            lastBackgroundHealingRun: {
+                checked: 25000,
+                optimized: 24993,
+                reused: 0,
+                failed: 1,
+                skipped: 0,
+                imagesPerSecond: 59.52,
+                durationMs: 420000,
+                completedAt: 1777824000000,
+                profile: 'fast'
+            }
+        });
+
+        const retrySignalBefore = useLibraryStore.getState().thumbnailOptimizationRetrySignal;
+        render(<GeneralTab settings={createSettings()} setSettings={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /view failures/i }));
+
+        expect(await screen.findByText('failed-image.png')).toBeTruthy();
+        expect(screen.getByText('Failed to decode image')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: /retry all/i }));
+
+        await waitFor(() => {
+            expect(useLibraryStore.getState().thumbnailOptimizationRetrySignal).toBe(retrySignalBefore + 1);
+        });
+        expect(await screen.findByText('No thumbnail failures found.')).toBeTruthy();
+        expect(invoke).toHaveBeenCalledWith('get_thumbnail_optimization_failures', { limit: 50 });
+        expect(invoke).toHaveBeenCalledWith('retry_failed_thumbnail_optimizations');
+    });
+
+    it('can check persisted failures even when the current store has no failure count', async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            failures: [
+                {
+                    id: 'persisted-failure',
+                    path: 'C:/library/persisted.png',
+                    thumbnailPath: null,
+                    failureCount: 1,
+                    lastError: 'File unavailable',
+                    lastAttemptAt: 1777824000000
+                }
+            ]
+        });
+
+        render(<GeneralTab settings={createSettings()} setSettings={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /check failures/i }));
+
+        expect(await screen.findByText('persisted.png')).toBeTruthy();
+        expect(screen.getByText('File unavailable')).toBeTruthy();
+        expect(invoke).toHaveBeenCalledWith('get_thumbnail_optimization_failures', { limit: 50 });
+    });
+
+    it('does not allow retry while the thumbnail optimizer is already running', async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            failures: [
+                {
+                    id: 'running-failure',
+                    path: 'C:/library/running.png',
+                    thumbnailPath: null,
+                    failureCount: 1,
+                    lastError: 'Decode failed',
+                    lastAttemptAt: 1777824000000
+                }
+            ]
+        });
+        useLibraryStore.setState({
+            isBackgroundHealingActive: true,
+            backgroundHealingPaused: false,
+            backgroundHealingDetails: {
+                checked: 10,
+                optimized: 8,
+                reused: 0,
+                failed: 1,
+                skipped: 0,
+                imagesPerSecond: 2,
+                batchMs: 0,
+                dbMs: 0,
+                encodeMs: 0,
+                profile: 'balanced',
+                phase: 'running',
+                isThrottled: false
+            }
+        });
+
+        render(<GeneralTab settings={createSettings()} setSettings={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /view failures/i }));
+
+        const retryButton = await screen.findByRole('button', { name: /retry all/i });
+        expect(retryButton).toHaveProperty('disabled', true);
+    });
+});

--- a/src/hooks/__tests__/thumbnailQueueProgress.test.ts
+++ b/src/hooks/__tests__/thumbnailQueueProgress.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+    formatThumbnailQueueCompleteMessage,
+    formatThumbnailQueueRunningMessage
+} from '../thumbnailQueueProgress';
+
+describe('thumbnail queue progress copy', () => {
+    it('focuses on optimized thumbnails when checked and optimized counts match', () => {
+        expect(formatThumbnailQueueRunningMessage({
+            checked: 340,
+            optimized: 340,
+            failed: 0
+        })).toBe('Optimized 340 thumbnails');
+    });
+
+    it('keeps checked count secondary when not every checked image was optimized', () => {
+        expect(formatThumbnailQueueRunningMessage({
+            checked: 340,
+            optimized: 338,
+            failed: 0
+        })).toBe('Optimized 338 thumbnails after checking 340 images');
+    });
+
+    it('uses a distinct complete message when no updates were needed', () => {
+        expect(formatThumbnailQueueCompleteMessage({
+            checked: 340,
+            optimized: 0,
+            failed: 0
+        })).toBe('Finished: no thumbnail updates needed');
+    });
+
+    it('uses attention copy for failures', () => {
+        expect(formatThumbnailQueueRunningMessage({
+            checked: 340,
+            optimized: 338,
+            failed: 2
+        })).toBe('Optimized 338 thumbnails; 2 need attention');
+    });
+});

--- a/src/hooks/__tests__/useThumbnailQueue.test.ts
+++ b/src/hooks/__tests__/useThumbnailQueue.test.ts
@@ -12,8 +12,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
  * 
  * The hook:
  * - Defers startup by 30 seconds to avoid blocking app initialization
- * - Fetches candidate entries before showing progress
+ * - Starts the backend-owned thumbnail optimization job
+ * - Listens for backend progress and completion events
  * - Pauses when `isImporting`, `isRegeneratingThumbnails`, or `syncStatus === 'syncing'`
+ * - Throttles instead of cancelling during ordinary image queries
  * - Resumes automatically when blocking activities complete
  * - Respects `enableAutoThumbnailHealing` settings flag
  * - Updates libraryStore progress state for ActivityDock visibility
@@ -38,13 +40,21 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).not.toContain('STARTUP_DELAY_MS = 5000');
     });
 
-    it('should fetch candidate entries before showing progress', async () => {
+    it('should start the backend job instead of using the generic scanner loop', async () => {
         const fs = await import('fs/promises');
         const path = await import('path');
         const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
         const content = await fs.readFile(hookPath, 'utf-8');
 
-        expect(content).toContain('getUnoptimizedImageEntries');
+        expect(content).toContain('startThumbnailOptimizationJob');
+        expect(content).toContain('thumbnail-optimization-progress');
+        expect(content).toContain('thumbnail-optimization-complete');
+        expect(content).toContain('thumbnailOptimizationProfile');
+        expect(content).not.toContain('scanImagesBulk');
+        expect(content).not.toContain('updateThumbnailPathsBatch');
+        expect(content).not.toContain('BATCH_SIZE');
+        expect(content).not.toContain('BATCH_DELAY_MS');
+        expect(content).not.toContain('getUnoptimizedImageEntries');
         expect(content).not.toContain('getUnoptimizedImagesCount');
         expect(content).toContain('total: 0');
     });
@@ -68,9 +78,23 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).toContain('setBackgroundHealingActive');
         expect(content).toContain('setBackgroundHealingProgress');
         expect(content).toContain('setBackgroundHealingPaused');
+        expect(content).toContain('setBackgroundHealingDetails');
     });
 
-    it('should pause when import is active', async () => {
+    it('should respond to explicit thumbnail optimization retry requests', async () => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
+        const content = await fs.readFile(hookPath, 'utf-8');
+
+        expect(content).toContain('thumbnailOptimizationRetrySignal');
+        expect(content).toContain('retryAfterCurrentRunRef');
+        expect(content).toContain('postRunRetrySignal');
+        expect(content).toContain('scheduleIdleCallback(() => {');
+        expect(content).toContain('runQueue();');
+    });
+
+    it('should pause only for high-priority blocking work', async () => {
         const fs = await import('fs/promises');
         const path = await import('path');
         const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
@@ -79,6 +103,38 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).toContain('isImporting');
         expect(content).toContain('isRegeneratingThumbnails');
         expect(content).toContain('syncStatus');
+        expect(content).toContain('isHardBlocked');
+        expect(content).toContain('setThumbnailOptimizationThrottled');
+        expect(content).toContain('isImageQueryFetching');
+        expect(content).not.toContain("queryClient.isFetching({ queryKey: ['images'] }) > 0");
+    });
+
+    it('should keep image query throttling out of startup scheduling', async () => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
+        const content = await fs.readFile(hookPath, 'utf-8');
+
+        const runQueueStart = content.indexOf('const runQueue = useCallback');
+        const runQueueEnd = content.indexOf('const [isStartupDelayComplete', runQueueStart);
+        const runQueueBlock = content.slice(runQueueStart, runQueueEnd);
+        const runQueueDependencies = runQueueBlock.slice(runQueueBlock.lastIndexOf('    }, ['));
+
+        expect(content).toContain('isImageQueryFetchingRef');
+        expect(runQueueBlock).toContain('isImageQueryFetchingRef.current');
+        expect(runQueueDependencies).not.toContain('isImageQueryFetching');
+        expect(content).toContain('setBackendThrottled(isImageQueryFetching)');
+    });
+
+    it('should restart once for profile or quality setting changes', async () => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
+        const content = await fs.readFile(hookPath, 'utf-8');
+
+        expect(content).toContain('runningConfigRef');
+        expect(content).toContain('restartRequestedRef');
+        expect(content).toContain('Restarting backend job for Smart Thumbnail settings change');
         expect(content).toContain("queryKey: ['images']");
     });
 });

--- a/src/hooks/thumbnailQueueProgress.ts
+++ b/src/hooks/thumbnailQueueProgress.ts
@@ -1,0 +1,55 @@
+export interface ThumbnailQueueProgressCounts {
+    checked: number;
+    optimized: number;
+    failed: number;
+}
+
+export const THUMBNAIL_QUEUE_START_MESSAGE = 'Checking library thumbnails...';
+export const THUMBNAIL_QUEUE_RUNNING_FOOTER = 'Runs at low priority and throttles while you browse.';
+export const THUMBNAIL_QUEUE_COMPLETE_FOOTER = 'Library thumbnails are up to date.';
+export const THUMBNAIL_QUEUE_FAILURE_FOOTER = 'Some files may be corrupt or unavailable.';
+
+const formatUnit = (count: number, unit: string) => (
+    `${count.toLocaleString()} ${unit}${count === 1 ? '' : 's'}`
+);
+
+const formatAttention = (count: number) => (
+    count === 1 ? '1 needs attention' : `${count.toLocaleString()} need attention`
+);
+
+export const formatThumbnailQueueRunningMessage = ({
+    checked,
+    optimized,
+    failed
+}: ThumbnailQueueProgressCounts): string => {
+    if (checked <= 0) {
+        return THUMBNAIL_QUEUE_START_MESSAGE;
+    }
+
+    const optimizedText = formatUnit(optimized, 'thumbnail');
+
+    if (failed > 0) {
+        return `Optimized ${formatUnit(optimized, 'thumbnail')}; ${formatAttention(failed)}`;
+    }
+
+    if (checked !== optimized) {
+        return `Optimized ${formatUnit(optimized, 'thumbnail')} after checking ${formatUnit(checked, 'image')}`;
+    }
+
+    return `Optimized ${optimizedText}`;
+};
+
+export const formatThumbnailQueueCompleteMessage = ({
+    optimized,
+    failed
+}: ThumbnailQueueProgressCounts): string => {
+    if (failed > 0) {
+        return `Finished: ${formatUnit(optimized, 'thumbnail')} optimized; ${formatAttention(failed)}`;
+    }
+
+    if (optimized === 0) {
+        return 'Finished: no thumbnail updates needed';
+    }
+
+    return `Finished: ${formatUnit(optimized, 'thumbnail')} optimized`;
+};

--- a/src/hooks/useThumbnailQueue.ts
+++ b/src/hooks/useThumbnailQueue.ts
@@ -1,321 +1,421 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useIsFetching, useQueryClient } from '@tanstack/react-query';
-import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import {
+    commands,
+    type ThumbnailOptimizationProfile,
+    type ThumbnailOptimizationResult
+} from '../bindings';
 import { useLibraryStore } from '../stores/libraryStore';
 import { useSettingsStore } from '../stores/settingsStore';
 import { isBrowserMockMode } from '../services/runtime';
+import { unwrap } from '../utils/spectaUtils';
+import {
+    formatThumbnailQueueCompleteMessage,
+    formatThumbnailQueueRunningMessage,
+    THUMBNAIL_QUEUE_START_MESSAGE
+} from './thumbnailQueueProgress';
 
-// Delay before starting auto-healing on app startup (ms)
-// Ensures app initialization completes first
 const STARTUP_DELAY_MS = 30000;
-
-// Delay between batches to give UI breathing room (ms)
-const BATCH_DELAY_MS = 250;
-
-// Delay before resuming after import completes (ms)
 const RESUME_DELAY_MS = 5000;
+const COMPLETE_VISIBLE_MS = 1500;
+
+interface ThumbnailOptimizationProgress {
+    checked: number;
+    total: number;
+    optimized: number;
+    reused: number;
+    failed: number;
+    skipped: number;
+    imagesPerSecond: number;
+    batchMs: number;
+    dbMs: number;
+    encodeMs: number;
+    profile: ThumbnailOptimizationProfile;
+    phase: string;
+    message: string;
+    isThrottled: boolean;
+}
+
+type ToastFn = (message: string, type: 'success' | 'error' | 'info' | 'warning') => void;
+type RunningThumbnailConfig = {
+    includeUpgradeable: boolean;
+    profile: ThumbnailOptimizationProfile;
+};
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
 
 /**
- * Background thumbnail auto-healing queue.
- * 
- * This hook orchestrates automatic thumbnail regeneration in the background.
- * Key features:
- * - Deferred startup: Waits 30s after app launch to avoid blocking initialization
- * - Pause on import: Automatically pauses when user imports files
- * - Low priority: Uses requestIdleCallback (with fallback) for scheduling
- * - Progress tracking: Updates store for ActivityDock visibility
+ * Starts and supervises the backend-owned Smart Thumbnail optimization job.
+ *
+ * Rust owns candidate selection, thumbnail generation, DB updates, progress metrics,
+ * and cancellation. The hook only coordinates Settings, blocking activity, and the
+ * ActivityDock presentation.
  */
-export function useThumbnailQueue(addToast?: (message: string, type: 'success' | 'error' | 'info' | 'warning') => void): void {
+export function useThumbnailQueue(addToast?: ToastFn): void {
     const queryClient = useQueryClient();
     const activeImageQueryCount = useIsFetching({ queryKey: ['images'] });
-    const abortControllerRef = useRef<AbortController | null>(null);
     const isRunningRef = useRef(false);
+    const completionHandledRef = useRef(false);
+    const cancelRequestedRef = useRef(false);
+    const lastThrottleRef = useRef<boolean | null>(null);
+    const runningConfigRef = useRef<RunningThumbnailConfig | null>(null);
+    const restartRequestedRef = useRef(false);
+    const retryAfterCurrentRunRef = useRef(false);
+    const isImageQueryFetchingRef = useRef(false);
     const browserMockMode = isBrowserMockMode();
+    const [resumeSignal, setResumeSignal] = useState(0);
+    const [postRunRetrySignal, setPostRunRetrySignal] = useState(0);
 
-
-    // Store subscriptions
     const isImporting = useLibraryStore(s => s.isImporting);
     const isRegeneratingThumbnails = useLibraryStore(s => s.isRegeneratingThumbnails);
     const syncStatus = useLibraryStore(s => s.syncStatus);
+    const thumbnailOptimizationRetrySignal = useLibraryStore(s => s.thumbnailOptimizationRetrySignal);
 
     const setBackgroundHealingActive = useLibraryStore(s => s.setBackgroundHealingActive);
     const setBackgroundHealingProgress = useLibraryStore(s => s.setBackgroundHealingProgress);
     const setBackgroundHealingPaused = useLibraryStore(s => s.setBackgroundHealingPaused);
+    const setBackgroundHealingDetails = useLibraryStore(s => s.setBackgroundHealingDetails);
+    const setLastBackgroundHealingRun = useLibraryStore(s => s.setLastBackgroundHealingRun);
 
-    // Settings - check if auto-healing is enabled
-    // Note: No fallback needed since settingsStore merges loaded values with DEFAULT_SETTINGS
     const enableAutoThumbnailHealing = useSettingsStore(s => s.settings.enableAutoThumbnailHealing);
-    const enforceHighQualityThumbnails = useSettingsStore(s => s.settings.enforceHighQualityThumbnails); // New
+    const enforceHighQualityThumbnails = useSettingsStore(s => s.settings.enforceHighQualityThumbnails);
+    const thumbnailOptimizationProfile = useSettingsStore(s => s.settings.thumbnailOptimizationProfile ?? 'balanced');
     const isSettingsLoaded = useSettingsStore(s => s.isLoaded);
 
-    // Check if any blocking activity is happening
     const isImageQueryFetching = activeImageQueryCount > 0;
-    const isBlocked = isImporting || isRegeneratingThumbnails || syncStatus === 'syncing' || isImageQueryFetching;
+    const isHardBlocked = isImporting || isRegeneratingThumbnails || syncStatus === 'syncing';
 
-    /**
-     * Schedule a callback with low priority using requestIdleCallback.
-     * Falls back to setTimeout for browsers without support.
-     */
+    useEffect(() => {
+        isImageQueryFetchingRef.current = isImageQueryFetching;
+    }, [isImageQueryFetching]);
+
+    const shouldPauseForActivity = useCallback(() => {
+        const store = useLibraryStore.getState();
+        return store.isImporting
+            || store.isRegeneratingThumbnails
+            || store.syncStatus === 'syncing';
+    }, []);
+
     const scheduleIdleCallback = useCallback((callback: () => void, delay: number = 0) => {
-        if (delay > 0) {
-            setTimeout(() => {
-                if ('requestIdleCallback' in window) {
-                    (window as typeof window & { requestIdleCallback: (cb: () => void) => number })
-                        .requestIdleCallback(callback, { timeout: 2000 });
-                } else {
-                    setTimeout(callback, 50);
-                }
-            }, delay);
-        } else {
+        const schedule = () => {
             if ('requestIdleCallback' in window) {
-                (window as typeof window & { requestIdleCallback: (cb: () => void) => number })
+                (window as typeof window & { requestIdleCallback: (cb: () => void, options?: { timeout: number }) => number })
                     .requestIdleCallback(callback, { timeout: 2000 });
             } else {
                 setTimeout(callback, 50);
             }
-        }
-    }, []);
-
-    /**
-     * Main processing loop that regenerates unoptimized thumbnails.
-     */
-    const runQueue = useCallback(async () => {
-        if (browserMockMode) return;
-        if (isRunningRef.current) return;
-        isRunningRef.current = true;
-
-        const { getUnoptimizedImageEntries } = await import('../services/db/maintenanceRepo');
-        const { getThumbnailDir } = await import('../services/thumbnailService');
-        const { scanImagesBulk } = await import('../services/metadataParser');
-        const { updateThumbnailPathsBatch } = await import('../services/db/imageRepo');
-
-        // Removed commands import to use raw invoke
-
-
-        const abortController = new AbortController();
-        abortControllerRef.current = abortController;
-
-        // Track attempted IDs in this session to prevent infinite loops on failing images
-        const attemptedIds = new Set<string>();
-        const shouldPauseForActivity = () => {
-            const store = useLibraryStore.getState();
-            return store.isImporting
-                || store.isRegeneratingThumbnails
-                || store.syncStatus === 'syncing'
-                || queryClient.isFetching({ queryKey: ['images'] }) > 0;
         };
 
+        if (delay > 0) {
+            setTimeout(schedule, delay);
+            return;
+        }
+
+        schedule();
+    }, []);
+
+    const setBackendThrottled = useCallback((throttled: boolean) => {
+        if (browserMockMode) return;
+        if (lastThrottleRef.current === throttled) return;
+
+        lastThrottleRef.current = throttled;
+        void commands.setThumbnailOptimizationThrottled(throttled).catch(error => {
+            console.error('[ThumbnailQueue] Failed to update backend throttle state', error);
+        });
+
+        const details = useLibraryStore.getState().backgroundHealingDetails;
+        if (details) {
+            setBackgroundHealingDetails({
+                ...details,
+                phase: throttled ? 'throttled' : 'running',
+                isThrottled: throttled
+            });
+        }
+    }, [browserMockMode, setBackgroundHealingDetails]);
+
+    const refreshThumbnailConsumers = useCallback(async (optimized: number) => {
+        if (optimized <= 0) return;
+
+        await queryClient.invalidateQueries({ queryKey: ['images'] });
+        await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
+
         try {
-            const thumbDir = await getThumbnailDir();
-            if (!thumbDir) {
-                console.warn('[ThumbnailQueue] No thumbnail directory');
-                isRunningRef.current = false;
-                setBackgroundHealingActive(false);
-                return;
-            }
+            const { rebuildThumbnailFacetCache } = await import('../services/db/imageRepo');
+            await rebuildThumbnailFacetCache();
+            useLibraryStore.getState().incrementFacetCacheVersion();
+        } catch (error) {
+            console.warn('[ThumbnailQueue] Thumbnail facet cache refresh failed', error);
+        }
+    }, [queryClient]);
 
-            let processed = 0;
-            let hasStarted = false;
-            let wasPaused = false;
-            const PAGE_SIZE = 200;
-            const BATCH_SIZE = 20;
+    const handleCompletion = useCallback(async (result: ThumbnailOptimizationResult) => {
+        if (completionHandledRef.current) return;
+        completionHandledRef.current = true;
+        const completedConfig = runningConfigRef.current;
+        isRunningRef.current = false;
+        runningConfigRef.current = null;
+        lastThrottleRef.current = null;
 
-            // Process in pages
-            while (!abortController.signal.aborted) {
-                // Check if we should pause
-                if (shouldPauseForActivity()) {
-                    console.log('[ThumbnailQueue] Pausing for blocking activity');
-                    setBackgroundHealingPaused(true);
-                    wasPaused = true;
-                    break;
-                }
-
-                // Fetch next page of entries (passed includeUpgradeable)
-                // We always fetch from offset 0 because successful processing removes items from the "unoptimized" set
-                const entries = await getUnoptimizedImageEntries(0, PAGE_SIZE, '', [], enforceHighQualityThumbnails);
-
-                if (entries.length === 0) break;
-
-                // Infinite loop protection: Filter out images we've already tried and failed to fix in this session
-                const freshEntries = entries.filter(e => !attemptedIds.has(e.id));
-
-                if (freshEntries.length === 0) {
-                    console.warn('[ThumbnailQueue] Aborting: All remaining unoptimized images have failed processing in this session.');
-                    break;
-                }
-
-                if (!hasStarted) {
-                    console.log(`[ThumbnailQueue] Starting background healing (High Quality: ${enforceHighQualityThumbnails})`);
-                    setBackgroundHealingActive(true);
-                    setBackgroundHealingProgress({ current: 0, total: 0, message: 'Optimizing thumbnails...' });
-                    hasStarted = true;
-                }
-
-                // Process in smaller batches
-                for (let i = 0; i < freshEntries.length; i += BATCH_SIZE) {
-                    if (abortController.signal.aborted) break;
-
-                    // Double-check for blocking activity between batches
-                    if (shouldPauseForActivity()) {
-                        console.log('[ThumbnailQueue] Pausing mid-batch for blocking activity');
-                        setBackgroundHealingPaused(true);
-                        isRunningRef.current = false;
-                        return;
-                    }
-
-                    const batchEntries = freshEntries.slice(i, i + BATCH_SIZE);
-                    const batchIds = batchEntries.map(e => e.id);
-                    const batchPaths = batchEntries.map(e => e.path);
-
-                    // Register attempts immediately
-                    batchIds.forEach(id => attemptedIds.add(id));
-
-                    const dbUpdates: { id: string; thumbnailPath: string; microThumbnail?: string | null; thumbnailSource?: string | null }[] = [];
-
-                    try {
-                        // FIX: Pass actual file paths to scanner, NOT IDs
-                        const results = await scanImagesBulk(batchPaths, thumbDir, false, false);
-                        results.forEach((res, idx) => {
-                            if (res.thumbnail) {
-                                dbUpdates.push({
-                                    id: batchIds[idx],
-                                    thumbnailPath: res.thumbnail,
-                                    microThumbnail: res.microThumbnail || null,
-                                    thumbnailSource: res.thumbnailSource || 'ambit'
-                                });
-                            }
-                        });
-
-                        if (dbUpdates.length > 0) {
-                            await updateThumbnailPathsBatch(dbUpdates);
-
-                            // Sync with UI: Update React Query cache immediately
-                            // We must update ALL queries starting with 'images' to catch various filter states
-                            const queries = queryClient.getQueriesData({ queryKey: ['images'] });
-                            const { convertFileSrc } = await import('@tauri-apps/api/core');
-
-                            let updateCount = 0;
-
-                            queries.forEach(([queryKey, oldData]: [any, any]) => {
-                                if (!oldData || !oldData.pages) return;
-
-                                queryClient.setQueryData(queryKey, (old: any) => {
-                                    if (!old || !old.pages) return old;
-
-                                    return {
-                                        ...old,
-                                        pages: old.pages.map((page: any) => ({
-                                            ...page,
-                                            images: page.images.map((img: any) => {
-                                                const update = dbUpdates.find(u => u.id === img.id);
-                                                if (update) {
-                                                    updateCount++;
-                                                    return {
-                                                        ...img,
-                                                        // CRITICAL FIX: Ensure protocol is correct for SmartImage detection
-                                                        thumbnailUrl: convertFileSrc(update.thumbnailPath),
-                                                        microThumbnail: null,
-                                                        thumbnailSource: 'ambit'
-                                                    };
-                                                }
-                                                return img;
-                                            })
-                                        }))
-                                    };
-                                });
-                            });
-
-                            if (updateCount > 0) {
-                                console.log(`[ThumbnailQueue] Silently updated ${updateCount} images in query cache`);
-                            }
-                        }
-
-                        // Check for failures in this batch
-                        const failedIds: string[] = [];
-
-                        results.forEach((res, idx) => {
-                            // Check for error field OR missing thumbnail
-                            if (res.error || res.errorReason || (!res.thumbnail && !res.microThumbnail)) {
-                                const failedId = batchIds[idx];
-                                const failedPath = batchPaths[idx];
-                                const errorReason = res.errorReason || (res as any).error || "Unknown Failure";
-
-                                failedIds.push(failedId);
-
-                                console.error(`[ThumbnailQueue] Failed to generate thumbnail for ID: ${failedId}`, errorReason);
-
-                                if (addToast) {
-                                    // Use the error message from backend if available
-                                    addToast(`Thumbnail failed for ${failedPath.split(/[\\/]/).pop()}: ${errorReason}`, 'error');
-                                }
-                            }
-                        });
-
-                        // Quarantine corrupt images
-                        if (failedIds.length > 0) {
-                            try {
-                                await invoke('mark_images_corrupt', { ids: failedIds });
-                                console.log(`[ThumbnailQueue] Quarantined ${failedIds.length} corrupt images`);
-                            } catch (e) {
-                                console.error('[ThumbnailQueue] Failed to mark images as corrupt', e);
-                            }
-                        }
-                    } catch (e) {
-                        console.error(`[ThumbnailQueue] Batch failed at processed ${processed + i}`, e);
-                    }
-
-                    // Only increment processed count for what we actually attempted
-                    processed += batchEntries.length;
-
-                    setBackgroundHealingProgress({
-                        current: processed,
-                        total: 0,
-                        message: `Optimizing thumbnails...`
-                    });
-
-                    // Small delay between batches for UI responsiveness
-                    await new Promise(resolve => setTimeout(resolve, BATCH_DELAY_MS));
-                }
-            }
-
-            if (wasPaused) {
-                return;
-            }
-
-            if (!hasStarted) {
-                console.log('[ThumbnailQueue] No unoptimized images found');
+        if (result.wasCancelled) {
+            if (!useLibraryStore.getState().backgroundHealingPaused) {
+                retryAfterCurrentRunRef.current = false;
                 setBackgroundHealingActive(false);
                 setBackgroundHealingProgress(null);
-                isRunningRef.current = false;
-                return;
+                setBackgroundHealingDetails(null);
+            } else if (enableAutoThumbnailHealing && !shouldPauseForActivity()) {
+                retryAfterCurrentRunRef.current = false;
+                setResumeSignal(signal => signal + 1);
             }
+            return;
+        }
 
-            // Complete
-            if (!abortController.signal.aborted) {
-                console.log(`[ThumbnailQueue] Complete: processed ${processed} images`);
-                setBackgroundHealingProgress({ current: processed, total: processed, message: 'Optimization complete' });
+        const imagesPerSecond = result.durationMs > 0
+            ? result.checked / (result.durationMs / 1000)
+            : 0;
+        const completeCount = Math.max(result.checked, 1);
+        setBackgroundHealingActive(true);
+        setBackgroundHealingPaused(false);
+        setBackgroundHealingProgress({
+            current: completeCount,
+            total: completeCount,
+            message: formatThumbnailQueueCompleteMessage({
+                checked: result.checked,
+                optimized: result.optimized,
+                failed: result.failed
+            })
+        });
+        setBackgroundHealingDetails(null);
+        setLastBackgroundHealingRun({
+            checked: result.checked,
+            optimized: result.optimized,
+            reused: result.reused,
+            failed: result.failed,
+            skipped: result.skipped,
+            imagesPerSecond,
+            durationMs: result.durationMs,
+            completedAt: Date.now(),
+            profile: completedConfig?.profile ?? thumbnailOptimizationProfile
+        });
 
-                // Brief delay before hiding
-                await new Promise(resolve => setTimeout(resolve, 1500));
-                setBackgroundHealingActive(false);
-                setBackgroundHealingProgress(null);
+        void refreshThumbnailConsumers(result.optimized);
+
+        await sleep(COMPLETE_VISIBLE_MS);
+
+        if (!completionHandledRef.current || isRunningRef.current || useLibraryStore.getState().backgroundHealingPaused) {
+            return;
+        }
+
+        setBackgroundHealingActive(false);
+        setBackgroundHealingProgress(null);
+
+        if (retryAfterCurrentRunRef.current && enableAutoThumbnailHealing) {
+            retryAfterCurrentRunRef.current = false;
+            setPostRunRetrySignal(signal => signal + 1);
+        }
+    }, [
+        enableAutoThumbnailHealing,
+        refreshThumbnailConsumers,
+        setBackgroundHealingActive,
+        setBackgroundHealingDetails,
+        setBackgroundHealingPaused,
+        setBackgroundHealingProgress,
+        setLastBackgroundHealingRun,
+        shouldPauseForActivity,
+        thumbnailOptimizationProfile
+    ]);
+
+    useEffect(() => {
+        if (browserMockMode) return;
+
+        const unlistenProgress = listen<ThumbnailOptimizationProgress>(
+            'thumbnail-optimization-progress',
+            (event) => {
+                if (cancelRequestedRef.current) return;
+
+                setBackgroundHealingActive(true);
+                setBackgroundHealingPaused(false);
+                setBackgroundHealingProgress({
+                    current: event.payload.checked,
+                    total: 0,
+                    message: formatThumbnailQueueRunningMessage({
+                        checked: event.payload.checked,
+                        optimized: event.payload.optimized,
+                        failed: event.payload.failed
+                    })
+                });
+                setBackgroundHealingDetails({
+                    checked: event.payload.checked,
+                    optimized: event.payload.optimized,
+                    reused: event.payload.reused,
+                    failed: event.payload.failed,
+                    skipped: event.payload.skipped,
+                    imagesPerSecond: event.payload.imagesPerSecond,
+                    batchMs: event.payload.batchMs,
+                    dbMs: event.payload.dbMs,
+                    encodeMs: event.payload.encodeMs,
+                    profile: event.payload.profile,
+                    phase: event.payload.phase,
+                    isThrottled: event.payload.isThrottled
+                });
+
+                if (event.payload.checked > 0) {
+                    console.debug('[ThumbnailQueue] Backend progress', event.payload);
+                }
             }
+        );
 
-        } catch (e) {
-            console.error('[ThumbnailQueue] Error during background healing', e);
+        const unlistenComplete = listen<ThumbnailOptimizationResult>(
+            'thumbnail-optimization-complete',
+            (event) => {
+                void handleCompletion(event.payload);
+            }
+        );
+
+        return () => {
+            unlistenProgress.then(unlisten => unlisten());
+            unlistenComplete.then(unlisten => unlisten());
+        };
+    }, [
+        browserMockMode,
+        handleCompletion,
+        setBackgroundHealingActive,
+        setBackgroundHealingDetails,
+        setBackgroundHealingPaused,
+        setBackgroundHealingProgress
+    ]);
+
+    const cancelBackendJob = useCallback(async (clearDock: boolean) => {
+        if (browserMockMode) return;
+
+        cancelRequestedRef.current = true;
+
+        try {
+            await commands.cancelThumbnailOptimizationJob();
+        } catch (error) {
+            console.error('[ThumbnailQueue] Failed to cancel backend job', error);
+        }
+
+        if (clearDock) {
+            completionHandledRef.current = true;
+            isRunningRef.current = false;
+            runningConfigRef.current = null;
+            lastThrottleRef.current = null;
+            restartRequestedRef.current = false;
+            setBackgroundHealingActive(false);
+            setBackgroundHealingPaused(false);
+            setBackgroundHealingProgress(null);
+            setBackgroundHealingDetails(null);
+        }
+    }, [
+        browserMockMode,
+        setBackgroundHealingActive,
+        setBackgroundHealingDetails,
+        setBackgroundHealingPaused,
+        setBackgroundHealingProgress
+    ]);
+
+    const runQueue = useCallback(async () => {
+        if (browserMockMode) return;
+
+        const settings = useSettingsStore.getState().settings;
+        if (!settings.enableAutoThumbnailHealing) return;
+        if (isRunningRef.current) return;
+
+        if (shouldPauseForActivity()) {
+            setBackgroundHealingPaused(true);
+            return;
+        }
+
+        const { getThumbnailDir } = await import('../services/thumbnailService');
+        const thumbnailDir = await getThumbnailDir();
+
+        if (!thumbnailDir) {
+            console.warn('[ThumbnailQueue] No thumbnail directory');
             setBackgroundHealingActive(false);
             setBackgroundHealingProgress(null);
-        } finally {
-            isRunningRef.current = false;
-            abortControllerRef.current = null;
+            setBackgroundHealingDetails(null);
+            return;
         }
-    }, [setBackgroundHealingActive, setBackgroundHealingProgress, setBackgroundHealingPaused, browserMockMode, enforceHighQualityThumbnails, queryClient]);
+
+        const optimizerConfig: RunningThumbnailConfig = {
+            includeUpgradeable: Boolean(settings.enforceHighQualityThumbnails),
+            profile: settings.thumbnailOptimizationProfile ?? 'balanced'
+        };
+        const shouldStartThrottled = isImageQueryFetchingRef.current;
+
+        isRunningRef.current = true;
+        completionHandledRef.current = false;
+        cancelRequestedRef.current = false;
+        restartRequestedRef.current = false;
+        runningConfigRef.current = optimizerConfig;
+        setBackgroundHealingActive(true);
+        setBackgroundHealingPaused(false);
+        setBackgroundHealingProgress({
+            current: 0,
+            total: 0,
+            message: THUMBNAIL_QUEUE_START_MESSAGE
+        });
+        setBackgroundHealingDetails({
+            checked: 0,
+            optimized: 0,
+            reused: 0,
+            failed: 0,
+            skipped: 0,
+            imagesPerSecond: 0,
+            batchMs: 0,
+            dbMs: 0,
+            encodeMs: 0,
+            profile: optimizerConfig.profile,
+            phase: shouldStartThrottled ? 'throttled' : 'running',
+            isThrottled: shouldStartThrottled
+        });
+
+        console.log('[ThumbnailQueue] Starting backend thumbnail optimization', {
+            includeUpgradeable: optimizerConfig.includeUpgradeable,
+            profile: optimizerConfig.profile
+        });
+
+        try {
+            const jobPromise = unwrap(commands.startThumbnailOptimizationJob({
+                thumbnailDir,
+                includeUpgradeable: optimizerConfig.includeUpgradeable,
+                profile: optimizerConfig.profile
+            }));
+            setBackendThrottled(shouldStartThrottled);
+
+            const result = await jobPromise;
+
+            cancelRequestedRef.current = false;
+            await handleCompletion(result);
+        } catch (error) {
+            if (cancelRequestedRef.current) return;
+
+            console.error('[ThumbnailQueue] Backend thumbnail optimization failed', error);
+            addToast?.(`Smart thumbnail optimization failed: ${String(error)}`, 'error');
+            completionHandledRef.current = true;
+            isRunningRef.current = false;
+            runningConfigRef.current = null;
+            lastThrottleRef.current = null;
+            setBackgroundHealingActive(false);
+            setBackgroundHealingPaused(false);
+            setBackgroundHealingProgress(null);
+            setBackgroundHealingDetails(null);
+        }
+    }, [
+        addToast,
+        browserMockMode,
+        handleCompletion,
+        setBackendThrottled,
+        setBackgroundHealingActive,
+        setBackgroundHealingDetails,
+        setBackgroundHealingPaused,
+        setBackgroundHealingProgress,
+        shouldPauseForActivity
+    ]);
 
     const [isStartupDelayComplete, setStartupDelayComplete] = useState(false);
 
-    /**
-     * Handle initial startup delay.
-     */
     useEffect(() => {
         if (browserMockMode) return;
 
@@ -325,82 +425,136 @@ export function useThumbnailQueue(addToast?: (message: string, type: 'success' |
         return () => clearTimeout(timer);
     }, [browserMockMode]);
 
-    /**
-     * Reactive control: Start or Stop based on Settings & Delay
-     */
     useEffect(() => {
         if (browserMockMode) return;
-
-        // 1. Prerequisites check
         if (!isSettingsLoaded || !isStartupDelayComplete) return;
 
-        // 2. Handle Enabled State
         if (enableAutoThumbnailHealing) {
-            // Only start if not already running and not paused by blocking activity
-            if (!isRunningRef.current) {
-                // Check if we are blocked before starting
-                const store = useLibraryStore.getState();
-                const currentlyBlocked = store.isImporting
-                    || store.isRegeneratingThumbnails
-                    || store.syncStatus === 'syncing'
-                    || store.backgroundHealingPaused
-                    || queryClient.isFetching({ queryKey: ['images'] }) > 0;
-
-                if (!currentlyBlocked) {
-                    console.log('[ThumbnailQueue] Smart Optimization enabled and idle, starting...');
-                    scheduleIdleCallback(() => runQueue());
-                }
+            if (!isRunningRef.current && !shouldPauseForActivity() && !useLibraryStore.getState().backgroundHealingPaused) {
+                scheduleIdleCallback(() => runQueue());
             }
+            return;
         }
-        // 3. Handle Disabled State
-        else {
-            if (isRunningRef.current) {
-                console.log('[ThumbnailQueue] Smart Optimization disabled by user, aborting...');
 
-                // Cancel operation
-                if (abortControllerRef.current) {
-                    abortControllerRef.current.abort();
-                    abortControllerRef.current = null;
-                }
-
-                // Reset state
-                isRunningRef.current = false;
-                setBackgroundHealingActive(false);
-                setBackgroundHealingPaused(false); // Clear pause state since we are fully stopping
-                setBackgroundHealingProgress(null);
-            }
-        }
+        void cancelBackendJob(true);
     }, [
+        browserMockMode,
+        cancelBackendJob,
         enableAutoThumbnailHealing,
+        enforceHighQualityThumbnails,
+        isHardBlocked,
         isSettingsLoaded,
         isStartupDelayComplete,
         runQueue,
         scheduleIdleCallback,
-        setBackgroundHealingActive,
-        setBackgroundHealingPaused,
-        setBackgroundHealingProgress,
-        enforceHighQualityThumbnails, // Added trigger
-        isBlocked, // Added: Restart when no longer blocked
-        queryClient
+        shouldPauseForActivity,
+        thumbnailOptimizationProfile
     ]);
 
-    /**
-     * Resume processing when blocking activities complete.
-     */
+    useEffect(() => {
+        if (browserMockMode) return;
+        if (!enableAutoThumbnailHealing) return;
+        if (!isRunningRef.current) return;
+
+        const runningConfig = runningConfigRef.current;
+        if (!runningConfig) return;
+
+        const nextConfig: RunningThumbnailConfig = {
+            includeUpgradeable: Boolean(enforceHighQualityThumbnails),
+            profile: thumbnailOptimizationProfile
+        };
+
+        if (
+            runningConfig.includeUpgradeable === nextConfig.includeUpgradeable
+            && runningConfig.profile === nextConfig.profile
+        ) {
+            return;
+        }
+
+        if (restartRequestedRef.current) return;
+
+        console.log('[ThumbnailQueue] Restarting backend job for Smart Thumbnail settings change');
+        restartRequestedRef.current = true;
+        setBackgroundHealingPaused(true);
+        void cancelBackendJob(false);
+    }, [
+        browserMockMode,
+        cancelBackendJob,
+        enableAutoThumbnailHealing,
+        enforceHighQualityThumbnails,
+        setBackgroundHealingPaused,
+        thumbnailOptimizationProfile
+    ]);
+
+    useEffect(() => {
+        if (browserMockMode) return;
+        if (!enableAutoThumbnailHealing || !isRunningRef.current) {
+            lastThrottleRef.current = null;
+            return;
+        }
+
+        setBackendThrottled(isImageQueryFetching);
+    }, [
+        browserMockMode,
+        enableAutoThumbnailHealing,
+        isImageQueryFetching,
+        setBackendThrottled
+    ]);
+
+    useEffect(() => {
+        if (browserMockMode) return;
+        if (!enableAutoThumbnailHealing) return;
+        if (!isHardBlocked || !isRunningRef.current) return;
+
+        console.log('[ThumbnailQueue] Pausing backend job for blocking activity');
+        setBackgroundHealingPaused(true);
+        void cancelBackendJob(false);
+    }, [
+        browserMockMode,
+        cancelBackendJob,
+        enableAutoThumbnailHealing,
+        isHardBlocked,
+        setBackgroundHealingPaused
+    ]);
+
+    useEffect(() => {
+        if (browserMockMode) return;
+        if (!isSettingsLoaded) return;
+        if (!enableAutoThumbnailHealing) return;
+        if (thumbnailOptimizationRetrySignal === 0 && postRunRetrySignal === 0) return;
+        if (isRunningRef.current) {
+            retryAfterCurrentRunRef.current = true;
+            return;
+        }
+
+        if (shouldPauseForActivity()) {
+            setBackgroundHealingPaused(true);
+            return;
+        }
+
+        scheduleIdleCallback(() => {
+            runQueue();
+        });
+    }, [
+        browserMockMode,
+        enableAutoThumbnailHealing,
+        isSettingsLoaded,
+        postRunRetrySignal,
+        runQueue,
+        scheduleIdleCallback,
+        setBackgroundHealingPaused,
+        shouldPauseForActivity,
+        thumbnailOptimizationRetrySignal
+    ]);
+
     useEffect(() => {
         if (browserMockMode) return;
 
         const store = useLibraryStore.getState();
-
-        // Only resume if:
-        // 1. We were previously running (indicated by paused state)
-        // 2. Blocking activity is gone
-        // 3. Feature is still enabled
-        if (store.backgroundHealingPaused && !isBlocked && enableAutoThumbnailHealing) {
+        if (store.backgroundHealingPaused && !isHardBlocked && enableAutoThumbnailHealing) {
             console.log('[ThumbnailQueue] Resuming after blocking activity...');
             setBackgroundHealingPaused(false);
 
-            // Delay before resuming to let things settle
             const resumeTimer = setTimeout(() => {
                 scheduleIdleCallback(() => {
                     runQueue();
@@ -409,18 +563,24 @@ export function useThumbnailQueue(addToast?: (message: string, type: 'success' |
 
             return () => clearTimeout(resumeTimer);
         }
-    }, [isBlocked, runQueue, scheduleIdleCallback, setBackgroundHealingPaused, enableAutoThumbnailHealing, browserMockMode]);
+    }, [
+        browserMockMode,
+        enableAutoThumbnailHealing,
+        isHardBlocked,
+        resumeSignal,
+        runQueue,
+        scheduleIdleCallback,
+        setBackgroundHealingPaused
+    ]);
 
-    /**
-     * Cleanup on unmount.
-     */
     useEffect(() => {
         return () => {
-            if (abortControllerRef.current) {
-                abortControllerRef.current.abort();
+            if (isRunningRef.current) {
+                void commands.cancelThumbnailOptimizationJob().catch(console.error);
             }
             setBackgroundHealingActive(false);
             setBackgroundHealingProgress(null);
+            setBackgroundHealingDetails(null);
         };
-    }, [setBackgroundHealingActive, setBackgroundHealingProgress]);
+    }, [setBackgroundHealingActive, setBackgroundHealingDetails, setBackgroundHealingProgress]);
 }

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -1106,7 +1106,9 @@ export const clearAllThumbnailPaths = async (): Promise<number> => {
         let retries = 3;
         while (retries > 0) {
             try {
-                const result = await db.execute('UPDATE images SET thumbnail_path = NULL, micro_thumbnail = NULL, thumbnail_source = NULL WHERE thumbnail_path IS NOT NULL AND thumbnail_path != ""');
+                const result = await db.execute(
+                    'UPDATE images SET thumbnail_path = NULL, micro_thumbnail = NULL, thumbnail_source = NULL, thumbnail_version = 0, thumbnail_failure_count = 0, thumbnail_last_error = NULL, thumbnail_last_attempt_at = NULL WHERE thumbnail_path IS NOT NULL AND thumbnail_path != ""'
+                );
                 console.log('[DB] Cleared thumbnail paths:', result.rowsAffected);
                 return result.rowsAffected;
             } catch (e: unknown) {
@@ -1139,7 +1141,7 @@ export const updateThumbnailPath = async (id: string, thumbnailPath: string): Pr
     const normalizedId = normalizePath(id);
     const normalizedThumb = normalizePath(thumbnailPath);
     await db.execute(
-        'UPDATE images SET thumbnail_path = ?, thumbnail_source = ? WHERE id = ?',
+        'UPDATE images SET thumbnail_path = ?, thumbnail_source = ?, thumbnail_version = 1, thumbnail_failure_count = 0, thumbnail_last_error = NULL, thumbnail_last_attempt_at = NULL WHERE id = ?',
         [normalizedThumb, 'ambit', normalizedId]
     );
 };
@@ -1172,13 +1174,31 @@ export const updateThumbnailPathsBatch = async (updates: {
     for (const { id, thumbnailPath, microThumbnail, thumbnailSource } of updates) {
         const normalizedId = normalizePath(id);
         const normalizedThumb = normalizePath(thumbnailPath);
+        const normalizedSource = thumbnailSource || null;
 
         let retries = 3;
         while (retries > 0) {
             try {
                 await db.execute(
-                    'UPDATE images SET thumbnail_path = ?, micro_thumbnail = COALESCE(?, micro_thumbnail), thumbnail_source = COALESCE(?, thumbnail_source) WHERE id = ?',
-                    [normalizedThumb, microThumbnail || null, thumbnailSource || null, normalizedId]
+                    `UPDATE images
+                     SET thumbnail_path = ?,
+                         micro_thumbnail = COALESCE(?, micro_thumbnail),
+                         thumbnail_source = COALESCE(?, thumbnail_source),
+                         thumbnail_version = CASE WHEN COALESCE(?, thumbnail_source) = 'ambit' THEN 1 ELSE thumbnail_version END,
+                         thumbnail_failure_count = CASE WHEN COALESCE(?, thumbnail_source) = 'ambit' THEN 0 ELSE thumbnail_failure_count END,
+                         thumbnail_last_error = CASE WHEN COALESCE(?, thumbnail_source) = 'ambit' THEN NULL ELSE thumbnail_last_error END,
+                         thumbnail_last_attempt_at = CASE WHEN COALESCE(?, thumbnail_source) = 'ambit' THEN NULL ELSE thumbnail_last_attempt_at END
+                     WHERE id = ?`,
+                    [
+                        normalizedThumb,
+                        microThumbnail || null,
+                        normalizedSource,
+                        normalizedSource,
+                        normalizedSource,
+                        normalizedSource,
+                        normalizedSource,
+                        normalizedId
+                    ]
                 );
                 break;
             } catch (e: unknown) {

--- a/src/services/invoke/__tests__/syncService.test.ts
+++ b/src/services/invoke/__tests__/syncService.test.ts
@@ -234,6 +234,10 @@ describe('syncImages live mode', () => {
         expect(result.touchedFacetResources.loras).toEqual(['DetailBoost']);
         expect(result.touchedFacetResources.tools).toEqual(['invokeai']);
         expect(insertImagesBatch).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(insertImagesBatch).mock.calls[0][0][0]).toEqual(expect.objectContaining({
+            thumbnailSource: 'invokeai',
+            thumbnailUrl: 'D:/AI/art/webUI/invokeai/outputs/images/thumbnails/new-image.webp'
+        }));
         expect(syncCollectionImages).toHaveBeenCalledTimes(1);
         expect(syncCollectionImages).toHaveBeenCalledWith([
             'D:/AI/art/webUI/invokeai/outputs/images/new-image.png'
@@ -305,6 +309,10 @@ describe('syncImages live mode', () => {
 
         expect(result.imported).toBe(1);
         expect(insertImagesBatch).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(insertImagesBatch).mock.calls[0][0][0]).toEqual(expect.objectContaining({
+            thumbnailSource: 'invokeai',
+            thumbnailUrl: 'D:/AI/art/webUI/invokeai/outputs/images/thumbnails/startup-image.webp'
+        }));
         expect(syncCollectionImages).toHaveBeenCalledTimes(1);
         expect(syncCollectionImages).toHaveBeenCalledWith([
             'D:/AI/art/webUI/invokeai/outputs/images/startup-image.png'

--- a/src/services/invoke/syncService.ts
+++ b/src/services/invoke/syncService.ts
@@ -436,6 +436,7 @@ export const syncImages = async (
                     id: fullPath,
                     url: convertFileSrc(fullPath),
                     thumbnailUrl: thumbnailPath,
+                    thumbnailSource: 'invokeai',
                     filename: row.image_name,
                     fileSize: fileSize,
                     timestamp: timestamp || Date.now(),

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -12,6 +12,35 @@ export interface SyncProgress {
     message?: string;
 }
 
+export type ThumbnailOptimizationDetailProfile = 'quiet' | 'balanced' | 'fast';
+
+export interface ThumbnailOptimizationDetails {
+    checked: number;
+    optimized: number;
+    reused: number;
+    failed: number;
+    skipped: number;
+    imagesPerSecond: number;
+    batchMs: number;
+    dbMs: number;
+    encodeMs: number;
+    profile: ThumbnailOptimizationDetailProfile;
+    phase: string;
+    isThrottled: boolean;
+}
+
+export interface ThumbnailOptimizationRunSummary {
+    checked: number;
+    optimized: number;
+    reused: number;
+    failed: number;
+    skipped: number;
+    imagesPerSecond: number;
+    durationMs: number;
+    completedAt: number;
+    profile: ThumbnailOptimizationDetailProfile;
+}
+
 export type SyncStatus = 'idle' | 'syncing' | 'complete' | 'error';
 export type LiveWatchSessionSource = 'generic' | 'invoke' | 'mixed';
 export type LiveWatchSessionPhase = 'watching' | 'syncing' | 'importing' | 'summary';
@@ -151,7 +180,10 @@ interface LibraryState {
     // Background Auto-Healing State
     isBackgroundHealingActive: boolean;
     backgroundHealingProgress: SyncProgress | null;
+    backgroundHealingDetails: ThumbnailOptimizationDetails | null;
+    lastBackgroundHealingRun: ThumbnailOptimizationRunSummary | null;
     backgroundHealingPaused: boolean;
+    thumbnailOptimizationRetrySignal: number;
 
     // Background Metadata Refresh State
     isRefreshingMetadata: boolean;
@@ -206,7 +238,10 @@ interface LibraryState {
     // Background Healing Actions
     setBackgroundHealingActive: (val: boolean) => void;
     setBackgroundHealingProgress: (progress: SyncProgress | null) => void;
+    setBackgroundHealingDetails: (details: ThumbnailOptimizationDetails | null) => void;
+    setLastBackgroundHealingRun: (summary: ThumbnailOptimizationRunSummary | null) => void;
     setBackgroundHealingPaused: (val: boolean) => void;
+    requestThumbnailOptimizationRun: () => void;
 
     // Background Metadata Refresh Actions
     setIsRefreshingMetadata: (val: boolean) => void;
@@ -264,7 +299,10 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     // Background Healing State
     isBackgroundHealingActive: false,
     backgroundHealingProgress: null,
+    backgroundHealingDetails: null,
+    lastBackgroundHealingRun: null,
     backgroundHealingPaused: false,
+    thumbnailOptimizationRetrySignal: 0,
 
     // Background Metadata Refresh State
     isRefreshingMetadata: false,
@@ -375,7 +413,12 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     // Background Healing Actions
     setBackgroundHealingActive: (val) => set({ isBackgroundHealingActive: val }),
     setBackgroundHealingProgress: (progress) => set({ backgroundHealingProgress: progress }),
+    setBackgroundHealingDetails: (details) => set({ backgroundHealingDetails: details }),
+    setLastBackgroundHealingRun: (summary) => set({ lastBackgroundHealingRun: summary }),
     setBackgroundHealingPaused: (val) => set({ backgroundHealingPaused: val }),
+    requestThumbnailOptimizationRun: () => set((state) => ({
+        thumbnailOptimizationRetrySignal: state.thumbnailOptimizationRetrySignal + 1
+    })),
 
     // Background Metadata Refresh Actions
     setIsRefreshingMetadata: (val) => set({ isRefreshingMetadata: val, isActivityDockDismissed: val ? false : undefined }),

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -41,6 +41,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     hideImportModal: false,
     enableAutoThumbnailHealing: true,
     enforceHighQualityThumbnails: false,
+    thumbnailOptimizationProfile: 'balanced',
     logLevel: 'info'
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,7 @@ export interface AppSettings {
   devMode?: boolean; // Toggle for experimental/dev features
   enableAutoThumbnailHealing?: boolean; // Auto-regenerate thumbnails in background
   enforceHighQualityThumbnails?: boolean; // Upgrade existing low-res thumbnails
+  thumbnailOptimizationProfile?: 'quiet' | 'balanced' | 'fast'; // Background thumbnail worker profile
   logLevel?: LogLevel; // Console log severity level
 }
 


### PR DESCRIPTION
## Summary
- move automatic Smart Thumbnail work to a backend-owned optimizer job with progress events, throttling, cancellation, and queue metadata
- keep ActivityDock low-density while adding detailed status, failure diagnostics, and retry controls in Settings > General
- repair thumbnail source/version state for InvokeAI/external thumbnails and keep migration 56 startup-light
- add cache-empty recovery so interrupted thumbnail cache rebuilds resume correctly

## Verification
- pnpm run bindings:check
- pnpm run typecheck
- pnpm run test:run -- GeneralTab useThumbnailQueue thumbnailQueueProgress ActivityDock syncService
- cargo check --manifest-path src-tauri\Cargo.toml --lib
- pnpm run test:rust

## Notes
This branch was recovered from a stranded Codex working copy into a proper Git worktree, then rebased onto latest origin/main before push.