### PR TITLE
[codex] add collection thumbnail hydration feedback

### DIFF
--- a/src/components/ui/CollectionThumbnailSkeleton.tsx
+++ b/src/components/ui/CollectionThumbnailSkeleton.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+
+interface CollectionThumbnailSkeletonProps {
+    className?: string;
+}
+
+export const CollectionThumbnailSkeleton: React.FC<CollectionThumbnailSkeletonProps> = ({
+    className = ''
+}) => (
+    <div
+        aria-label="Collection thumbnail loading"
+        data-testid="collection-thumbnail-skeleton"
+        className={`relative overflow-hidden bg-gray-200 dark:bg-white/10 border border-gray-200 dark:border-white/5 ${className}`}
+    >
+        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 dark:via-white/10 to-transparent -translate-x-full animate-shimmer" />
+    </div>
+);

--- a/src/features/collections/components/AddToCollectionModal.tsx
+++ b/src/features/collections/components/AddToCollectionModal.tsx
@@ -5,6 +5,8 @@ import { Search, Folder, ArrowUpDown, Check, X, Plus, Archive, Sparkles } from '
 import { Collection } from '../../../types';
 import { SearchInput } from '../../filters/components/FilterPrimitives';
 import { PrivacyAwareThumbnail } from '../../../components/ui/PrivacyAwareThumbnail';
+import { CollectionThumbnailSkeleton } from '../../../components/ui/CollectionThumbnailSkeleton';
+import { useCollectionStore } from '../../../stores/collectionStore';
 
 interface AddToCollectionModalProps {
     isOpen: boolean;
@@ -45,6 +47,7 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
     const [sort, setSort] = useState<CollectionSort>('date_desc');
     const [showSortMenu, setShowSortMenu] = useState(false);
     const [showArchived, setShowArchived] = useState(false);
+    const thumbnailHydrationPendingIds = useCollectionStore(s => s.thumbnailHydrationPendingIds);
 
     const allCollections = [...collections, ...smartCollections];
 
@@ -66,7 +69,7 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
             }
         });
 
