### PR TITLE
feat(compare): polish comparison interactions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -515,6 +515,7 @@ export default function App() {
                 collections={collections}
                 smartCollections={smartCollections}
                 toggleFavorite={toggleFavorite}
+                togglePin={actions.handlePinImage}
                 settings={settings}
                 filters={filters}
                 collectionToEditId={modals.collectionToEditId}

--- a/src/components/GlobalModals.tsx
+++ b/src/components/GlobalModals.tsx
@@ -50,6 +50,7 @@ interface GlobalModalsProps {
     collections: any[];
     smartCollections?: any[];
     toggleFavorite: (id: string) => void;
+    togglePin?: (id: string, isPinned: boolean) => void;
     settings: AppSettings;
     filters?: any;
     collectionToEditId?: string | null;
@@ -91,6 +92,7 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
     collections,
     smartCollections = [],
     toggleFavorite,
+    togglePin,
     settings,
     filters,
     collectionToEditId,
@@ -212,6 +214,7 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
                         imageB={filteredImages.find(i => i.id === Array.from(selectedIds)[1]) || filteredImages[1]}
                         onClose={() => closeModal('compare')}
                         onToggleFavorite={toggleFavorite}
+                        onTogglePin={togglePin}
                     />
                 )}
 

--- a/src/components/ui/GlobalModals.tsx
+++ b/src/components/ui/GlobalModals.tsx
@@ -114,7 +114,7 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
 }) => {
   const { settings, setSettings } = useSettings();
   const { collections, smartCollections } = useCollections();
-  const { images, toggleFavorite } = useSearch();
+  const { images, toggleFavorite, togglePin } = useSearch();
 
   // Individual tabs now handle their own toast notifications
   const close = (key: keyof typeof modals) => setModals((p: any) => ({ ...p, [key]: false }));
@@ -166,6 +166,7 @@ export const GlobalModals: React.FC<GlobalModalsProps> = ({
           imageB={images.find(i => i.id === Array.from(selectedIds)[1])!}
           onClose={() => close('compare')}
           onToggleFavorite={toggleFavorite}
+          onTogglePin={(id, isPinned) => { void togglePin(id, isPinned); }}
         />
       )}
 

--- a/src/features/maintenance/components/MaintenanceView.tsx
+++ b/src/features/maintenance/components/MaintenanceView.tsx
@@ -199,6 +199,19 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
         selectionRangeHandler(indexes, isAdditive);
     }, [selectionRangeHandler]);
 
+    const handleCompareTogglePin = useCallback((id: string, isPinned: boolean) => {
+        if (!onTogglePin) return;
+
+        setCompareImages(prev => {
+            if (!prev) return prev;
+            return [
+                prev[0].id === id ? { ...prev[0], isPinned } : prev[0],
+                prev[1].id === id ? { ...prev[1], isPinned } : prev[1]
+            ];
+        });
+        onTogglePin(id, isPinned);
+    }, [onTogglePin]);
+
 
     // --- Actions ---
 
@@ -634,6 +647,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
                     imageB={compareImages[1]}
                     onClose={() => setCompareImages(null)}
                     onToggleFavorite={(id) => onToggleFavorite?.(id)}
+                    onTogglePin={onTogglePin ? handleCompareTogglePin : undefined}
                 />
             )}
         </div>

--- a/src/features/viewer/components/CompareModal.tsx
+++ b/src/features/viewer/components/CompareModal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, ZoomIn, ZoomOut, RotateCcw, ArrowRightLeft, Columns, Layers, PanelLeft, ChevronRight, Sidebar, SplitSquareHorizontal, Heart, GitCompare, Eye, EyeOff } from 'lucide-react';
+import { X, ZoomIn, ZoomOut, RotateCcw, ArrowRightLeft, Columns, Layers, PanelLeft, ChevronRight, Sidebar, SplitSquareHorizontal, Heart, GitCompare, Eye, EyeOff, Pin } from 'lucide-react';
 import { AIImage } from '../../../types';
 import { SmartImage } from '../../library/components/SmartImage';
 import { getFilename } from '../../../utils/pathUtils';
