### PR TITLE
[codex] Improve A1111 folder discovery

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -69,6 +69,7 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         scanner::show_in_folder,
         scanner::scan_directory_with_stats,
         scanner::scan_directory_since,
+        scanner::a1111::discover_a1111_folders,
         thumb::optimizer::start_thumbnail_optimization_job,
         thumb::optimizer::cancel_thumbnail_optimization_job,
         thumb::optimizer::set_thumbnail_optimization_throttled,

--- a/src-tauri/src/scanner/a1111.rs
+++ b/src-tauri/src/scanner/a1111.rs
@@ -1,0 +1,718 @@
+use serde::Serialize;
+use specta::Type;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const MAX_DEPTH: usize = 4;
+const IMAGE_LIMIT: usize = 300_000;
+
+const VARIANT_A1111: &str = "Automatic1111";
+const VARIANT_FORGE: &str = "Forge";
+const VARIANT_SDNEXT: &str = "SD.Next";
+const VARIANT_ANAPNOE: &str = "Anapnoe";
+const VARIANT_UNKNOWN: &str = "Unknown";
+
+const TYPE_TXT2IMG: &str = "txt2img";
+const TYPE_IMG2IMG: &str = "img2img";
+const TYPE_EXTRAS: &str = "extras";
+const TYPE_GRID: &str = "grid";
+const TYPE_SAVED: &str = "saved";
+const TYPE_UNKNOWN: &str = "unknown";
+
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct A1111DiscoveryCandidate {
+    pub path: String,
+    pub name: String,
+    pub image_count: usize,
+    pub inferred_type: String,
+    pub is_priority: bool,
+    pub variant: String,
+}
+
+#[derive(Debug, Clone, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct A1111DiscoveryResult {
+    pub detected_variant: String,
+    pub candidates: Vec<A1111DiscoveryCandidate>,
+    pub logs: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct ImageCount {
+    count: usize,
+    capped: bool,
+}
+
+#[derive(Debug)]
+struct DirectoryListing {
+    entries: Vec<PathBuf>,
+    entry_errors: Vec<String>,
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn discover_a1111_folders(root_path: String) -> Result<A1111DiscoveryResult, String> {
+    tauri::async_runtime::spawn_blocking(move || Ok(discover_a1111_folders_impl(&root_path)))
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn discover_a1111_folders_impl(root_path: &str) -> A1111DiscoveryResult {
+    let mut logs = Vec::new();
+    let mut warnings = Vec::new();
+    let root = PathBuf::from(root_path);
+    let normalized_root = normalize_path(&root);
+
+    log(&mut logs, format!("Starting scan of {normalized_root}"));
+    let detected_variant = detect_webui_variation(&root, &mut logs, &mut warnings);
+    log(
+        &mut logs,
+        format!("Detected Installation Type: {detected_variant}"),
+    );
+
+    let mut candidates = Vec::new();
+    process_folder(
+        &root,
+        0,
+        &detected_variant,
+        &mut candidates,
+        &mut logs,
+        &mut warnings,
+    );
+
+    A1111DiscoveryResult {
+        detected_variant,
+        candidates,
+        logs,
+        warnings,
+    }
+}
+
+fn detect_webui_variation(
+    root_path: &Path,
+    logs: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) -> String {
+    let entries = match sorted_read_dir(root_path) {
+        Ok(listing) => {
+            push_entry_warnings(warnings, logs, listing.entry_errors);
+            listing.entries
+        }
+        Err(error) => {
+            push_warning(
+                warnings,
+                logs,
+                format!(
+                    "Could not inspect installation markers at {}: {}",
+                    normalize_path(root_path),
+                    error
+                ),
+            );
+            return VARIANT_UNKNOWN.to_string();
+        }
+    };
+
+    let file_names = entries
+        .iter()
+        .filter_map(|path| file_name_lower(path))
+        .collect::<std::collections::HashSet<_>>();
+
+    if file_names.contains("modules_forge") {
+        return VARIANT_FORGE.to_string();
+    }
+
+    if let Some(readme_path) = entries
+        .iter()
+        .find(|path| file_name_lower(path).as_deref() == Some("readme.md"))
+    {
+        if let Ok(content) = std::fs::read_to_string(readme_path) {
+            let lower_content = content
+                .chars()
+                .take(1000)
+                .collect::<String>()
+                .to_lowercase();
+            if lower_content.contains("sd.next") || lower_content.contains("vladmandic") {
+                return VARIANT_SDNEXT.to_string();
+            }
+            if lower_content.contains("forge") && lower_content.contains("webui") {
+                return VARIANT_FORGE.to_string();
+            }
+            if lower_content.contains("anapnoe") {
+                return VARIANT_ANAPNOE.to_string();
+            }
+        }
+    }
+
+    let mut modules_files = std::collections::HashSet::new();
+    if file_names.contains("modules") {
+        let modules_path = root_path.join("modules");
+        match sorted_read_dir(&modules_path) {
+            Ok(listing) => {
+                push_entry_warnings(warnings, logs, listing.entry_errors);
+                for path in listing.entries {
+                    if let Some(name) = file_name_lower(&path) {
+                        modules_files.insert(name);
+                    }
+                }
+            }
+            Err(error) => push_warning(
+                warnings,
+                logs,
+                format!(
+                    "Could not inspect module markers at {}: {}",
+                    normalize_path(&modules_path),
+                    error
+                ),
+            ),
+        }
+    }
+
+    if modules_files.contains("forge_legacy.py") || file_names.contains("entry_with_update.py") {
+        return VARIANT_FORGE.to_string();
+    }
+
+    if modules_files.contains("installer.py") || modules_files.contains("sd_next_impl.py") {
+        return VARIANT_SDNEXT.to_string();
+    }
+
+    if file_names.contains("webui.py")
+        || file_names.contains("webui.sh")
+        || file_names.contains("webui.bat")
+    {
+        return VARIANT_A1111.to_string();
+    }
+
+    VARIANT_UNKNOWN.to_string()
+}
+
+fn process_folder(
+    path: &Path,
+    depth: usize,
+    detected_variant: &str,
+    candidates: &mut Vec<A1111DiscoveryCandidate>,
+    logs: &mut Vec<String>,
+    warnings: &mut Vec<String>,
+) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+
+    if is_thumbnails_dir(path) {
+        return;
+    }
+
+    log(
+        logs,
+        format!("Processing: {} (Depth {depth})", normalize_path(path)),
+    );
+
+    let entries = match sorted_read_dir(path) {
+        Ok(listing) => {
+            push_entry_warnings(warnings, logs, listing.entry_errors);
+            listing.entries
+        }
+        Err(error) => {
+            push_warning(
+                warnings,
+                logs,
+                format!("Could not read {}: {}", normalize_path(path), error),
+            );
+            return;
+        }
+    };
+
+    let mut direct_image_count = 0usize;
+    let mut subdirs = Vec::new();
+
+    for entry_path in &entries {
+        if entry_path.is_dir() {
+            if let Some(lower_name) = file_name_lower(entry_path) {
+                if !is_ignored_discovery_dir(&lower_name) {
+                    subdirs.push(entry_path.clone());
+                }
+            }
+        } else if is_importable_image_file(entry_path) {
+            direct_image_count += 1;
+        }
+    }
+
+    let subdir_names = if subdirs.is_empty() {
+        ".".to_string()
+    } else {
+        subdirs
+            .iter()
+            .filter_map(|path| path.file_name().and_then(|name| name.to_str()))
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    log(
+        logs,
+        format!(
+            "  Found {} entries. Subdirs: {}. Direct Images: {}",
+            entries.len(),
+            subdir_names,
+            direct_image_count
+        ),
+    );
+
+    let normalized_path = normalize_path(path);
+    let inferred_type = infer_type_from_path(&normalized_path).to_string();
+    let is_priority = inferred_type != TYPE_UNKNOWN;
+
+    if is_priority {
+        let total = count_images_recursive(path, IMAGE_LIMIT, warnings, logs);
+        if total.count > 0 {
+            candidates.push(A1111DiscoveryCandidate {
+                path: normalized_path,
+                name: folder_name(path),
+                image_count: total.count,
+                inferred_type,
+                is_priority: true,
+                variant: detected_variant.to_string(),
+            });
+            let cap_detail = if total.capped { " (capped)" } else { "" };
+            log(
+                logs,
+                format!(
+                    "  -> Added Priority: {} (Images: {}{})",
+                    normalize_path(path),
+                    total.count,
+                    cap_detail
+                ),
+            );
+        } else {
+            log(
+                logs,
+                format!("  -> Skipped Priority (Empty): {}", normalize_path(path)),
+            );
+        }
+        return;
+    }
+
+    let has_priority_deep = subdirs.iter().any(|subdir| {
+        let sub_type = infer_type_from_path(&normalize_path(subdir));
+        if sub_type != TYPE_UNKNOWN {
+            log(
+                logs,
+                format!(
+                    "  -> Has Priority Deep: {} is {}",
+                    folder_name(subdir),
+                    sub_type
+                ),
+            );
+            true
+        } else {
+            false
+        }
+    });
+
+    if !has_priority_deep && depth > 0 {
+        let total = count_images_recursive(path, IMAGE_LIMIT, warnings, logs);
+        if total.count > 0 {
+            candidates.push(A1111DiscoveryCandidate {
+                path: normalized_path,
+                name: folder_name(path),
+                image_count: total.count,
+                inferred_type: TYPE_UNKNOWN.to_string(),
+                is_priority: false,
+                variant: detected_variant.to_string(),
+            });
+            let cap_detail = if total.capped { " (capped)" } else { "" };
+            log(
+                logs,
+                format!(
+                    "  -> Added Consolidated: {} (Images: {}{})",
+                    normalize_path(path),
+                    total.count,
+                    cap_detail
+                ),
+            );
+            return;
+        }
+
+        log(
+            logs,
+            format!(
+                "  -> Skipped Consolidated (No Images): {}",
+                normalize_path(path)
+            ),
+        );
+    } else if has_priority_deep {
+        log(logs, "  -> Recursing (Has Priority Deep)".to_string());
+    } else if depth == 0 {
+        log(logs, "  -> Recursing (Root)".to_string());
+    }
+
+    for subdir in subdirs {
+        process_folder(
+            &subdir,
+            depth + 1,
+            detected_variant,
+            candidates,
+            logs,
+            warnings,
+        );
+    }
+}
+
+fn count_images_recursive(
+    root: &Path,
+    limit: usize,
+    warnings: &mut Vec<String>,
+    logs: &mut Vec<String>,
+) -> ImageCount {
+    let mut count = 0usize;
+    let mut pending_dirs = vec![root.to_path_buf()];
+    let mut capped = false;
+
+    while let Some(current) = pending_dirs.pop() {
+        if count >= limit {
+            capped = true;
+            break;
+        }
+
+        let entries = match sorted_read_dir(&current) {
+            Ok(listing) => {
+                push_entry_warnings(warnings, logs, listing.entry_errors);
+                listing.entries
+            }
+            Err(error) => {
+                push_warning(
+                    warnings,
+                    logs,
+                    format!("Could not read {}: {}", normalize_path(&current), error),
+                );
+                continue;
+            }
+        };
+
+        for entry_path in entries {
+            if count >= limit {
+                capped = true;
+                break;
+            }
+
+            if entry_path.is_dir() {
+                if !is_thumbnails_dir(&entry_path) {
+                    pending_dirs.push(entry_path);
+                }
+            } else if is_importable_image_file(&entry_path) {
+                count += 1;
+            }
+        }
+    }
+
+    if capped {
+        push_warning(
+            warnings,
+            logs,
+            format!(
+                "Image count for {} reached the {} file scan cap",
+                normalize_path(root),
+                limit
+            ),
+        );
+    }
+
+    ImageCount { count, capped }
+}
+
+fn sorted_read_dir(path: &Path) -> std::io::Result<DirectoryListing> {
+    let mut entries = Vec::new();
+    let mut entry_errors = Vec::new();
+
+    for entry in std::fs::read_dir(path)? {
+        match entry {
+            Ok(entry) => entries.push(entry.path()),
+            Err(error) => entry_errors.push(format!(
+                "Could not read entry in {}: {}",
+                normalize_path(path),
+                error
+            )),
+        }
+    }
+
+    entries.sort_by_key(|path| normalize_path(path).to_lowercase());
+    Ok(DirectoryListing {
+        entries,
+        entry_errors,
+    })
+}
+
+fn infer_type_from_path(path: &str) -> &'static str {
+    let normalized = path.replace('\\', "/").to_lowercase();
+    if normalized.contains("txt2img-grids") || normalized.contains("img2img-grids") {
+        return TYPE_GRID;
+    }
+
+    let parts = normalized.split('/').collect::<Vec<_>>();
+    if parts
+        .iter()
+        .any(|part| matches!(*part, "txt2img-images" | "txt2img" | "text"))
+    {
+        return TYPE_TXT2IMG;
+    }
+    if parts
+        .iter()
+        .any(|part| matches!(*part, "img2img-images" | "img2img" | "image"))
+    {
+        return TYPE_IMG2IMG;
+    }
+    if parts
+        .iter()
+        .any(|part| matches!(*part, "extras-images" | "extras" | "upscale"))
+    {
+        return TYPE_EXTRAS;
+    }
+    if parts
+        .iter()
+        .any(|part| matches!(*part, "grids" | "grids-images"))
+    {
+        return TYPE_GRID;
+    }
+    if parts.iter().any(|part| matches!(*part, "save" | "saved")) {
+        return TYPE_SAVED;
+    }
+
+    TYPE_UNKNOWN
+}
+
+fn is_ignored_discovery_dir(lower_name: &str) -> bool {
+    matches!(
+        lower_name,
+        "venv"
+            | "scripts"
+            | "extensions"
+            | "models"
+            | "embeddings"
+            | "tmp"
+            | "cache"
+            | ".git"
+            | "thumbnails"
+    )
+}
+
+fn is_importable_image_file(path: &Path) -> bool {
+    if is_thumbnail_file(path) {
+        return false;
+    }
+
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| matches!(ext.to_lowercase().as_str(), "png" | "jpg" | "jpeg" | "webp"))
+        .unwrap_or(false)
+}
+
+fn is_thumbnail_file(path: &Path) -> bool {
+    file_name_lower(path)
+        .map(|name| name.ends_with("thumbnail.png"))
+        .unwrap_or(false)
+}
+
+fn is_thumbnails_dir(path: &Path) -> bool {
+    file_name_lower(path)
+        .map(|name| name == "thumbnails")
+        .unwrap_or(false)
+}
+
+fn file_name_lower(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_lowercase())
+}
+
+fn folder_name(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_string())
+        .unwrap_or_else(|| path.to_string_lossy().to_string())
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn log(logs: &mut Vec<String>, message: String) {
+    logs.push(format!("[{}] {}", current_time_label(), message));
+}
+
+fn push_warning(warnings: &mut Vec<String>, logs: &mut Vec<String>, message: String) {
+    warnings.push(message.clone());
+    log(logs, format!("  ! Warning: {message}"));
+}
+
+fn push_entry_warnings(
+    warnings: &mut Vec<String>,
+    logs: &mut Vec<String>,
+    entry_errors: Vec<String>,
+) {
+    for entry_error in entry_errors {
+        push_warning(warnings, logs, entry_error);
+    }
+}
+
+fn current_time_label() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() % 86_400)
+        .unwrap_or(0);
+    let hour_24 = secs / 3600;
+    let minute = (secs % 3600) / 60;
+    let second = secs % 60;
+    let suffix = if hour_24 >= 12 { "PM" } else { "AM" };
+    let hour_12 = match hour_24 % 12 {
+        0 => 12,
+        hour => hour,
+    };
+    format!("{hour_12}:{minute:02}:{second:02} {suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_discovery_dir(test_name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "ambit_a1111_{test_name}_{}_{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_file(path: &Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"image").unwrap();
+    }
+
+    #[test]
+    fn sorted_read_dir_returns_sorted_entries_without_entry_errors() {
+        let root = temp_discovery_dir("sorted_read_dir");
+        write_file(&root.join("b.png"));
+        write_file(&root.join("a.png"));
+        fs::create_dir_all(root.join("z-folder")).unwrap();
+
+        let listing = sorted_read_dir(&root).unwrap();
+        let names = listing
+            .entries
+            .iter()
+            .map(|entry| entry.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["a.png", "b.png", "z-folder"]);
+        assert!(listing.entry_errors.is_empty());
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn discovers_standard_date_subfolder_outputs() {
+        let root = temp_discovery_dir("date_outputs").join("outputs");
+        write_file(&root.join("img2img-images/2023-04-20/00001.png"));
+        write_file(&root.join("txt2img/00002.jpg"));
+        write_file(&root.join("txt2img-images/2023-04-20/00003.webp"));
+
+        let result = discover_a1111_folders_impl(&root.to_string_lossy());
+
+        let names = result
+            .candidates
+            .iter()
+            .map(|candidate| {
+                (
+                    candidate.name.as_str(),
+                    candidate.inferred_type.as_str(),
+                    candidate.image_count,
+                    candidate.is_priority,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names,
+            vec![
+                ("img2img-images", TYPE_IMG2IMG, 1, true),
+                ("txt2img", TYPE_TXT2IMG, 1, true),
+                ("txt2img-images", TYPE_TXT2IMG, 1, true),
+            ]
+        );
+        assert!(result.warnings.is_empty());
+
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn thumbnail_files_and_thumbnail_dirs_are_not_counted() {
+        let root = temp_discovery_dir("thumbnail_skip").join("outputs");
+        write_file(&root.join("txt2img-images/2023-04-20/00001.png"));
+        write_file(&root.join("txt2img-images/2023-04-20/00001.thumbnail.png"));
+        write_file(&root.join("txt2img-images/thumbnails/preview.png"));
+
+        let result = discover_a1111_folders_impl(&root.to_string_lossy());
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].name, "txt2img-images");
+        assert_eq!(result.candidates[0].image_count, 1);
+
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn custom_folders_with_images_are_non_priority_candidates() {
+        let root = temp_discovery_dir("custom_folder").join("outputs");
+        write_file(&root.join("custom-archive/2024-01-01/00001.png"));
+
+        let result = discover_a1111_folders_impl(&root.to_string_lossy());
+
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].name, "custom-archive");
+        assert_eq!(result.candidates[0].inferred_type, TYPE_UNKNOWN);
+        assert!(!result.candidates[0].is_priority);
+        assert_eq!(result.candidates[0].image_count, 1);
+
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn empty_priority_folders_are_skipped() {
+        let root = temp_discovery_dir("empty_priority").join("outputs");
+        fs::create_dir_all(root.join("txt2img-images/2023-04-20")).unwrap();
+
+        let result = discover_a1111_folders_impl(&root.to_string_lossy());
+
+        assert!(result.candidates.is_empty());
+        assert!(result
+            .logs
+            .iter()
+            .any(|entry| entry.contains("Skipped Priority (Empty)")));
+
+        let _ = fs::remove_dir_all(root.parent().unwrap());
+    }
+
+    #[test]
+    fn recursive_count_reports_scan_cap_warning() {
+        let root = temp_discovery_dir("cap_warning");
+        write_file(&root.join("one.png"));
+        write_file(&root.join("two.png"));
+        write_file(&root.join("three.png"));
+        let mut warnings = Vec::new();
+        let mut logs = Vec::new();
+
+        let result = count_images_recursive(&root, 2, &mut warnings, &mut logs);
+
+        assert_eq!(result.count, 2);
+        assert!(result.capped);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("scan cap"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -1,3 +1,4 @@
+pub mod a1111;
 pub mod core;
 pub mod models;
 pub mod traversal;

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -370,6 +370,14 @@ async scanDirectorySince(path: string, since: number) : Promise<Result<FileEntry
     else return { status: "error", error: e  as any };
 }
 },
+async discoverA1111Folders(rootPath: string) : Promise<Result<A1111DiscoveryResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("discover_a1111_folders", { rootPath }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async startThumbnailOptimizationJob(config: ThumbnailOptimizationConfig) : Promise<Result<ThumbnailOptimizationResult, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("start_thumbnail_optimization_job", { config }) };
@@ -522,6 +530,8 @@ async getInvokeDbSnapshot(rootPath: string) : Promise<Result<InvokeDbSnapshot, s
 
 /** user-defined types **/
 
+export type A1111DiscoveryCandidate = { path: string; name: string; imageCount: number; inferredType: string; isPriority: boolean; variant: string }
+export type A1111DiscoveryResult = { detectedVariant: string; candidates: A1111DiscoveryCandidate[]; logs: string[]; warnings: string[] }
 export type BackupInfo = { name: string; path: string; createdAt: string; sizeBytes: number }
 export type DbDiagnostics = { dbPath: string; imageCount: number; deletedCount: number; modelCount: number; cacheCount: number; toolNullCount: number }
 export type FacetResourceTouches = { checkpoints: string[]; loras: string[]; embeddings: string[]; hypernetworks: string[]; controlNets: string[]; ipAdapters: string[]; tools: string[] }

--- a/src/features/settings/components/A1111Tab.tsx
+++ b/src/features/settings/components/A1111Tab.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { Palette, Folder, Info, FolderSearch, Loader2, CheckCircle2, XCircle, Plus, ChevronDown, FolderOpen, RefreshCw, X } from 'lucide-react';
-import { AppSettings, GeneratorTool } from '../../../types';
+import { Palette, Folder, Info, FolderSearch, Loader2, CheckCircle2, XCircle, Plus, ChevronDown, FolderOpen } from 'lucide-react';
+import { GeneratorTool, type AppSettings, type MonitoredFolder } from '../../../types';
 import { useLibraryContext } from '../../../hooks/useLibraryContext';
 import { useSearch } from '../../../contexts/SearchContext'; // Added
-import { A1111FolderType, DiscoveryCandidate, WebUIVariant } from '../../../services/a1111/types';
+import { A1111FolderType, type DiscoveryCandidate, WebUIVariant } from '../../../services/a1111/types';
 import { useToast } from '../../../hooks/useToast';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
 
@@ -14,18 +14,30 @@ interface TabProps {
     onClose?: () => void;
 }
 
-export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings, onClose }) => {
+const variantToGeneratorTool = (variant?: WebUIVariant): GeneratorTool | undefined => {
+    switch (variant) {
+        case WebUIVariant.FORGE:
+            return GeneratorTool.FORGE;
+        case WebUIVariant.SDNEXT:
+            return GeneratorTool.SDNEXT;
+        case WebUIVariant.ANAPNOE:
+            return GeneratorTool.ANAPNOE;
+        case WebUIVariant.A1111:
+            return GeneratorTool.AUTOMATIC1111;
+        default:
+            return undefined;
+    }
+};
+
+const variantToImportTool = (variant?: WebUIVariant): GeneratorTool =>
+    variantToGeneratorTool(variant) ?? GeneratorTool.UNKNOWN;
+
+export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings }) => {
     const {
         setIsImporting,
         setImportProgress,
-        refreshCollections,
-        isResolvingModels: isResolving,
-        setIsResolvingModels: setIsResolving,
-        modelResolutionProgress: resolutionProgress,
-        setModelResolutionProgress: setResolutionProgress,
-        lastModelResolutionResult: resolutionResult,
-        setLastModelResolutionResult: setResolutionResult
-    } = useLibraryContext() as any;
+        refreshCollections
+    } = useLibraryContext();
     const { refreshMetadata } = useSearch(); // Added hook usage
     const { addToast } = useToast();
     const [localTestResult, setLocalTestResult] = useState<{ success: boolean; message: string } | null>(null);