-    const sortOptions = [
+    const sortOptions: Array<{ id: CollectionSort; label: string }> = [
         { id: 'date_desc', label: 'Recently Created' },
         { id: 'date_asc', label: 'Oldest Created' },
         { id: 'name_asc', label: 'Name (A-Z)' },
@@ -147,7 +150,7 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
                                             <button
                                                 key={opt.id}
                                                 onClick={() => {
-                                                    setSort(opt.id as any);
+                                                    setSort(opt.id);
                                                     setShowSortMenu(false);
                                                 }}
                                                 className={`w-full text-left px-4 py-2 text-xs flex items-center justify-between hover:bg-gray-100 dark:hover:bg-white/5 transition-colors ${sort === opt.id ? 'text-sage-600 dark:text-sage-400 font-bold bg-sage-50/50 dark:bg-sage-900/10' : 'text-gray-600 dark:text-gray-400'}`}
@@ -167,59 +170,73 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
                 <div className="max-h-[350px] overflow-y-auto custom-scrollbar p-2">
                     {filtered.length > 0 ? (
                         <div className="grid grid-cols-1 gap-1">
-                            {filtered.map(col => (
-                                <button
-                                    key={col.id}
-                                    onClick={() => onConfirm(selectedIds, col.id, mode, sourceCollectionId)}
-                                    className="w-full group text-left px-4 py-3 rounded-xl hover:bg-sage-50 dark:hover:bg-sage-900/10 flex items-center justify-between transition-all border border-transparent hover:border-sage-200/50 dark:hover:border-sage-500/20"
-                                >
-                                    <div className="flex items-center gap-3">
-                                        {col.thumbnail ? (
-                                            <div className="w-10 h-10 flex-shrink-0 relative">
-                                                <PrivacyAwareThumbnail
-                                                    src={col.thumbnail}
-                                                    safeSrc={col.safeThumbnail}
-                                                    alt=""
-                                                    isSensitive={col.thumbnailIsSensitive}
-                                                    wrapperClassName="w-full h-full rounded-lg"
-                                                    imgClassName="w-full h-full object-cover shadow-sm border border-gray-200 dark:border-white/5"
-                                                    fallback={col.filters ? <Sparkles className="w-5 h-5 text-sage-500 opacity-20" /> : <Folder className="w-5 h-5 opacity-20" />}
-                                                />
-                                                {col.color && (
-                                                    <div
-                                                        className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-900 shadow-sm ${getColorClass(col.color)}`}
+                            {filtered.map(col => {
+                                const showThumbnailSkeleton = !!thumbnailHydrationPendingIds[col.id] && !col.thumbnail;
+
+                                return (
+                                    <button
+                                        key={col.id}
+                                        onClick={() => onConfirm(selectedIds, col.id, mode, sourceCollectionId)}
+                                        className="w-full group text-left px-4 py-3 rounded-xl hover:bg-sage-50 dark:hover:bg-sage-900/10 flex items-center justify-between transition-all border border-transparent hover:border-sage-200/50 dark:hover:border-sage-500/20"
+                                    >
+                                        <div className="flex items-center gap-3">
+                                            {col.thumbnail ? (
+                                                <div className="w-10 h-10 flex-shrink-0 relative">
+                                                    <PrivacyAwareThumbnail
+                                                        src={col.thumbnail}
+                                                        safeSrc={col.safeThumbnail}
+                                                        alt=""
+                                                        isSensitive={col.thumbnailIsSensitive}
+                                                        wrapperClassName="w-full h-full rounded-lg"
+                                                        imgClassName="w-full h-full object-cover shadow-sm border border-gray-200 dark:border-white/5"
+                                                        fallback={col.filters ? <Sparkles className="w-5 h-5 text-sage-500 opacity-20" /> : <Folder className="w-5 h-5 opacity-20" />}
                                                     />
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <div
-                                                className={`w-10 h-10 rounded-lg flex items-center justify-center border border-gray-200 dark:border-white/5 flex-shrink-0 relative ${col.isArchived ? 'bg-sage-100/50 dark:bg-zinc-800/50' : 'bg-gray-100 dark:bg-zinc-800'}`}
-                                            >
-                                                {col.isArchived ? <Archive className="w-5 h-5 text-gray-400" /> : (col.filters ? <Sparkles className="w-5 h-5 text-sage-500" /> : <Folder className="w-5 h-5 text-gray-400 dark:text-zinc-500" />)}
-                                                {col.color && (
-                                                    <div
-                                                        className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-900 shadow-sm ${getColorClass(col.color)}`}
-                                                    />
-                                                )}
-                                            </div>
-                                        )}
-                                        <div>
-                                            <div className="flex items-center gap-2">
-                                                <div className="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-sage-700 dark:group-hover:text-sage-300 transition-colors">
-                                                    {col.name}
+                                                    {col.color && (
+                                                        <div
+                                                            className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-900 shadow-sm ${getColorClass(col.color)}`}
+                                                        />
+                                                    )}
                                                 </div>
-                                                {col.isArchived && (
-                                                    <span className="text-[8px] bg-gray-200 dark:bg-white/10 text-gray-500 px-1 rounded uppercase tracking-tighter">Archived</span>
-                                                )}
+                                            ) : showThumbnailSkeleton ? (
+                                                <div className="w-10 h-10 flex-shrink-0 relative">
+                                                    <CollectionThumbnailSkeleton className="w-full h-full rounded-lg" />
+                                                    {col.color && (
+                                                        <div
+                                                            className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-900 shadow-sm ${getColorClass(col.color)}`}
+                                                        />
+                                                    )}
+                                                </div>
+                                            ) : (
+                                                <div
+                                                    data-testid="collection-thumbnail-fallback"
+                                                    className={`w-10 h-10 rounded-lg flex items-center justify-center border border-gray-200 dark:border-white/5 flex-shrink-0 relative ${col.isArchived ? 'bg-sage-100/50 dark:bg-zinc-800/50' : 'bg-gray-100 dark:bg-zinc-800'}`}
+                                                >
+                                                    {col.isArchived ? <Archive className="w-5 h-5 text-gray-400" /> : (col.filters ? <Sparkles className="w-5 h-5 text-sage-500" /> : <Folder className="w-5 h-5 text-gray-400 dark:text-zinc-500" />)}
+                                                    {col.color && (
+                                                        <div
+                                                            className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-900 shadow-sm ${getColorClass(col.color)}`}
+                                                        />
+                                                    )}
+                                                </div>
+                                            )}
+                                            <div>
+                                                <div className="flex items-center gap-2">
+                                                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100 group-hover:text-sage-700 dark:group-hover:text-sage-300 transition-colors">
+                                                        {col.name}
+                                                    </div>
+                                                    {col.isArchived && (
+                                                        <span className="text-[8px] bg-gray-200 dark:bg-white/10 text-gray-500 px-1 rounded uppercase tracking-tighter">Archived</span>
+                                                    )}
+                                                </div>
+                                                <div className="text-[10px] text-gray-500 dark:text-gray-500 uppercase tracking-wider">{col.count ?? col.imageIds.length} images</div>
                                             </div>
-                                            <div className="text-[10px] text-gray-500 dark:text-gray-500 uppercase tracking-wider">{col.count ?? col.imageIds.length} images</div>
                                         </div>
-                                    </div>
-                                    <div className="opacity-0 group-hover:opacity-100 transform translate-x-2 group-hover:translate-x-0 transition-all text-sage-600">
-                                        <Plus className="w-4 h-4" />
-                                    </div>
-                                </button>
-                            ))}
+                                        <div className="opacity-0 group-hover:opacity-100 transform translate-x-2 group-hover:translate-x-0 transition-all text-sage-600">
+                                            <Plus className="w-4 h-4" />
+                                        </div>
+                                    </button>
+                                );
+                            })}
                         </div>
                     ) : (
                         <div className="py-12 flex flex-col items-center justify-center text-gray-400">

--- a/src/features/collections/components/__tests__/AddToCollectionModal.test.tsx
+++ b/src/features/collections/components/__tests__/AddToCollectionModal.test.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { render, screen } from '../../../../test/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Collection } from '../../../../types';
+import { useCollectionStore } from '../../../../stores/collectionStore';
+import { AddToCollectionModal } from '../AddToCollectionModal';
+
+vi.mock('framer-motion', () => {
+    type MotionDivProps = React.HTMLAttributes<HTMLDivElement> & {
+        initial?: unknown;
+        animate?: unknown;
+        exit?: unknown;
+    };
+
+    const MotionDiv = ({
+        children,
+        initial: _initial,
+        animate: _animate,
+        exit: _exit,
+        ...props
+    }: MotionDivProps) => <div {...props}>{children}</div>;
+
+    return {
+        AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+        motion: {
+            div: MotionDiv
+        }
+    };
+});
+
+vi.mock('../../../../components/ui/PrivacyAwareThumbnail', () => ({
+    PrivacyAwareThumbnail: ({ src }: { src?: string | null }) => (
+        <div data-testid="privacy-aware-thumbnail" data-src={src || ''} />
+    )
+}));
+
+const baseCollection: Collection = {
+    id: 'collection-1',
+    name: 'Collection One',
+    imageIds: [],
+    count: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    source: 'ambit'
+};
+
+const renderModal = (collections: Collection[]) => render(
+    <AddToCollectionModal
+        isOpen
+        onClose={() => { }}
+        collections={collections}
+        selectedIds={['image-1']}
+        onConfirm={() => { }}
+    />
+);
+
+describe('AddToCollectionModal thumbnail hydration states', () => {
+    beforeEach(() => {
+        useCollectionStore.setState(useCollectionStore.getInitialState(), true);
+    });
+
+    it('renders a skeleton for collections with pending thumbnail hydration', () => {
+        useCollectionStore.setState({
+            thumbnailHydrationPendingIds: {
+                'collection-1': true
+            }
+        });
+
+        renderModal([baseCollection]);
+
+        expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
+        expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();
+        expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
+    });
+});

--- a/src/features/filters/components/CollectionItem.tsx
+++ b/src/features/filters/components/CollectionItem.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { FolderInput, Archive, Folder, Sparkles, Check } from 'lucide-react';
 import { Collection, FilterState } from '../../../types';
 import { PrivacyAwareThumbnail } from '../../../components/ui/PrivacyAwareThumbnail';
+import { CollectionThumbnailSkeleton } from '../../../components/ui/CollectionThumbnailSkeleton';
 import { formatCountCompact } from '../../../utils/formatUtils';
 import { createCollectionSelectionFilters } from '../../../utils/filterState';
 
@@ -28,6 +29,7 @@ interface CollectionItemProps {
     onResetThumbnail?: (colId: string) => void;
     onDelete?: (colId: string) => void;
     viewMode?: 'grid' | 'list';
+    isThumbnailPending?: boolean;
 }
 
 const getColorClass = (colorName?: string) => {
@@ -59,10 +61,12 @@ export const CollectionItem: React.FC<CollectionItemProps> = ({
     dropTargetId,
     onResetThumbnail,
     onDelete,
-    viewMode = 'list'
+    viewMode = 'list',
+    isThumbnailPending = false
 }) => {
     const isSelected = filters.collectionId === col.id;
     const thumbUrl = col.thumbnail || '';
+    const showThumbnailSkeleton = isThumbnailPending && !thumbUrl;
     return (
         <div
             key={col.id}
@@ -120,8 +124,10 @@ export const CollectionItem: React.FC<CollectionItemProps> = ({
                                 imgClassName={`w-full h-full object-cover ${col.isArchived ? 'grayscale opacity-70' : ''}`}
                                 fallback={col.filters ? <Sparkles className="w-8 h-8 text-sage-500 opacity-20" /> : <Folder className="w-8 h-8 opacity-20" />}
                             />
+                        ) : showThumbnailSkeleton ? (
+                            <CollectionThumbnailSkeleton className="w-full h-full" />
                         ) : (
-                            <div className="w-full h-full flex items-center justify-center opacity-20">
+                            <div data-testid="collection-thumbnail-fallback" className="w-full h-full flex items-center justify-center opacity-20">
                                 {col.filters ? <Sparkles className="w-8 h-8 text-sage-500" /> : <Folder className="w-8 h-8" />}
                             </div>
                         )}
@@ -191,8 +197,13 @@ export const CollectionItem: React.FC<CollectionItemProps> = ({
                                 />
                                 {col.color && <div className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-800 ${getColorClass(col.color)}`} />}
                             </div>
+                        ) : showThumbnailSkeleton ? (
+                            <div className="relative w-8 h-8 flex-shrink-0">
+                                <CollectionThumbnailSkeleton className="w-full h-full rounded-lg" />
+                                {col.color && <div className={`absolute -bottom-1 -right-1 w-3 h-3 rounded-full border-2 border-white dark:border-zinc-800 ${getColorClass(col.color)}`} />}
+                            </div>
                         ) : (
-                            <div className={`w-8 h-8 rounded-lg flex items-center justify-center border border-gray-200 dark:border-white/5 flex-shrink-0 relative ${col.isArchived ? 'bg-sage-100/50 dark:bg-zinc-800/50' : 'bg-gray-100 dark:bg-zinc-800'}`}>
+                            <div data-testid="collection-thumbnail-fallback" className={`w-8 h-8 rounded-lg flex items-center justify-center border border-gray-200 dark:border-white/5 flex-shrink-0 relative ${col.isArchived ? 'bg-sage-100/50 dark:bg-zinc-800/50' : 'bg-gray-100 dark:bg-zinc-800'}`}>
                                 {col.isArchived ? (
                                     <Archive className="w-4 h-4 text-gray-400" />
                                 ) : col.filters ? (

--- a/src/features/filters/components/CollectionList.tsx
+++ b/src/features/filters/components/CollectionList.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Archive, ArrowUpDown, Search, Pin, Check, LayoutGrid, List as ListIcon, Calendar, Clock, ArrowDownWideNarrow, ArrowUpWideNarrow, SortDesc, SortAsc } from 'lucide-react';
-import { Collection, FilterState } from '../../../types';
+import type { Collection, CollectionSortOption, FilterState } from '../../../types';
 import { SearchInput, SortDropdown } from './FilterPrimitives';
 import { CollectionContextMenu } from '../../collections/components/CollectionContextMenu';
 import { CollectionItem } from './CollectionItem';
@@ -29,7 +29,20 @@ interface CollectionListProps<T extends Collection> {
     emptyMessage?: React.ReactNode;
 }
 
-export type CollectionSort = 'name_asc' | 'name_desc' | 'count_asc' | 'count_desc' | 'date_asc' | 'date_desc' | 'recent_desc' | 'recent_asc';
+const collectionSortIds: CollectionSortOption[] = [
+    'name_asc',
+    'name_desc',
+    'count_asc',
+    'count_desc',
+    'date_asc',
+    'date_desc',
+    'recent_desc',
+    'recent_asc'
+];
+
+const isCollectionSort = (id: unknown): id is CollectionSortOption => (
+    typeof id === 'string' && collectionSortIds.includes(id as CollectionSortOption)
+);
 
 export function CollectionList<T extends Collection>({
     collections,
@@ -54,16 +67,21 @@ export function CollectionList<T extends Collection>({
     const [showArchived, setShowArchived] = useState(false);
     const { settings, setSettings } = useSettings();
     const refreshSmartCounts = useCollectionStore(s => s.refreshSmartCounts);
-    const sort = (settings.resourceSortOptions?.['collections'] as CollectionSort) || 'recent_desc';
+    const thumbnailHydrationPendingIds = useCollectionStore(s => s.thumbnailHydrationPendingIds);
+    const persistedSort = settings.resourceSortOptions?.collections;
+    const sort: CollectionSortOption = isCollectionSort(persistedSort) ? persistedSort : 'recent_desc';
 
-    const setSort = (newSort: CollectionSort) => {
+    const setSort = (newSort: CollectionSortOption) => {
         setSettings(prev => ({
             ...prev,
             resourceSortOptions: {
                 ...(prev.resourceSortOptions || {}),
-                collections: newSort as any
+                collections: newSort
             }
         }));
+    };
+    const handleSortSelect = (id: string) => {
+        if (isCollectionSort(id)) setSort(id);
     };
     const [showSortMenu, setShowSortMenu] = useState(false);
     const [dropTargetId, setDropTargetId] = useState<string | null>(null);
@@ -205,7 +223,7 @@ export function CollectionList<T extends Collection>({
                         { id: 'count_asc', label: 'Fewest Images', icon: SortAsc },
                     ]}
                     currentValue={sort}
-                    onSelect={(id) => setSort(id as any)}
+                    onSelect={handleSortSelect}
                     align="left"
                     triggerClassName={(isOpen) => `transition-colors p-1.5 rounded-lg border ${isOpen ? 'text-sage-600 dark:text-sage-400 bg-sage-50 dark:bg-sage-900/40 border-sage-200 dark:border-sage-500/30' : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5'}`}
                 />
@@ -288,6 +306,7 @@ export function CollectionList<T extends Collection>({
                                             onResetThumbnail={onResetCollectionThumbnail}
                                             onDelete={onDeleteCollection}
                                             viewMode={viewMode}
+                                            isThumbnailPending={!!thumbnailHydrationPendingIds[col.id]}
                                         />
                                     </motion.div>
                                 ))}
@@ -336,6 +355,7 @@ export function CollectionList<T extends Collection>({
                                     onResetThumbnail={onResetCollectionThumbnail}
                                     onDelete={onDeleteCollection}
                                     viewMode={viewMode}
+                                    isThumbnailPending={!!thumbnailHydrationPendingIds[col.id]}
                                 />
                             </motion.div>
                         ))}

--- a/src/features/filters/components/ResourceSection.tsx
+++ b/src/features/filters/components/ResourceSection.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Search, Puzzle, Check, LayoutGrid, List as ListIcon, SortAsc, SortDesc, Clock, Calendar, ArrowDownWideNarrow, ArrowUpWideNarrow, Pin, Circle, CircleDot, Eye, EyeOff, RotateCcw } from 'lucide-react';
-import { AssetScope, FilterState } from '../../../types';
+import type { AssetScope, FacetSortOption, FilterState } from '../../../types';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { SectionHeader, SearchInput, SortDropdown } from './FilterPrimitives';
 import { formatCountCompact, formatModelName } from '../../../utils/formatUtils';
@@ -65,6 +65,21 @@ const compareWithNameTieBreak = (primary: number, a: ResourceItem, b: ResourceIt
     primary || compareByName(a, b)
 );
 
+const facetSortIds: FacetSortOption[] = [
+    'count_desc',
+    'count_asc',
+    'name_asc',
+    'name_desc',
+    'recent_desc',
+    'recent_asc',
+    'added_desc',
+    'added_asc'
+];
+
+const isFacetSortOption = (id: unknown): id is FacetSortOption => (
+    typeof id === 'string' && facetSortIds.includes(id as FacetSortOption)
+);
+
 export const ResourceSection: React.FC<ResourceSectionProps> = ({
     title,
     type,
@@ -85,7 +100,8 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
     // Get view mode from settings, default to 'list'
     const viewMode = settings.resourceViewModes?.[type] || 'list';
     // Get sort option from settings, default to 'count_desc'
-    const sortOption = settings.resourceSortOptions?.[type] || 'count_desc';
+    const persistedSortOption = settings.resourceSortOptions?.[type];
+    const sortOption: FacetSortOption = isFacetSortOption(persistedSortOption) ? persistedSortOption : 'count_desc';
 
     const toggleViewMode = useCallback((e: React.MouseEvent) => {
         e.stopPropagation();
@@ -99,7 +115,7 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
         }));
     }, [type, viewMode, setSettings]);
 
-    const setSortOption = useCallback((option: typeof sortOption) => {
+    const setSortOption = useCallback((option: FacetSortOption) => {
         setSettings(prev => ({
             ...prev,
             resourceSortOptions: {
@@ -108,6 +124,10 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
             }
         }));
     }, [type, setSettings]);
+
+    const handleSortSelect = useCallback((id: string) => {
+        if (isFacetSortOption(id)) setSortOption(id);
+    }, [setSortOption]);
 
     // Map UI type to FilterState key (checkpoints uses 'models' in FilterState for historical reasons)
     const filterKey: ResourceFilterKey = type === 'checkpoints' ? 'models' : type;
@@ -462,7 +482,7 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                                 { id: 'added_desc', label: 'Newest Added', icon: Calendar },
                             ]}
                             currentValue={sortOption}
-                            onSelect={(id) => setSortOption(id as any)}
+                            onSelect={handleSortSelect}
                             align="left"
                             triggerClassName={(isOpen) => `transition-colors p-1.5 rounded-lg border ${isOpen ? 'text-sage-600 dark:text-sage-400 bg-sage-50 dark:bg-sage-900/40 border-sage-200 dark:border-sage-500/30' : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5'}`}
                         />

--- a/src/features/filters/components/__tests__/CollectionItem.test.tsx
+++ b/src/features/filters/components/__tests__/CollectionItem.test.tsx
@@ -1,0 +1,109 @@
+import * as React from 'react';
+import { render, screen } from '../../../../test/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+import type { Collection, FilterState } from '../../../../types';
+import { CollectionItem } from '../CollectionItem';
+
+vi.mock('../../../../components/ui/PrivacyAwareThumbnail', () => ({
+    PrivacyAwareThumbnail: ({ src }: { src?: string | null }) => (
+        <div data-testid="privacy-aware-thumbnail" data-src={src || ''} />
+    )
+}));
+
+const filters: FilterState = {
+    searchQuery: '',
+    models: [],
+    tools: [],
+    loras: [],
+    embeddings: [],
+    hypernetworks: [],
+    samplers: [],
+    generationTypes: [],
+    controlNets: [],
+    ipAdapters: [],
+    dateRange: 'all',
+    favoritesOnly: false,
+    collectionId: null
+};
+
+const baseCollection: Collection = {
+    id: 'collection-1',
+    name: 'Collection One',
+    imageIds: [],
+    count: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    source: 'ambit'
+};
+
+const noopDrag = (_event: React.DragEvent, _collectionId: string) => { };
+const noopDrop = (_event: React.DragEvent, _collectionId: string) => { };
+const noopContextMenu = (_event: React.MouseEvent, _collectionId: string) => { };
+
+const renderCollectionItem = (
+    collection: Collection,
+    options: {
+        isThumbnailPending?: boolean;
+        viewMode?: 'grid' | 'list';
+    } = {}
+) => render(
+    <CollectionItem
+        col={collection}
+        filters={filters}
+        setFilters={() => { }}
+        editingColId={null}
+        editName=""
+        setEditName={() => { }}
+        setEditingColId={() => { }}
+        handleRenameSubmit={() => { }}
+        handleDragEnter={noopDrag}
+        handleDragOver={noopDrag}
+        handleDragLeave={() => { }}
+        handleDrop={noopDrop}
+        handleContextMenu={noopContextMenu}
+        dropTargetId={null}
+        viewMode={options.viewMode ?? 'list'}
+        isThumbnailPending={options.isThumbnailPending}
+    />
+);
+
+describe('CollectionItem thumbnail hydration states', () => {
+    it('renders a skeleton while a collection thumbnail is pending', () => {
+        renderCollectionItem(baseCollection, { isThumbnailPending: true });
+
+        expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
+        expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();
+        expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
+    });
+
+    it('renders the fallback once a collection has no thumbnail pending', () => {
+        renderCollectionItem({
+            ...baseCollection,
+            count: 0
+        });
+
+        expect(screen.getByTestId('collection-thumbnail-fallback')).toBeTruthy();
+        expect(screen.queryByTestId('collection-thumbnail-skeleton')).toBeNull();
+        expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
+    });
+
+    it('renders an existing thumbnail instead of the pending skeleton', () => {
+        renderCollectionItem({
+            ...baseCollection,
+            thumbnail: 'asset://collection-thumb.webp'
+        }, { isThumbnailPending: true });
+
+        expect(screen.getByTestId('privacy-aware-thumbnail').getAttribute('data-src')).toBe('asset://collection-thumb.webp');
+        expect(screen.queryByTestId('collection-thumbnail-skeleton')).toBeNull();
+        expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();
+    });
+
+    it('renders the pending skeleton in grid mode', () => {
+        renderCollectionItem(baseCollection, {
+            isThumbnailPending: true,
+            viewMode: 'grid'
+        });
+
+        expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
+    });
+});

--- a/src/features/filters/components/__tests__/CollectionList.test.tsx
+++ b/src/features/filters/components/__tests__/CollectionList.test.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { render, screen } from '../../../../test/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Collection, FilterState, SidebarSortOption } from '../../../../types';
+import { useCollectionStore } from '../../../../stores/collectionStore';
+import { CollectionList } from '../CollectionList';
+
+const settingsContextMocks = vi.hoisted(() => ({
+    resourceSortOptions: {} as Record<string, SidebarSortOption>,
+    setSettings: vi.fn()
+}));
+
+vi.mock('../../../../contexts/SettingsContext', () => ({
+    useSettings: () => ({
+        settings: {
+            resourceViewModes: { collections: 'list' },
+            resourceSortOptions: settingsContextMocks.resourceSortOptions
+        },
+        setSettings: settingsContextMocks.setSettings
+    })
+}));
+
+const filters: FilterState = {
+    searchQuery: '',
+    models: [],
+    tools: [],
+    loras: [],
+    embeddings: [],
+    hypernetworks: [],
+    samplers: [],
+    generationTypes: [],
+    controlNets: [],
+    ipAdapters: [],
+    dateRange: 'all',
+    favoritesOnly: false,
+    collectionId: null
+};
+
+const setFilters: React.Dispatch<React.SetStateAction<FilterState>> = () => { };
+
+const makeCollection = ({
+    id,
+    name,
+    createdAt,
+    updatedAt
+}: {
+    id: string;
+    name: string;
+    createdAt: number;
+    updatedAt: number;
+}): Collection => ({
+    id,
+    name,
+    imageIds: [],
+    count: 1,
+    createdAt,
+    updatedAt,
+    source: 'ambit'
+});
+
+const renderCollectionList = (collections: Collection[]) => render(
+    <CollectionList
+        collections={collections}
+        filters={filters}
+        setFilters={setFilters}
+        onDeleteCollection={vi.fn()}
+    />
+);
+
+const expectCollectionOrder = (names: string[]) => {
+    for (let index = 0; index < names.length - 1; index += 1) {
+        const current = screen.getByText(names[index]);
+        const next = screen.getByText(names[index + 1]);
+        expect(current.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+};
+
+describe('CollectionList persisted sort narrowing', () => {
+    beforeEach(() => {
+        settingsContextMocks.resourceSortOptions = {};
+        settingsContextMocks.setSettings.mockClear();
+        useCollectionStore.setState(useCollectionStore.getInitialState(), true);
+    });
+
+    it('uses collection date sorting when date_desc is persisted for collections', () => {
+        settingsContextMocks.resourceSortOptions = { collections: 'date_desc' };
+
+        renderCollectionList([
+            makeCollection({
+                id: 'old-recent',
+                name: 'Old Recent',
+                createdAt: 100,
+                updatedAt: 900
+            }),
+            makeCollection({
+                id: 'new-stale',
+                name: 'New Stale',
+                createdAt: 900,
+                updatedAt: 100
+            })
+        ]);
+
+        expectCollectionOrder(['New Stale', 'Old Recent']);
+    });
+
+    it('falls back to recent sorting when an invalid collection sort is persisted', () => {
+        settingsContextMocks.resourceSortOptions = {
+            collections: 'not_a_collection_sort' as unknown as SidebarSortOption
+        };
+
+        renderCollectionList([
+            makeCollection({
+                id: 'old-recent',
+                name: 'Old Recent',
+                createdAt: 100,
+                updatedAt: 900
+            }),
+            makeCollection({
+                id: 'new-stale',
+                name: 'New Stale',
+                createdAt: 900,
+                updatedAt: 100
+            })
+        ]);
+
+        expectCollectionOrder(['Old Recent', 'New Stale']);
+    });
+});

--- a/src/features/filters/components/__tests__/ResourceSection.test.tsx
+++ b/src/features/filters/components/__tests__/ResourceSection.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor } from '../../../../test/testUtils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ComponentProps } from 'react';
 import { ResourceSection, type AssetScope } from '../ResourceSection';
-import type { FacetSortOption, FilterState } from '../../../../types';
+import type { FilterState, SidebarSortOption } from '../../../../types';
 
 const commandMocks = vi.hoisted(() => ({
     setResourceThumbnailSensitivity: vi.fn(),
@@ -11,7 +11,7 @@ const commandMocks = vi.hoisted(() => ({
 }));
 
 const settingsContextMocks = vi.hoisted(() => ({
-    resourceSortOptions: {} as Record<string, FacetSortOption>,
+    resourceSortOptions: {} as Record<string, SidebarSortOption>,
     setSettings: vi.fn()
 }));
 
@@ -56,7 +56,7 @@ beforeEach(() => {
     settingsContextMocks.setSettings.mockClear();
 });
 
-const setResourceSort = (sort: FacetSortOption) => {
+const setResourceSort = (sort: SidebarSortOption) => {
     settingsContextMocks.resourceSortOptions = { loras: sort };
 };
 
@@ -435,5 +435,29 @@ describe('ResourceSection asset sorting', () => {
         });
 
         expectResourceOrder(['Alpha', 'Beta']);
+    });
+
+    it('falls back to count sorting when a resource section has a collection-only date sort persisted', () => {
+        setResourceSort('date_desc');
+
+        renderSortingSection({
+            assetScope: 'used',
+            data: [
+                {
+                    name: 'NewerLowUse',
+                    hash: 'lora_NewerLowUse',
+                    count: 1,
+                    createdAt: 900
+                },
+                {
+                    name: 'OlderHighUse',
+                    hash: 'lora_OlderHighUse',
+                    count: 5,
+                    createdAt: 100
+                }
+            ]
+        });
+
+        expectResourceOrder(['OlderHighUse', 'NewerLowUse']);
     });
 });

--- a/src/stores/__tests__/collectionStore.test.ts
+++ b/src/stores/__tests__/collectionStore.test.ts
@@ -300,6 +300,137 @@ describe('collectionStore smart count refresh', () => {
         }));
     });
 
+    it('marks thumbnail hydration pending ids while collection thumbnails are loading', async () => {
+        let resolveSummaries: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetCollectionThumbnailSummaries.mockImplementationOnce(() => new Promise(resolve => {
+            resolveSummaries = resolve;
+        }));
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'static-1',
+                    name: 'Static One',
+                    createdAt: 1,
+                    updatedAt: 1,
+                    source: 'ambit',
+                    count: 3,
+                    imageIds: []
+                }],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshCollectionThumbnails();
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({
+            'static-1': true
+        });
+        await waitFor(() => expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledTimes(1));
+
+        resolveSummaries?.({
+            'static-1': {
+                thumbnail: 'asset://thumb.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await refreshPromise;
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({});
+    });
+
+    it('does not mark empty collections as thumbnail hydration pending', async () => {
+        let resolveSummaries: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetCollectionThumbnailSummaries.mockImplementationOnce(() => new Promise(resolve => {
+            resolveSummaries = resolve;
+        }));
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    {
+                        id: 'empty-static',
+                        name: 'Empty Static',
+                        createdAt: 1,
+                        updatedAt: 1,
+                        source: 'ambit',
+                        count: 0,
+                        imageIds: []
+                    },
+                    {
+                        id: 'filled-static',
+                        name: 'Filled Static',
+                        createdAt: 2,
+                        updatedAt: 2,
+                        source: 'ambit',
+                        count: 1,
+                        imageIds: []
+                    }
+                ],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshCollectionThumbnails();
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({
+            'filled-static': true
+        });
+        await waitFor(() => expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledTimes(1));
+
+        resolveSummaries?.({});
+        await refreshPromise;
+    });
+
+    it('hydrates pinned and recent collection thumbnails first', async () => {
+        mockGetCollectionThumbnailSummaries.mockResolvedValue({});
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    {
+                        id: 'old-static',
+                        name: 'Old Static',
+                        createdAt: 1,
+                        updatedAt: 1,
+                        source: 'ambit',
+                        count: 1,
+                        imageIds: []
+                    },
+                    {
+                        id: 'pinned-static',
+                        name: 'Pinned Static',
+                        createdAt: 2,
+                        updatedAt: 2,
+                        source: 'ambit',
+                        count: 1,
+                        imageIds: [],
+                        isPinned: true
+                    },
+                    {
+                        id: 'recent-static',
+                        name: 'Recent Static',
+                        createdAt: 3,
+                        updatedAt: 5,
+                        source: 'ambit',
+                        count: 1,
+                        imageIds: []
+                    }
+                ],
+                isLoaded: true
+            });
+        });
+
+        await useCollectionStore.getState().refreshCollectionThumbnails();
+
+        const [firstBatch] = mockGetCollectionThumbnailSummaries.mock.calls[0] as [Array<{ id: string }>];
+        expect(firstBatch.map(collection => collection.id)).toEqual([
+            'pinned-static',
+            'recent-static',
+            'old-static'
+        ]);
+    });
+
     it('chunks collection thumbnail refreshes and skips smart collections', async () => {
         mockGetCollectionThumbnailSummaries.mockImplementation(async (batch: Array<{ id: string }>) => Object.fromEntries(
             batch.map((collection: { id: string }) => [collection.id, {
@@ -389,5 +520,59 @@ describe('collectionStore smart count refresh', () => {
         expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
             thumbnail: 'asset://fresh.webp'
         }));
+    });
+
+    it('does not clear newer pending thumbnail state from stale refreshes', async () => {
+        let resolveFirst: ((value: Record<string, unknown>) => void) | undefined;
+        let resolveSecond: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetCollectionThumbnailSummaries
+            .mockImplementationOnce(() => new Promise(resolve => {
+                resolveFirst = resolve;
+            }))
+            .mockImplementationOnce(() => new Promise(resolve => {
+                resolveSecond = resolve;
+            }));
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'static-1',
+                    name: 'Static One',
+                    createdAt: 1,
+                    updatedAt: 1,
+                    source: 'ambit',
+                    count: 3,
+                    imageIds: []
+                }],
+                isLoaded: true
+            });
+        });
+
+        const staleRun = useCollectionStore.getState().refreshCollectionThumbnails();
+        await waitFor(() => expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledTimes(1));
+        const freshRun = useCollectionStore.getState().refreshCollectionThumbnails();
+        await waitFor(() => expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledTimes(2));
+
+        resolveFirst?.({
+            'static-1': {
+                thumbnail: 'asset://stale.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await staleRun;
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({
+            'static-1': true
+        });
+
+        resolveSecond?.({
+            'static-1': {
+                thumbnail: 'asset://fresh.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await freshRun;
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({});
     });
 });

--- a/src/stores/collectionStore.ts
+++ b/src/stores/collectionStore.ts
@@ -22,6 +22,28 @@ const chunk = <T,>(items: T[], size: number): T[][] => {
     return chunks;
 };
 
+const shouldShowThumbnailHydrationPending = (collection: Collection): boolean => {
+    if (collection.filters || collection.thumbnail) return false;
+
+    const imageCount = collection.count ?? collection.imageIds.length;
+    return imageCount > 0 || !!collection.customThumbnail;
+};
+
+const sortForThumbnailHydration = (collections: Collection[]): Collection[] => (
+    [...collections].sort((a, b) => {
+        if (!!a.isPinned !== !!b.isPinned) return a.isPinned ? -1 : 1;
+        return (b.updatedAt || b.createdAt) - (a.updatedAt || a.createdAt);
+    })
+);
+
+const buildPendingThumbnailMap = (collections: Collection[]): Record<string, true> => (
+    Object.fromEntries(
+        collections
+            .filter(shouldShowThumbnailHydrationPending)
+            .map(collection => [collection.id, true] as const)
+    )
+);
+
 interface RefreshSmartCountsOptions {
     includeArchived?: boolean;
     collectionIds?: string[];
@@ -35,6 +57,7 @@ type RefreshSmartCountsInput = RefreshSmartCountsOptions | Collection[];
 interface CollectionState {
     collections: Collection[];
     isLoaded: boolean;
+    thumbnailHydrationPendingIds: Record<string, true>;
 
     // Actions
     initialize: () => Promise<void>;
@@ -52,6 +75,7 @@ export const useCollectionStore = create<CollectionState>()(
         (set, get) => ({
             collections: [],
             isLoaded: false,
+            thumbnailHydrationPendingIds: {},
 
             refreshCollections: async (debounced = false) => {
                 const run = async () => {
@@ -85,7 +109,11 @@ export const useCollectionStore = create<CollectionState>()(
                 const run = async () => {
                     const runId = ++thumbnailRefreshRunId;
                     try {
-                        const currentCollections = get().collections.filter(collection => !collection.filters);
+                        const currentCollections = sortForThumbnailHydration(
+                            get().collections.filter(collection => !collection.filters)
+                        );
+                        set({ thumbnailHydrationPendingIds: buildPendingThumbnailMap(currentCollections) });
+
                         if (currentCollections.length === 0) return;
 
                         const { getCollectionThumbnailSummaries } = await import('../services/db/collectionRepo');
@@ -99,12 +127,19 @@ export const useCollectionStore = create<CollectionState>()(
                                 collections: state.collections.map((collection) => {
                                     const summary = summaries[collection.id];
                                     return summary ? { ...collection, ...summary } : collection;
-                                })
+                                }),
+                                thumbnailHydrationPendingIds: Object.fromEntries(
+                                    Object.entries(state.thumbnailHydrationPendingIds)
+                                        .filter(([collectionId]) => !collectionBatch.some(collection => collection.id === collectionId))
+                                ) as Record<string, true>
                             }));
 
                             await delay(COLLECTION_THUMBNAIL_YIELD_MS);
                         }
                     } catch (e) {
+                        if (runId === thumbnailRefreshRunId) {
+                            set({ thumbnailHydrationPendingIds: {} });
+                        }
                         console.error('[CollectionStore] Failed to refresh collection thumbnails', e);
                     }
                 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,6 +202,14 @@ export type FacetSortOption =
   | 'recent_desc' | 'recent_asc'
   | 'added_desc' | 'added_asc';
 
+export type CollectionSortOption =
+  | 'name_asc' | 'name_desc'
+  | 'count_asc' | 'count_desc'
+  | 'date_asc' | 'date_desc'
+  | 'recent_desc' | 'recent_asc';
+
+export type SidebarSortOption = FacetSortOption | CollectionSortOption;
+
 export type FacetType = 'checkpoints' | 'loras' | 'embeddings' | 'hypernetworks' | 'controlNets' | 'ipAdapters' | 'tools';
 
 
@@ -266,7 +274,7 @@ export interface AppSettings {
   libraryShowIntermediates?: boolean; // Persisted view preference
   resourceFolders?: string[]; // New: Folders to scan for resources (models/loras)
   resourceViewModes?: Record<string, 'grid' | 'list'>; // Persisted view mode per resource section
-  resourceSortOptions?: Record<string, FacetSortOption>; // Persisted sort option per resource section
+  resourceSortOptions?: Record<string, SidebarSortOption>; // Persisted sort option per sidebar resource or collection section
   hideImportModal?: boolean; // User dismissed the import education modal
   systemPrompts?: Record<string, string>; // Dev override for AI prompts
   devMode?: boolean; // Toggle for experimental/dev features


### PR DESCRIPTION
## Summary
- Keep collection startup fast while showing explicit skeleton feedback for regular collection thumbnail hydration.
- Prioritize thumbnail hydration by pinned and recently updated collections, and clear pending state as batches complete.
- Tighten sidebar sort settings so resource facet sorts and collection-only sorts are narrowed by each consumer.

## Why
Collection rows and gallery content render quickly, but collection cover thumbnails can resolve later. Without an explicit pending state, those collections look like completed empty or missing-thumbnail states. This PR keeps hydration in the background while making that transient state visible.

## Validation
- `pnpm run test:run -- collectionStore`
- `pnpm run test:run -- CollectionItem AddToCollectionModal`
- `pnpm run test:run -- ResourceSection CollectionList`
- `pnpm run typecheck`
- `git diff --check`