@@ -11,35 +11,125 @@ interface CompareModalProps {
     imageB: AIImage;
     onClose: () => void;
     onToggleFavorite: (id: string) => void;
+    onTogglePin?: (id: string, isPinned: boolean) => void;
 }
 
 type CompareMode = 'split' | 'slider' | 'overlay';
 type DiffMode = 'diff' | 'raw';
 
-// Extracted Component to prevent re-renders
-const ImageContainer = ({
+const DIAGONAL_OFFSET_PX = 28;
+const DIAGONAL_DIVIDER_WIDTH_PX = 4;
+const CANVAS_PADDING_PX = 24;
+const SLIDER_HIT_TARGET_WIDTH_PX = 80;
+const SLIDER_EDGE_TRAVEL_PX = DIAGONAL_OFFSET_PX + Math.ceil(DIAGONAL_DIVIDER_WIDTH_PX / 2) + 2;
+
+interface MediaFrame {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}
+
+interface CanvasSize {
+    width: number;
+    height: number;
+}
+
+const getFittedRect = (
+    imageWidth: number,
+    imageHeight: number,
+    availableWidth: number,
+    availableHeight: number
+): MediaFrame => {
+    if (imageWidth <= 0 || imageHeight <= 0 || availableWidth <= 0 || availableHeight <= 0) {
+        return {
+            left: CANVAS_PADDING_PX,
+            top: CANVAS_PADDING_PX,
+            width: Math.max(0, availableWidth),
+            height: Math.max(0, availableHeight)
+        };
+    }
+
+    const scale = Math.min(availableWidth / imageWidth, availableHeight / imageHeight);
+    const width = imageWidth * scale;
+    const height = imageHeight * scale;
+
+    return {
+        left: CANVAS_PADDING_PX + (availableWidth - width) / 2,
+        top: CANVAS_PADDING_PX + (availableHeight - height) / 2,
+        width,
+        height
+    };
+};
+
+const getUnionFrame = (frameA: MediaFrame, frameB: MediaFrame): MediaFrame => {
+    const left = Math.min(frameA.left, frameB.left);
+    const top = Math.min(frameA.top, frameB.top);
+    const right = Math.max(frameA.left + frameA.width, frameB.left + frameB.width);
+    const bottom = Math.max(frameA.top + frameA.height, frameB.top + frameB.height);
+
+    return {
+        left,
+        top,
+        width: Math.max(0, right - left),
+        height: Math.max(0, bottom - top)
+    };
+};
+
+const framesAreEqual = (frameA: MediaFrame, frameB: MediaFrame) => (
+    Math.abs(frameA.left - frameB.left) < 0.5 &&
+    Math.abs(frameA.top - frameB.top) < 0.5 &&
+    Math.abs(frameA.width - frameB.width) < 0.5 &&
+    Math.abs(frameA.height - frameB.height) < 0.5
+);
+
+const getZoomedFrame = (
+    frame: MediaFrame,
+    canvasSize: CanvasSize,
+    position: { x: number, y: number },
+    scale: number
+): MediaFrame => {
+    if (canvasSize.width <= 0 || canvasSize.height <= 0) return frame;
+
+    const originX = canvasSize.width / 2;
+    const originY = canvasSize.height / 2;
+
+    return {
+        left: originX + position.x + (frame.left - originX) * scale,
+        top: originY + position.y + (frame.top - originY) * scale,
+        width: frame.width * scale,
+        height: frame.height * scale
+    };
+};
+
+const clampFrameToCanvas = (frame: MediaFrame, canvasSize: CanvasSize): MediaFrame => {
+    if (canvasSize.width <= 0 || canvasSize.height <= 0) return frame;
+
+    const left = Math.max(0, frame.left);
+    const top = Math.max(0, frame.top);
+    const right = Math.min(canvasSize.width, frame.left + frame.width);
+    const bottom = Math.min(canvasSize.height, frame.top + frame.height);
+
+    return {
+        left,
+        top,
+        width: Math.max(0, right - left),
+        height: Math.max(0, bottom - top)
+    };
+};
+
+const ImageActions = ({
     img,
     side,
-    position,
-    scale,
-    isDraggingCanvas,
-    onToggleFavorite
+    onToggleFavorite,
+    onTogglePin
 }: {
     img: AIImage,
     side: 'left' | 'right',
-    position: { x: number, y: number },
-    scale: number,
-    isDraggingCanvas: boolean,
-    onToggleFavorite: (id: string) => void
+    onToggleFavorite: (id: string) => void,
+    onTogglePin?: (id: string, isPinned: boolean) => void
 }) => (
-    <div className="relative w-full h-full flex items-center justify-center bg-zinc-950">
-        {/* Filename Tag */}
-        <div className={`absolute top-6 ${side === 'left' ? 'left-6' : 'right-6'} z-20 bg-black/70 backdrop-blur-md px-4 py-2 rounded-lg border border-white/10 shadow-xl pointer-events-none`}>
-            <div className="text-white text-xs font-bold">{getFilename(img.filename)}</div>
-            <div className="text-[10px] text-gray-400 font-mono mt-0.5">{img.width}x{img.height} • {img.metadata.model}</div>
-        </div>
-
-        {/* Heart Overlay */}
+    <div className={`absolute top-3 ${side === 'left' ? 'left-3' : 'right-3'} z-50 flex gap-2 pointer-events-auto`}>
         <button
             onMouseDown={(e) => e.stopPropagation()}
             onClick={(e) => {
@@ -47,15 +137,49 @@ const ImageContainer = ({
                 e.stopPropagation();
                 onToggleFavorite(img.id);
             }}
-            className={`absolute top-6 ${side === 'left' ? 'left-6 mt-14' : 'right-6 mt-14'} z-30 p-2.5 bg-black/60 hover:bg-black/90 rounded-full transition-all group cursor-pointer pointer-events-auto border border-white/10`}
+            className="p-2.5 bg-black/60 hover:bg-black/90 rounded-full transition-all group cursor-pointer border border-white/10 backdrop-blur-md"
             title={img.isFavorite ? "Remove from favorites" : "Add to favorites"}
         >
             <Heart className={`w-4 h-4 transition-transform group-hover:scale-110 ${img.isFavorite ? 'fill-red-500 text-red-500' : 'text-white'}`} />
         </button>
 
+        {onTogglePin && (
+            <button
+                onMouseDown={(e) => e.stopPropagation()}
+                onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onTogglePin(img.id, !img.isPinned);
+                }}
+                className="p-2.5 bg-black/60 hover:bg-black/90 rounded-full transition-all group cursor-pointer border border-white/10 backdrop-blur-md"
+                title={img.isPinned ? "Unpin" : "Pin to top"}
+            >
+                <Pin className={`w-4 h-4 transition-transform group-hover:scale-110 ${img.isPinned ? 'fill-sage-400 text-sage-400' : 'text-white'}`} />
+            </button>
+        )}
+    </div>
+);
+
+// Extracted Component to prevent re-renders
+const ImageContainer = ({
+    img,
+    position,
+    scale,
+    isDraggingCanvas,
+    imagePaddingClassName = 'p-6',
+    objectPosition = 'center'
+}: {
+    img: AIImage,
+    position: { x: number, y: number },
+    scale: number,
+    isDraggingCanvas: boolean,
+    imagePaddingClassName?: string,
+    objectPosition?: React.CSSProperties['objectPosition']
+}) => (
+    <div className="relative w-full h-full flex items-center justify-center bg-zinc-950">
         {/* Image Transform */}
         <div
-            className="w-full h-full flex items-center justify-center p-6 box-border"
+            className={`w-full h-full flex items-center justify-center ${imagePaddingClassName} box-border`}
             style={{ transform: `translate(${position.x}px, ${position.y}px) scale(${scale})`, transition: isDraggingCanvas ? 'none' : 'transform 0.1s ease-out' }}
         >
             <SmartImage
@@ -65,6 +189,7 @@ const ImageContainer = ({
                 imgClassName="w-full h-full object-contain shadow-2xl"
                 draggable={false}
                 objectFit="contain"
+                style={{ objectFit: 'contain', objectPosition }}
             />
         </div>
     </div>
@@ -74,7 +199,8 @@ export const CompareModal: React.FC<CompareModalProps> = ({
     imageA,
     imageB,
     onClose,
-    onToggleFavorite
+    onToggleFavorite,
+    onTogglePin
 }) => {
     // View State
     const [mode, setMode] = useState<CompareMode>('split');
@@ -82,6 +208,17 @@ export const CompareModal: React.FC<CompareModalProps> = ({
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [sliderPos, setSliderPos] = useState(50);
     const [diffMode, setDiffMode] = useState<DiffMode>('diff');
+    const [isOverlayHover, setIsOverlayHover] = useState(false);
+    const [mediaFrame, setMediaFrame] = useState<MediaFrame>({
+        left: CANVAS_PADDING_PX,
+        top: CANVAS_PADDING_PX,
+        width: 0,
+        height: 0
+    });
+    const [canvasSize, setCanvasSize] = useState<CanvasSize>({
+        width: 0,
+        height: 0
+    });
 
     const [panelWidth, setPanelWidth] = useState(400); // Widened for diff view
     const [isPanelOpen, setIsPanelOpen] = useState(true);
@@ -93,6 +230,55 @@ export const CompareModal: React.FC<CompareModalProps> = ({
     const dragStartRef = useRef({ x: 0, y: 0 });
     const sliderRef = useRef<HTMLDivElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
+    const activeMediaFrame = clampFrameToCanvas(
+        getZoomedFrame(mediaFrame, canvasSize, position, scale),
+        canvasSize
+    );
+    const activeMediaFrameRef = useRef(activeMediaFrame);
+
+    useEffect(() => {
+        activeMediaFrameRef.current = activeMediaFrame;
+    }, [activeMediaFrame]);
+
+    useEffect(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const updateMediaFrame = () => {
+            const rect = container.getBoundingClientRect();
+            const nextCanvasSize = {
+                width: rect.width,
+                height: rect.height
+            };
+            const availableWidth = Math.max(0, rect.width - CANVAS_PADDING_PX * 2);
+            const availableHeight = Math.max(0, rect.height - CANVAS_PADDING_PX * 2);
+            const nextFrame = getUnionFrame(
+                getFittedRect(imageA.width, imageA.height, availableWidth, availableHeight),
+                getFittedRect(imageB.width, imageB.height, availableWidth, availableHeight)
+            );
+
+            setCanvasSize(prev => (
+                Math.abs(prev.width - nextCanvasSize.width) < 0.5 &&
+                Math.abs(prev.height - nextCanvasSize.height) < 0.5
+            ) ? prev : nextCanvasSize);
+            setMediaFrame(prev => framesAreEqual(prev, nextFrame) ? prev : nextFrame);
+        };
+
+        updateMediaFrame();
+
+        if (typeof ResizeObserver === 'undefined') {
+            window.addEventListener('resize', updateMediaFrame);
+            return () => window.removeEventListener('resize', updateMediaFrame);
+        }
+
+        const observer = new ResizeObserver(updateMediaFrame);
+        observer.observe(container);
+        return () => observer.disconnect();
+    }, [imageA.width, imageA.height, imageB.width, imageB.height]);
+
+    useEffect(() => {
+        if (mode !== 'overlay') setIsOverlayHover(false);
+    }, [mode]);
 
     // --- Zoom/Pan Handlers ---
     const handleWheel = (e: React.WheelEvent) => {
@@ -122,8 +308,27 @@ export const CompareModal: React.FC<CompareModalProps> = ({
         if (isDraggingSlider && containerRef.current) {
             e.preventDefault();
             const rect = containerRef.current.getBoundingClientRect();
-            const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
-            setSliderPos((x / rect.width) * 100);
+            const frame = activeMediaFrameRef.current;
+            const travelLeft = frame.width > 0 ? frame.left - SLIDER_EDGE_TRAVEL_PX : 0;
+            const travelWidth = frame.width > 0 ? frame.width + SLIDER_EDGE_TRAVEL_PX * 2 : rect.width;
+            const x = Math.max(travelLeft, Math.min(e.clientX - rect.left, travelLeft + travelWidth));
+            setSliderPos(travelWidth > 0 ? ((x - travelLeft) / travelWidth) * 100 : 50);
+        }
+
+        if (mode === 'overlay' && containerRef.current) {
+            const rect = containerRef.current.getBoundingClientRect();
+            const frame = activeMediaFrameRef.current;
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            const isInsideFrame = (
+                frame.width > 0 &&
+                frame.height > 0 &&
+                x >= frame.left &&
+                x <= frame.left + frame.width &&
+                y >= frame.top &&
+                y <= frame.top + frame.height
+            );
+            setIsOverlayHover(isInsideFrame);
         }
     };
 
@@ -222,13 +427,43 @@ export const CompareModal: React.FC<CompareModalProps> = ({
         </div>
     );
 
-    const commonImageProps = { position, scale, isDraggingCanvas, onToggleFavorite };
+    const commonImageProps = { position, scale, isDraggingCanvas };
+    const sliderTravelLeft = activeMediaFrame.left - SLIDER_EDGE_TRAVEL_PX;
+    const sliderTravelWidth = activeMediaFrame.width + SLIDER_EDGE_TRAVEL_PX * 2;
+    const sliderTravelX = sliderTravelLeft + (sliderTravelWidth * sliderPos) / 100;
+    const sliderVisualX = Math.max(activeMediaFrame.left, Math.min(sliderTravelX, activeMediaFrame.left + activeMediaFrame.width));
+    const activeMediaFrameStyle: React.CSSProperties = {
+        left: activeMediaFrame.left,
+        top: activeMediaFrame.top,
+        width: activeMediaFrame.width,
+        height: activeMediaFrame.height
+    };
+    const sliderHandleStyle: React.CSSProperties = {
+        left: sliderVisualX,
+        top: activeMediaFrame.top,
+        height: activeMediaFrame.height,
+        width: SLIDER_HIT_TARGET_WIDTH_PX
+    };
+    const sliderDividerTrackStyle: React.CSSProperties = {
+        left: sliderTravelX - activeMediaFrame.left,
+        width: SLIDER_HIT_TARGET_WIDTH_PX
+    };
+    const overlayHintStyle: React.CSSProperties = {
+        left: activeMediaFrame.left + activeMediaFrame.width / 2,
+        top: Math.max(activeMediaFrame.top + 12, activeMediaFrame.top + activeMediaFrame.height - 48),
+        transform: 'translateX(-50%)'
+    };
+    const sliderClipPath = `polygon(${activeMediaFrame.left}px ${activeMediaFrame.top}px, ${sliderTravelX + DIAGONAL_OFFSET_PX}px ${activeMediaFrame.top}px, ${sliderTravelX - DIAGONAL_OFFSET_PX}px ${activeMediaFrame.top + activeMediaFrame.height}px, ${activeMediaFrame.left}px ${activeMediaFrame.top + activeMediaFrame.height}px)`;
+    const sliderDividerClipPath = `polygon(calc(50% + ${DIAGONAL_OFFSET_PX}px - ${DIAGONAL_DIVIDER_WIDTH_PX / 2}px) 0, calc(50% + ${DIAGONAL_OFFSET_PX}px + ${DIAGONAL_DIVIDER_WIDTH_PX / 2}px) 0, calc(50% - ${DIAGONAL_OFFSET_PX}px + ${DIAGONAL_DIVIDER_WIDTH_PX / 2}px) 100%, calc(50% - ${DIAGONAL_OFFSET_PX}px - ${DIAGONAL_DIVIDER_WIDTH_PX / 2}px) 100%)`;
 
     return (
         <div
             className="fixed inset-0 z-[70] bg-black flex flex-col animate-in fade-in duration-200"
             onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
+            onMouseLeave={() => {
+                handleMouseUp();
+                setIsOverlayHover(false);
+            }}
             onMouseMove={handleMouseMove}
             onClick={onClose}
         >
@@ -289,35 +524,52 @@ export const CompareModal: React.FC<CompareModalProps> = ({
 
                     {/* SPLIT */}
                     {mode === 'split' && (
-                        <>
-                            <div className="flex-1 border-r border-white/5 overflow-hidden relative">
-                                <ImageContainer img={imageA} side="left" {...commonImageProps} />
+                        <div className="absolute inset-0 p-6 flex gap-4 overflow-hidden">
+                            <div className="flex-1 overflow-hidden relative">
+                                <ImageContainer img={imageA} imagePaddingClassName="p-0" objectPosition="right center" {...commonImageProps} />
+                                <ImageActions img={imageA} side="left" onToggleFavorite={onToggleFavorite} onTogglePin={onTogglePin} />
                             </div>
                             <div className="flex-1 overflow-hidden relative">
-                                <ImageContainer img={imageB} side="right" {...commonImageProps} />
+                                <ImageContainer img={imageB} imagePaddingClassName="p-0" objectPosition="left center" {...commonImageProps} />
+                                <ImageActions img={imageB} side="right" onToggleFavorite={onToggleFavorite} onTogglePin={onTogglePin} />
                             </div>
-                        </>
+                        </div>
                     )}
 
                     {/* SLIDER */}
                     {mode === 'slider' && (
                         <div className="w-full h-full relative overflow-hidden flex items-center justify-center">
                             <div className="absolute inset-0 flex items-center justify-center">
-                                <ImageContainer img={imageB} side="right" {...commonImageProps} />
+                                <ImageContainer img={imageB} {...commonImageProps} />
                             </div>
                             <div
-                                className="absolute inset-0 flex items-center justify-center bg-[#050505] border-r border-sage-500 shadow-[2px_0_20px_rgba(0,0,0,0.8)]"
-                                style={{ clipPath: `inset(0 ${100 - sliderPos}% 0 0)` }}
+                                className="absolute inset-0 flex items-center justify-center bg-[#050505] shadow-[2px_0_20px_rgba(0,0,0,0.8)]"
+                                style={{ clipPath: sliderClipPath }}
                             >
-                                <ImageContainer img={imageA} side="left" {...commonImageProps} />
+                                <ImageContainer img={imageA} {...commonImageProps} />
+                            </div>
+                            <div className="absolute z-50 pointer-events-none" style={activeMediaFrameStyle}>
+                                <ImageActions img={imageA} side="left" onToggleFavorite={onToggleFavorite} onTogglePin={onTogglePin} />
+                                <ImageActions img={imageB} side="right" onToggleFavorite={onToggleFavorite} onTogglePin={onTogglePin} />
+                            </div>
+                            <div className="absolute z-40 overflow-hidden pointer-events-none" style={activeMediaFrameStyle}>
+                                <div
+                                    className="absolute top-0 h-full -translate-x-1/2"
+                                    style={sliderDividerTrackStyle}
+                                >
+                                    <div
+                                        className="absolute inset-0 bg-sage-500 shadow-[0_0_18px_rgba(115,140,85,0.45),2px_0_20px_rgba(0,0,0,0.8)]"
+                                        style={{ clipPath: sliderDividerClipPath }}
+                                    />
+                                </div>
                             </div>
                             <div
                                 ref={sliderRef}
-                                className="absolute top-0 bottom-0 w-1 bg-sage-500 cursor-ew-resize z-40 hover:bg-sage-400 transition-colors flex items-center justify-center group"
-                                style={{ left: `${sliderPos}%` }}
+                                className="absolute -translate-x-1/2 cursor-ew-resize z-40 flex items-center justify-center group"
+                                style={sliderHandleStyle}
                                 onMouseDown={handleSliderMouseDown}
                             >
-                                <div className="w-8 h-8 rounded-full bg-sage-500 flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform">
+                                <div className="w-8 h-8 rounded-full bg-sage-500 flex items-center justify-center shadow-lg group-hover:scale-110 transition-transform rotate-[4deg]">
                                     <ArrowRightLeft className="w-4 h-4 text-white" />
                                 </div>
                             </div>
@@ -326,15 +578,22 @@ export const CompareModal: React.FC<CompareModalProps> = ({
 
                     {/* OVERLAY */}
                     {mode === 'overlay' && (
-                        <div className="w-full h-full relative overflow-hidden flex items-center justify-center group">
+                        <div className="w-full h-full relative overflow-hidden flex items-center justify-center">
                             <div className="absolute inset-0 flex items-center justify-center">
-                                <ImageContainer img={imageA} side="left" {...commonImageProps} />
+                                <ImageContainer img={imageA} {...commonImageProps} />
                             </div>
-                            <div className="absolute inset-0 flex items-center justify-center transition-opacity duration-200 opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto">
-                                <ImageContainer img={imageB} side="right" {...commonImageProps} />
+                            <div className={`absolute inset-0 flex items-center justify-center transition-opacity duration-300 ease-out ${isOverlayHover ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}>
+                                <ImageContainer img={imageB} {...commonImageProps} />
                             </div>
-                            <div className="absolute bottom-12 bg-black/80 text-white px-4 py-2 rounded-full text-xs pointer-events-none border border-white/10 backdrop-blur-md">
-                                Hover to reveal <span className="font-bold text-sage-400">{getFilename(imageB.filename)}</span>
+                            <div className="absolute z-50 pointer-events-none" style={activeMediaFrameStyle}>
+                                <ImageActions img={imageA} side="left" onToggleFavorite={onToggleFavorite} onTogglePin={onTogglePin} />
+                                <ImageActions img={imageB} side="right" onToggleFavorite={onToggleFavorite} onTogglePin={onTogglePin} />
+                            </div>
+                            <div
+                                className="absolute z-40 bg-black/80 text-white px-4 py-2 rounded-full text-xs pointer-events-none border border-white/10 backdrop-blur-md"
+                                style={overlayHintStyle}
+                            >
+                                Hover to reveal comparison
                             </div>
                         </div>
                     )}


### PR DESCRIPTION
## Summary
- add a diagonal, image-bound swipe divider with endpoint compensation
- make comparison controls consistent with heart and pin actions across Split, Swipe, and Overlay
- make Swipe and Overlay use zoom-aware media-frame geometry so hover, clipping, and controls track the visible image area
- wire pin behavior through compare modal entry points, including maintenance compare state updates

## Impact
This improves the comparison modal styling and interaction consistency while keeping existing comparison modes, zoom, pan, favorite, and pin behavior intact.

## Validation
- `pnpm run typecheck`
- `pnpm run build`
- `git diff --check`
- Browser smoke check with mock images: opened compare modal, switched to Swipe, zoomed to 200%, switched to Overlay, and checked for console errors