@@ -52,36 +64,35 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
         if (!settings.a1111Path) return;
         setIsDiscovering(true);
         setLocalTestResult(null);
+        setScanLogs([]);
         try {
-            const { discoverA1111Candidates } = await import('../../../services/a1111/config');
+            const { discoverA1111Candidates, getUnlinkedPriorityCandidatePaths } = await import('../../../services/a1111/config');
             const existing = new Set(settings.monitoredFolders.map(f => f.path.replace(/\\/g, '/').toLowerCase()));
-            const { candidates: results, logs } = await discoverA1111Candidates(settings.a1111Path, existing);
-
-            // Apply Manual Override if selected
-            if (forceVariant !== 'Auto') {
-                results.forEach(c => {
-                    c.variant = forceVariant;
-                });
-                logs.push(`[Info] Manual Override applied: Forced all candidates to ${forceVariant}`);
-            }
+            const { candidates: results, logs, warnings } = await discoverA1111Candidates(settings.a1111Path, existing, forceVariant);
 
             setCandidates(results);
             setScanLogs(logs);
 
             // Auto-select priority folders that aren't linked yet
-            const priorityUnlinked = results.filter(c => c.isPriority && !c.isAlreadyLinked);
-            setSelectedPaths(new Set(priorityUnlinked.map(c => c.path)));
+            setSelectedPaths(new Set(getUnlinkedPriorityCandidatePaths(results)));
 
-            // If NO priority folders AT ALL, auto-show all
-            if (results.filter(c => c.isPriority).length === 0 && results.length > 0) {
-                setShowAllFolders(true);
-            }
+            const priorityCount = results.filter(c => c.isPriority).length;
+            setShowAllFolders(priorityCount === 0 && results.length > 0);
 
-            if (results.length === 0) {
+            if (warnings.length > 0) {
+                const warningLabel = warnings.length === 1 ? 'warning' : 'warnings';
+                const message = results.length === 0
+                    ? `Discovery completed with ${warnings.length} ${warningLabel} and no importable folders. Review scan debug log.`
+                    : `Discovery completed with ${warnings.length} ${warningLabel}. Review scan debug log.`;
+                setLocalTestResult({ success: false, message });
+            } else if (results.length === 0) {
                 setLocalTestResult({ success: false, message: "No potential folders containing images found." });
             }
         } catch (e) {
             console.error(e);
+            setCandidates([]);
+            setSelectedPaths(new Set());
+            setShowAllFolders(false);
             setLocalTestResult({ success: false, message: "Discovery failed. Check path permissions." });
         } finally {
             setIsDiscovering(false);
@@ -101,33 +112,25 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
 
         setIsDiscovering(true);
         setIsImporting(true); // Ref-counting: +1
+        let newFolderIds = new Set<string>();
 
         try {
             const { processFoldersUnified } = await import('../../../services/importService');
-            const { GeneratorTool } = await import('../../../types');
-            const { WebUIVariant } = await import('../../../services/a1111/types');
 
-            // 1. Prepare New Folders (with lastScanned set to NOW to bypass auto-monitor)
+            // 1. Prepare New Folders. Keep lastScanned empty until import succeeds.
             const brandNew = toLink.filter(c => !c.isAlreadyLinked);
             const alreadyLinked = toLink.filter(c => c.isAlreadyLinked);
 
             const now = Date.now();
-            const newFolderObjects = brandNew.map(c => {
-                let variant: GeneratorTool | undefined = undefined;
-                if (c.variant === WebUIVariant.FORGE) variant = GeneratorTool.FORGE;
-                else if (c.variant === WebUIVariant.SDNEXT) variant = GeneratorTool.SDNEXT;
-                else if (c.variant === WebUIVariant.ANAPNOE) variant = GeneratorTool.ANAPNOE;
-                else if (c.variant === WebUIVariant.A1111) variant = GeneratorTool.AUTOMATIC1111;
-
-                return {
-                    id: `a1111_${c.inferredType}_${now}_${Math.random().toString(36).substr(2, 5)}`,
-                    path: c.path,
-                    isActive: true,
-                    imageCount: c.imageCount,
-                    variant: variant,
-                    lastScanned: now // CRITICAL: Prevents useFolderMonitor from scanning this again immediately
-                };
-            });
+            const newFolderObjects: MonitoredFolder[] = brandNew.map(c => ({
+                id: `a1111_${c.inferredType}_${now}_${Math.random().toString(36).substr(2, 5)}`,
+                path: c.path,
+                isActive: true,
+                imageCount: c.imageCount,
+                variant: variantToGeneratorTool(c.variant),
+                initialScanPending: true
+            }));
+            newFolderIds = new Set(newFolderObjects.map(folder => folder.id));
 
             // 2. Update Settings (UI will show them immediately)
             if (newFolderObjects.length > 0) {
@@ -139,37 +142,71 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
 
             // 3. Build Unified Task List
             const foldersToSync = [
-                ...alreadyLinked.map(c => {
-                    let variant = GeneratorTool.UNKNOWN;
-                    if (c.variant === WebUIVariant.FORGE) variant = GeneratorTool.FORGE;
-                    else if (c.variant === WebUIVariant.SDNEXT) variant = GeneratorTool.SDNEXT;
-                    else if (c.variant === WebUIVariant.ANAPNOE) variant = GeneratorTool.ANAPNOE;
-                    else if (c.variant === WebUIVariant.A1111) variant = GeneratorTool.AUTOMATIC1111;
-                    return { path: c.path, variant };
-                }),
+                ...alreadyLinked.map(c => ({ path: c.path, variant: variantToImportTool(c.variant) })),
                 ...newFolderObjects.map(f => ({ path: f.path, variant: f.variant }))
             ];
 
             // 4. Run Unified Import
             if (foldersToSync.length > 0) {
-                await processFoldersUnified(foldersToSync, {
+                const result = await processFoldersUnified(foldersToSync, {
                     onProgress: (current, total, message) => {
                         setImportProgress({ current, total, message });
                     },
                     forceRescan: false
                 });
+                const completedAt = Date.now();
+                const importCompleted = result.failedPaths.length === 0;
 
-                if (refreshCollections) refreshCollections();
-                if (refreshMetadata) await refreshMetadata(); // Force full gallery refresh
+                if (newFolderIds.size > 0) {
+                    setSettings(prev => ({
+                        ...prev,
+                        monitoredFolders: prev.monitoredFolders.map(folder =>
+                            newFolderIds.has(folder.id)
+                                ? {
+                                    ...folder,
+                                    lastScanned: importCompleted ? completedAt : undefined,
+                                    initialScanPending: false
+                                }
+                                : folder
+                        )
+                    }));
+                }
+
+                let refreshFailed = false;
+                try {
+                    if (refreshCollections) await refreshCollections();
+                    if (refreshMetadata) await refreshMetadata(); // Force full gallery refresh
+                } catch (refreshError) {
+                    refreshFailed = true;
+                    console.error("Post-import refresh failed", refreshError);
+                }
 
                 const totalCount = foldersToSync.length;
-                const msg = `Processed ${totalCount} folders (${brandNew.length} new, ${alreadyLinked.length} rescanned)`;
-                setLocalTestResult({ success: true, message: msg });
-                addToast(msg, 'success');
+                if (importCompleted) {
+                    const msg = refreshFailed
+                        ? `Processed ${totalCount} folders (${brandNew.length} new, ${alreadyLinked.length} rescanned), but refresh failed.`
+                        : `Processed ${totalCount} folders (${brandNew.length} new, ${alreadyLinked.length} rescanned)`;
+                    setLocalTestResult({ success: !refreshFailed, message: msg });
+                    addToast(msg, refreshFailed ? 'warning' : 'success');
+                } else {
+                    const msg = `Processed ${totalCount} folders with ${result.failedPaths.length} failed file(s). Folder cursor was not advanced.`;
+                    setLocalTestResult({ success: false, message: msg });
+                    addToast(msg, 'warning');
+                }
             }
 
         } catch (e) {
             console.error("Link/Import failed", e);
+            if (newFolderIds.size > 0) {
+                setSettings(prev => ({
+                    ...prev,
+                    monitoredFolders: prev.monitoredFolders.map(folder =>
+                        newFolderIds.has(folder.id)
+                            ? { ...folder, lastScanned: undefined, initialScanPending: false }
+                            : folder
+                    )
+                }));
+            }
             setLocalTestResult({ success: false, message: "Use Check Console for details" });
             addToast("Import failed", "error");
         } finally {
@@ -284,6 +321,20 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
                         </button>
 
                     </div>
+
+                    {localTestResult && (
+                        <div className={`flex items-center gap-2 rounded-xl border px-4 py-3 text-xs font-bold ${localTestResult.success
+                            ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
+                            : 'border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-400'
+                            }`}>
+                            {localTestResult.success ? (
+                                <CheckCircle2 className="h-4 w-4 shrink-0" />
+                            ) : (
+                                <XCircle className="h-4 w-4 shrink-0" />
+                            )}
+                            <span>{localTestResult.message}</span>
+                        </div>
+                    )}
 
                     {candidates.length > 0 && (
                         <div className="space-y-4 animate-in fade-in slide-in-from-top-4 duration-500">
@@ -411,19 +462,20 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
                                 </button>
                             </div>
 
-                            {settings.devMode && scanLogs.length > 0 && (
-                                <div className="mt-4 mb-4">
-                                    <details className="group">
-                                        <summary className="text-[10px] font-black uppercase tracking-widest text-gray-400 cursor-pointer select-none hover:text-sage-500 transition-colors list-none flex items-center gap-2">
-                                            <span className="group-open:rotate-90 transition-transform">▸</span>
-                                            View Scan Debug Log ({scanLogs.length} entries)
-                                        </summary>
-                                        <div className="mt-2 p-3 bg-black/90 text-green-400 font-mono text-[10px] rounded-lg max-h-60 overflow-y-auto whitespace-pre-wrap border border-white/10 shadow-inner">
-                                            {scanLogs.join('\n')}
-                                        </div>
-                                    </details>
+                        </div>
+                    )}
+
+                    {settings.devMode && scanLogs.length > 0 && (
+                        <div className="mt-4 mb-4">
+                            <details className="group">
+                                <summary className="text-[10px] font-black uppercase tracking-widest text-gray-400 cursor-pointer select-none hover:text-sage-500 transition-colors list-none flex items-center gap-2">
+                                    <span className="group-open:rotate-90 transition-transform">▸</span>
+                                    View Scan Debug Log ({scanLogs.length} entries)
+                                </summary>
+                                <div className="mt-2 p-3 bg-black/90 text-green-400 font-mono text-[10px] rounded-lg max-h-60 overflow-y-auto whitespace-pre-wrap border border-white/10 shadow-inner">
+                                    {scanLogs.join('\n')}
                                 </div>
-                            )}
+                            </details>
                         </div>
                     )}
                 </div>

--- a/src/features/settings/components/__tests__/A1111Tab.test.tsx
+++ b/src/features/settings/components/__tests__/A1111Tab.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '../../../../test/testUtils';
+import type { AppSettings } from '../../../../types';
+import { WebUIVariant } from '../../../../services/a1111/types';
+import { A1111Tab } from '../A1111Tab';
+
+const mocks = vi.hoisted(() => ({
+    addToast: vi.fn(),
+    discoverA1111Candidates: vi.fn(),
+    getUnlinkedPriorityCandidatePaths: vi.fn(),
+    refreshCollections: vi.fn(),
+    refreshMetadata: vi.fn(),
+    setImportProgress: vi.fn(),
+    setIsImporting: vi.fn()
+}));
+
+vi.mock('../../../../hooks/useLibraryContext', () => ({
+    useLibraryContext: () => ({
+        setIsImporting: mocks.setIsImporting,
+        setImportProgress: mocks.setImportProgress,
+        refreshCollections: mocks.refreshCollections
+    })
+}));
+
+vi.mock('../../../../contexts/SearchContext', () => ({
+    useSearch: () => ({
+        refreshMetadata: mocks.refreshMetadata
+    })
+}));
+
+vi.mock('../../../../hooks/useToast', () => ({
+    useToast: () => ({
+        addToast: mocks.addToast
+    })
+}));
+
+vi.mock('../../../../services/a1111/config', () => ({
+    discoverA1111Candidates: mocks.discoverA1111Candidates,
+    getUnlinkedPriorityCandidatePaths: mocks.getUnlinkedPriorityCandidatePaths
+}));
+
+const createSettings = (): AppSettings => ({
+    hasCompletedOnboarding: true,
+    theme: 'dark',
+    thumbnailSize: 200,
+    confirmDelete: true,
+    defaultTheaterMode: false,
+    monitoredFolders: [],
+    maskedKeywords: [],
+    maskingMode: 'blur',
+    enableAI: false,
+    a1111Path: 'D:/SD/outputs',
+    devMode: true
+});
+
+describe('A1111Tab discovery warnings', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.getUnlinkedPriorityCandidatePaths.mockReturnValue([]);
+    });
+
+    it('surfaces warning-only discovery results and keeps the debug log visible', async () => {
+        mocks.discoverA1111Candidates.mockResolvedValue({
+            detectedVariant: WebUIVariant.A1111,
+            candidates: [],
+            logs: ['[9:31:52 AM]   ! Warning: Could not read D:/SD/outputs/txt2img-images'],
+            warnings: ['Could not read D:/SD/outputs/txt2img-images']
+        });
+
+        render(<A1111Tab settings={createSettings()} setSettings={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /scan for folders/i }));
+
+        expect(await screen.findByText('Discovery completed with 1 warning and no importable folders. Review scan debug log.')).toBeTruthy();
+        expect(screen.getByText('View Scan Debug Log (1 entries)')).toBeTruthy();
+        expect(screen.queryByText('No potential folders containing images found.')).toBeNull();
+
+        await waitFor(() => {
+            expect(mocks.discoverA1111Candidates).toHaveBeenCalledWith(
+                'D:/SD/outputs',
+                expect.any(Set),
+                'Auto'
+            );
+        });
+    });
+});

--- a/src/services/a1111/__tests__/config.test.ts
+++ b/src/services/a1111/__tests__/config.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    discoverA1111Candidates,
+    getUnlinkedPriorityCandidatePaths
+} from '../config';
+import { A1111FolderType, type DiscoveryCandidate, WebUIVariant } from '../types';
+
+const mocks = vi.hoisted(() => ({
+    discoverA1111Folders: vi.fn()
+}));
+
+vi.mock('../../../bindings', () => ({
+    commands: {
+        discoverA1111Folders: mocks.discoverA1111Folders
+    }
+}));
+
+describe('discoverA1111Candidates', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.discoverA1111Folders.mockResolvedValue({
+            status: 'ok',
+            data: {
+                detectedVariant: WebUIVariant.A1111,
+                candidates: [
+                    {
+                        path: 'D:\\SD\\outputs\\txt2img-images',
+                        name: 'txt2img-images',
+                        imageCount: 12,
+                        inferredType: A1111FolderType.TXT2IMG,
+                        isPriority: true,
+                        variant: WebUIVariant.A1111
+                    },
+                    {
+                        path: 'D:\\SD\\outputs\\custom',
+                        name: 'custom',
+                        imageCount: 4,
+                        inferredType: A1111FolderType.UNKNOWN,
+                        isPriority: false,
+                        variant: WebUIVariant.UNKNOWN
+                    }
+                ],
+                logs: ['[9:31:52 AM] backend log'],
+                warnings: ['count cap reached']
+            }
+        });
+    });
+
+    it('maps backend candidates and marks already linked folders', async () => {
+        const result = await discoverA1111Candidates(
+            'D:/SD/outputs',
+            new Set(['d:/sd/outputs/txt2img-images'])
+        );
+
+        expect(mocks.discoverA1111Folders).toHaveBeenCalledWith('D:/SD/outputs');
+        expect(result.detectedVariant).toBe(WebUIVariant.A1111);
+        expect(result.warnings).toEqual(['count cap reached']);
+        expect(result.candidates[0]).toMatchObject({
+            path: 'D:/SD/outputs/txt2img-images',
+            inferredType: A1111FolderType.TXT2IMG,
+            isAlreadyLinked: true,
+            isPriority: true,
+            variant: WebUIVariant.A1111
+        });
+        expect(result.candidates[1]).toMatchObject({
+            path: 'D:/SD/outputs/custom',
+            inferredType: A1111FolderType.UNKNOWN,
+            isAlreadyLinked: false,
+            isPriority: false,
+            variant: WebUIVariant.UNKNOWN
+        });
+    });
+
+    it('applies manual variant override without changing backend discovery', async () => {
+        const result = await discoverA1111Candidates(
+            'D:/SD/outputs',
+            new Set(),
+            WebUIVariant.FORGE
+        );
+
+        expect(result.detectedVariant).toBe(WebUIVariant.FORGE);
+        expect(result.candidates.map(candidate => candidate.variant)).toEqual([
+            WebUIVariant.FORGE,
+            WebUIVariant.FORGE
+        ]);
+        expect(result.logs).toContain('[Info] Manual Override applied: Forced all candidates to Forge');
+    });
+});
+
+describe('getUnlinkedPriorityCandidatePaths', () => {
+    it('returns only unlinked priority candidates for auto-selection', () => {
+        const candidates: DiscoveryCandidate[] = [
+            {
+                path: 'D:/SD/outputs/img2img-images',
+                name: 'img2img-images',
+                imageCount: 1,
+                inferredType: A1111FolderType.IMG2IMG,
+                isAlreadyLinked: false,
+                isPriority: true,
+                variant: WebUIVariant.A1111
+            },
+            {
+                path: 'D:/SD/outputs/txt2img',
+                name: 'txt2img',
+                imageCount: 1,
+                inferredType: A1111FolderType.TXT2IMG,
+                isAlreadyLinked: true,
+                isPriority: true,
+                variant: WebUIVariant.A1111
+            },
+            {
+                path: 'D:/SD/outputs/custom',
+                name: 'custom',
+                imageCount: 1,
+                inferredType: A1111FolderType.UNKNOWN,
+                isAlreadyLinked: false,
+                isPriority: false,
+                variant: WebUIVariant.A1111
+            }
+        ];
+
+        expect(getUnlinkedPriorityCandidatePaths(candidates)).toEqual([
+            'D:/SD/outputs/img2img-images'
+        ]);
+    });
+});

--- a/src/services/a1111/config.ts
+++ b/src/services/a1111/config.ts
@@ -1,237 +1,87 @@
-import { readDir, readFile } from '@tauri-apps/plugin-fs';
-import { A1111Config, A1111FolderType, DiscoveryCandidate, WebUIVariant } from './types';
+import { commands, type A1111DiscoveryCandidate as BackendDiscoveryCandidate } from '../../bindings';
 import { normalizePath } from '../../utils/pathUtils';
+import { unwrap } from '../../utils/spectaUtils';
+import { A1111FolderType, type DiscoveryCandidate, type DiscoveryResult, WebUIVariant } from './types';
 
-const MAX_DEPTH = 4;
-
-/**
- * Attempts to detect the specific WebUI variant (A1111, Forge, SD.Next, Anapnoe)
- * based on file structure signatures.
- */
-export const detectWebUIVariation = async (rootPath: string): Promise<WebUIVariant> => {
-    try {
-        const entries = await readDir(rootPath);
-        const fileNames = new Set(entries.map(e => e.name.toLowerCase()));
-
-        // 1. Forge Detection (Robust)
-        // Newer Forge has 'modules_forge' folder
-        if (fileNames.has('modules_forge')) {
-            return WebUIVariant.FORGE;
-        }
-
-        // 2. Read README.md for definitive identification
-        // This is safe and reliable for identifying forks
-        if (fileNames.has('readme.md')) {
-            try {
-                // Find potential readme file with correct casing
-                const readmeName = entries.find(e => e.name.toLowerCase() === 'readme.md')?.name;
-                if (readmeName) {
-                    const bytes = await readFile(`${rootPath}/${readmeName}`);
-                    const content = new TextDecoder('utf-8').decode(bytes);
-                    const lowerContent = content.slice(0, 1000).toLowerCase(); // Scan first 1000 chars
-
-                    if (lowerContent.includes('sd.next') || lowerContent.includes('vladmandic')) {
-                        return WebUIVariant.SDNEXT;
-                    }
-                    if (lowerContent.includes('forge') && lowerContent.includes('webui')) {
-                        return WebUIVariant.FORGE;
-                    }
-                    if (lowerContent.includes('anapnoe')) {
-                        return WebUIVariant.ANAPNOE;
-                    }
-                }
-            } catch (e) {
-                // Ignore read errors, fall back to file structure
-            }
-        }
-
-        // 3. Fallback File Structure Checks
-        // Scan modules folder if it exists
-        let modulesFiles = new Set<string>();
-        if (fileNames.has('modules')) {
-            try {
-                const modEntries = await readDir(`${rootPath}/modules`);
-                modEntries.forEach(e => modulesFiles.add(e.name.toLowerCase()));
-            } catch (e) { }
-        }
-
-        // Forge Fallback
-        if (modulesFiles.has('forge_legacy.py') || fileNames.has('entry_with_update.py')) {
-            return WebUIVariant.FORGE;
-        }
-
-        // SD.Next Fallback
-        if (modulesFiles.has('installer.py') || modulesFiles.has('sd_next_impl.py')) {
-            return WebUIVariant.SDNEXT;
-        }
-
-        // 4. Final Fallback to A1111 if webui.py exists
-        if (fileNames.has('webui.py') || fileNames.has('webui.sh') || fileNames.has('webui.bat')) {
-            return WebUIVariant.A1111;
-        }
-
-        return WebUIVariant.UNKNOWN;
-
-    } catch (e) {
-        console.error("Failed to detect WebUI variant", e);
-        return WebUIVariant.UNKNOWN;
+const toFolderType = (value: string): A1111FolderType => {
+    if ((Object.values(A1111FolderType) as string[]).includes(value)) {
+        return value as A1111FolderType;
     }
-};
-
-/**
- * Perform a dynamic discovery of potential A1111/SD folders.
- * Scans depth 4 subfolders for images and applies heuristics.
- */
-export const discoverA1111Candidates = async (
-    rootPath: string,
-    existingPaths: Set<string>
-): Promise<{ candidates: DiscoveryCandidate[], logs: string[] }> => {
-    const candidates: DiscoveryCandidate[] = [];
-    const logs: string[] = [];
-    const log = (msg: string) => logs.push(`[${new Date().toLocaleTimeString()}] ${msg}`);
-    const normalizedRoot = normalizePath(rootPath);
-
-    log(`Starting scan of ${normalizedRoot}`);
-
-    // Detect Variant First
-    const detectedVariant = await detectWebUIVariation(rootPath);
-    log(`Detected Installation Type: ${detectedVariant}`);
-
-    // Helper to recursively count images in a folder
-    const countImagesRecursive = async (path: string): Promise<number> => {
-        let count = 0;
-        try {
-            const entries = await readDir(path);
-            for (const entry of entries) {
-                if (entry.isDirectory) {
-                    const lowerName = entry.name?.toLowerCase() || '';
-                    if (lowerName === 'thumbnails') continue;
-                    count += await countImagesRecursive(`${path}/${entry.name}`);
-                } else {
-                    const ext = entry.name?.split('.').pop()?.toLowerCase();
-                    if (['png', 'jpg', 'jpeg', 'webp'].includes(ext || '')) count++;
-                }
-            }
-        } catch (e) { }
-        return count;
-    };
-
-    // Helper to check if a folder is a candidate
-    const processFolder = async (path: string, depth: number) => {
-        if (depth > MAX_DEPTH) return;
-
-        const folderName = path.split(/[\\/]/).pop()?.toLowerCase() || '';
-        if (folderName === 'thumbnails') return;
-
-        log(`Processing: ${path} (Depth ${depth})`);
-
-        try {
-            const entries = await readDir(path);
-            let directImageCount = 0;
-            const subdirs: { name: string, fullPath: string }[] = [];
-
-            for (const entry of entries) {
-                if (entry.isDirectory) {
-                    const lowerName = entry.name?.toLowerCase() || '';
-                    if (!['venv', 'scripts', 'extensions', 'models', 'embeddings', 'tmp', 'cache', '.git', 'thumbnails'].includes(lowerName)) {
-                        subdirs.push({ name: entry.name, fullPath: `${path}/${entry.name}` });
-                    }
-                } else if (entry.isFile) {
-                    const ext = entry.name?.split('.').pop()?.toLowerCase();
-                    if (['png', 'jpg', 'jpeg', 'webp'].includes(ext || '')) {
-                        directImageCount++;
-                    }
-                }
-            }
-
-            log(`  Found ${entries.length} entries. Subdirs: ${subdirs.map(s => s.name).join(', ')}. Direct Images: ${directImageCount}`);
-
-            const normalizedPath = normalizePath(path);
-            const type = inferTypeFromPath(normalizedPath);
-            const isPriority = type !== A1111FolderType.UNKNOWN;
-
-            if (isPriority) {
-                const totalImageCount = await countImagesRecursive(path);
-                if (totalImageCount > 0) {
-                    candidates.push({
-                        path: normalizedPath,
-                        name: path.split(/[\\/]/).pop() || path,
-                        imageCount: totalImageCount,
-                        inferredType: type,
-                        isAlreadyLinked: existingPaths.has(normalizedPath.toLowerCase()),
-                        isPriority: true,
-                        variant: detectedVariant
-                    });
-                    log(`  -> Added Priority: ${path} (Images: ${totalImageCount})`);
-                } else {
-                    log(`  -> Skipped Priority (Empty): ${path}`);
-                }
-                return;
-            }
-
-            // Check if any subdirectory is a priority folder or contains one
-            let hasPriorityDeep = false;
-            for (const subdir of subdirs) {
-                const subType = inferTypeFromPath(normalizePath(subdir.fullPath));
-                if (subType !== A1111FolderType.UNKNOWN) {
-                    hasPriorityDeep = true;
-                    log(`  -> Has Priority Deep: ${subdir.name} is ${subType}`);
-                    break;
-                }
-            }
-
-            if (!hasPriorityDeep && depth > 0) {
-                // If this is NOT the root and has NO priority folders deep inside, 
-                // check if it has images anywhere inside. If so, consolidate.
-                const totalImageCount = await countImagesRecursive(path);
-                if (totalImageCount > 0) {
-                    candidates.push({
-                        path: normalizedPath,
-                        name: path.split(/[\\/]/).pop() || path,
-                        imageCount: totalImageCount,
-                        inferredType: A1111FolderType.UNKNOWN,
-                        isAlreadyLinked: existingPaths.has(normalizedPath.toLowerCase()),
-                        isPriority: false,
-                        variant: detectedVariant
-                    });
-                    log(`  -> Added Consolidated: ${path} (Images: ${totalImageCount})`);
-                    // Consolidate here, don't recurse deeper if we found images and it's a "clean" custom folder
-                    return;
-                } else {
-                    log(`  -> Skipped Consolidated (No Images): ${path}`);
-                }
-            } else if (hasPriorityDeep) {
-                log(`  -> Recursing (Has Priority Deep)`);
-            } else if (depth === 0) {
-                log(`  -> Recursing (Root)`);
-            }
-
-            // Otherwise, recurse deeper
-            for (const subdir of subdirs) {
-                await processFolder(subdir.fullPath, depth + 1);
-            }
-        } catch (e) {
-            log(`Error processing ${path}: ${e}`);
-        }
-    };
-
-    await processFolder(normalizedRoot, 0);
-    return { candidates, logs };
-};
-
-const inferTypeFromPath = (path: string): A1111FolderType => {
-    const lower = path.toLowerCase();
-    // Prioritize grids
-    if (lower.includes('txt2img-grids') || lower.includes('img2img-grids')) return A1111FolderType.GRID;
-
-    // Check specific folder names (not just containing the word)
-    const parts = lower.split(/[\\/]/);
-    if (parts.some(p => p === 'txt2img-images' || p === 'txt2img' || p === 'text')) return A1111FolderType.TXT2IMG;
-    if (parts.some(p => p === 'img2img-images' || p === 'img2img' || p === 'image')) return A1111FolderType.IMG2IMG;
-    if (parts.some(p => p === 'extras-images' || p === 'extras' || p === 'upscale')) return A1111FolderType.EXTRAS;
-    if (parts.some(p => p === 'grids' || p === 'grids-images')) return A1111FolderType.GRID;
-    if (parts.some(p => p === 'save' || p === 'saved')) return A1111FolderType.SAVED;
-
     return A1111FolderType.UNKNOWN;
 };
 
+const toWebUIVariant = (value: string): WebUIVariant => {
+    if ((Object.values(WebUIVariant) as string[]).includes(value)) {
+        return value as WebUIVariant;
+    }
+    return WebUIVariant.UNKNOWN;
+};
+
+const normalizeExistingPaths = (existingPaths: Set<string>): Set<string> =>
+    new Set(Array.from(existingPaths, path => normalizePath(path).toLowerCase()));
+
+const mapBackendCandidate = (
+    candidate: BackendDiscoveryCandidate,
+    existingPaths: Set<string>,
+    forcedVariant: WebUIVariant | 'Auto'
+): DiscoveryCandidate => {
+    const normalizedPath = normalizePath(candidate.path);
+    const variant = forcedVariant === 'Auto'
+        ? toWebUIVariant(candidate.variant)
+        : forcedVariant;
+
+    return {
+        path: normalizedPath,
+        name: candidate.name,
+        imageCount: candidate.imageCount,
+        inferredType: toFolderType(candidate.inferredType),
+        isAlreadyLinked: existingPaths.has(normalizedPath.toLowerCase()),
+        isPriority: candidate.isPriority,
+        variant
+    };
+};
+
+export const getUnlinkedPriorityCandidatePaths = (candidates: DiscoveryCandidate[]): string[] =>
+    candidates
+        .filter(candidate => candidate.isPriority && !candidate.isAlreadyLinked)
+        .map(candidate => candidate.path);
+
+/**
+ * Attempts to detect the specific WebUI variant (A1111, Forge, SD.Next, Anapnoe).
+ * This now goes through the backend discovery command so archive paths are not
+ * limited by the frontend fs plugin scope.
+ */
+export const detectWebUIVariation = async (rootPath: string): Promise<WebUIVariant> => {
+    const result = await unwrap(commands.discoverA1111Folders(rootPath));
+    return toWebUIVariant(result.detectedVariant);
+};
+
+/**
+ * Discover potential A1111/SD WebUI folders using the same recursive image rules
+ * as the importer, then add frontend-only state such as linked status and manual
+ * variant override.
+ */
+export const discoverA1111Candidates = async (
+    rootPath: string,
+    existingPaths: Set<string>,
+    forcedVariant: WebUIVariant | 'Auto' = 'Auto'
+): Promise<DiscoveryResult> => {
+    const result = await unwrap(commands.discoverA1111Folders(rootPath));
+    const normalizedExistingPaths = normalizeExistingPaths(existingPaths);
+    const logs = [...result.logs];
+
+    if (forcedVariant !== 'Auto') {
+        logs.push(`[Info] Manual Override applied: Forced all candidates to ${forcedVariant}`);
+    }
+
+    return {
+        detectedVariant: forcedVariant === 'Auto'
+            ? toWebUIVariant(result.detectedVariant)
+            : forcedVariant,
+        candidates: result.candidates.map(candidate =>
+            mapBackendCandidate(candidate, normalizedExistingPaths, forcedVariant)
+        ),
+        logs,
+        warnings: [...result.warnings]
+    };
+};

--- a/src/services/a1111/types.ts
+++ b/src/services/a1111/types.ts
@@ -33,3 +33,10 @@ export interface DiscoveryCandidate {
     isPriority: boolean;
     variant?: WebUIVariant;
 }
+
+export interface DiscoveryResult {
+    detectedVariant: WebUIVariant;
+    candidates: DiscoveryCandidate[];
+    logs: string[];
+    warnings: string[];
+}


### PR DESCRIPTION
## Summary

- Adds a Rust-backed A1111/SD WebUI discovery command that recursively counts importable images using backend filesystem behavior.
- Detects standard output folders with date-based subfolders, including `img2img-images`, `txt2img`, and `txt2img-images`.
- Surfaces discovery warnings and debug logs, including warning-only scans and per-entry directory read errors.
- Keeps first-import cursors from advancing until import succeeds, with focused frontend and Rust coverage.

## Root Cause

The previous TypeScript discovery path only counted direct images for priority folders. Standard A1111 folders that store outputs under date subfolders could be recognized as priority folders but skipped because their direct image count was zero.

## Validation

- `pnpm test:run -- src\features\settings\components\__tests__\A1111Tab.test.tsx src\services\a1111\__tests__\config.test.ts`
- `pnpm run typecheck`
- `pnpm run test:rust`
- `git diff --check`