### PR TITLE
[codex] Harden beta security blockers and add advisory audit

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -67,5 +67,13 @@ jobs:
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      - name: install cargo-audit
+        run: cargo install cargo-audit --version 0.22.1 --locked
+
+      # RUSTSEC-2023-0071 is ignored by the audit wrapper because it is pulled
+      # through optional sqlx-mysql while Ambit only enables the SQLite beta path.
+      - name: run rust dependency advisory audit
+        run: pnpm run audit:rust
+
       - name: run rust tests
         run: pnpm test:rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,14 @@ jobs:
       - name: install frontend dependencies
         run: pnpm install
 
+      - name: install cargo-audit
+        run: cargo install cargo-audit --version 0.22.1 --locked
+
+      # RUSTSEC-2023-0071 is ignored by the audit wrapper because it is pulled
+      # through optional sqlx-mysql while Ambit only enables the SQLite beta path.
+      - name: run rust dependency advisory audit
+        run: pnpm run audit:rust
+
       - name: verify version consistency
         run: pnpm check:versions
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@google/genai": "^1.30.0",
+    "@google/genai": "^1.52.0",
     "@tanstack/react-query": "^5.90.16",
     "@tanstack/react-query-devtools": "^5.91.2",
     "@tauri-apps/api": "^2.9.1",
@@ -61,7 +61,7 @@
     "autoprefixer": "^10.4.17",
     "cross-env": "^10.1.0",
     "jsdom": "^27.4.0",
-    "postcss": "^8.4.35",
+    "postcss": "^8.5.14",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.8.2",
     "vite": "^8.0.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:versions": "node ./scripts/check-version-consistency.mjs",
     "typecheck": "tsc --noEmit",
     "verify:release": "pnpm run check:versions && pnpm run bindings:check && pnpm run typecheck && pnpm run test:run && pnpm run test:rust",
+    "audit:rust": "node ./scripts/audit-rust.mjs",
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@google/genai':
-        specifier: ^1.30.0
-        version: 1.48.0
+        specifier: ^1.52.0
+        version: 1.52.0
       '@tanstack/react-query':
         specifier: ^5.90.16
         version: 5.96.2(react@19.2.4)
@@ -104,7 +104,7 @@ importers:
         version: 5.2.0(vite@8.0.8(@types/node@22.19.17)(jiti@1.21.7))
       autoprefixer:
         specifier: ^10.4.17
-        version: 10.4.27(postcss@8.5.8)
+        version: 10.4.27(postcss@8.5.14)
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -112,8 +112,8 @@ importers:
         specifier: ^27.4.0
         version: 27.4.0
       postcss:
-        specifier: ^8.4.35
-        version: 8.5.8
+        specifier: ^8.5.14
+        version: 8.5.14
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.19
@@ -292,8 +292,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@google/genai@1.48.0':
-    resolution: {integrity: sha512-plonYK4ML2PrxsRD9SeqmFt76eREWkQdPCglOA6aYDzL1AAbE+7PUnT54SvpWGfws13L0AZEqGSpL7+1IPnTxQ==}
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -344,8 +344,8 @@ packages:
   '@protobufjs/base64@1.1.2':
     resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
 
-  '@protobufjs/codegen@2.0.4':
-    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
 
   '@protobufjs/eventemitter@1.1.0':
     resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
@@ -356,8 +356,8 @@ packages:
   '@protobufjs/float@1.0.2':
     resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
 
-  '@protobufjs/inquire@1.1.0':
-    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
 
   '@protobufjs/path@1.1.2':
     resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
@@ -365,8 +365,8 @@ packages:
   '@protobufjs/pool@1.1.0':
     resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
 
-  '@protobufjs/utf8@1.1.0':
-    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
@@ -1453,8 +1453,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1570,8 +1570,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   pretty-format@27.5.1:
@@ -1584,8 +1584,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.7:
+    resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
     engines: {node: '>=12.0.0'}
 
   punycode@2.3.1:
@@ -2229,11 +2229,11 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@google/genai@1.48.0':
+  '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.7
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -2284,24 +2284,24 @@ snapshots:
 
   '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4': {}
+  '@protobufjs/codegen@2.0.5': {}
 
   '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
 
   '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0': {}
+  '@protobufjs/inquire@1.1.1': {}
 
   '@protobufjs/path@1.1.2': {}
 
   '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0': {}
+  '@protobufjs/utf8@1.1.1': {}
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -2671,13 +2671,13 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  autoprefixer@10.4.27(postcss@8.5.8):
+  autoprefixer@10.4.27(postcss@8.5.14):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001786
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.8
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
 
   bail@2.0.2: {}
@@ -3439,7 +3439,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   node-domexception@1.0.0: {}
 
@@ -3496,28 +3496,28 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  postcss-import@15.1.0(postcss@8.5.8):
+  postcss-import@15.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.8):
+  postcss-js@4.1.0(postcss@8.5.14):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.8
+      postcss: 8.5.14
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.8):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.8
+      postcss: 8.5.14
 
-  postcss-nested@6.2.0(postcss@8.5.8):
+  postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.5.8
+      postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -3527,9 +3527,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.8:
+  postcss@8.5.14:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3543,18 +3543,18 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.7:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/codegen': 2.0.5
       '@protobufjs/eventemitter': 1.1.0
       '@protobufjs/fetch': 1.1.0
       '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/inquire': 1.1.1
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
+      '@protobufjs/utf8': 1.1.1
       '@types/node': 22.19.17
       long: 5.3.2
 
@@ -3792,11 +3792,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.8
-      postcss-import: 15.1.0(postcss@8.5.8)
-      postcss-js: 4.1.0(postcss@8.5.8)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.8)
-      postcss-nested: 6.2.0(postcss@8.5.8)
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)
+      postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -3936,7 +3936,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:

--- a/scripts/audit-rust.mjs
+++ b/scripts/audit-rust.mjs
@@ -1,0 +1,102 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+
+const ignoredAdvisories = new Map([
+  [
+    'RUSTSEC-2023-0071',
+    'optional rsa dependency through sqlx-mysql; Ambit beta only enables the local SQLite path',
+  ],
+]);
+
+const args = [
+  'audit',
+  '--file',
+  'src-tauri/Cargo.lock',
+  '--target-os',
+  'windows',
+  '--format',
+  'json',
+  ...[...ignoredAdvisories.keys()].flatMap((id) => ['--ignore', id]),
+];
+
+const result = spawnSync('cargo', args, {
+  cwd: process.cwd(),
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(result.stdout);
+} catch (error) {
+  if (result.stdout) {
+    console.error(result.stdout);
+  }
+  if (result.stderr) {
+    console.error(result.stderr);
+  }
+  console.error(`Failed to parse cargo audit JSON output: ${error.message}`);
+  process.exit(result.status ?? 1);
+}
+
+const vulnerabilities = report.vulnerabilities?.list ?? [];
+if (vulnerabilities.length > 0) {
+  console.error(`Rust advisory audit failed: ${vulnerabilities.length} unignored vulnerability finding(s).`);
+
+  for (const finding of vulnerabilities) {
+    const advisory = finding.advisory ?? {};
+    const pkg = finding.package ?? {};
+    console.error(
+      `- ${advisory.id ?? 'unknown'} ${pkg.name ?? advisory.package ?? 'unknown'}@${pkg.version ?? 'unknown'}: ${advisory.title ?? 'untitled advisory'}`,
+    );
+  }
+
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  if (result.stderr) {
+    console.error(result.stderr);
+  }
+  console.error(`cargo audit exited with status ${result.status}.`);
+  process.exit(result.status);
+}
+
+const warnings = report.warnings ?? {};
+const warningEntries = Object.entries(warnings);
+const warningCount = warningEntries.reduce((total, [, items]) => total + items.length, 0);
+const warningSummary = warningEntries
+  .filter(([, items]) => items.length > 0)
+  .map(([kind, items]) => `${kind}: ${items.length}`)
+  .join(', ');
+
+const dependencyCount = report.lockfile?.['dependency-count'] ?? 'unknown';
+console.log(`Rust advisory audit passed: 0 unignored vulnerabilities across ${dependencyCount} dependencies.`);
+console.log(
+  `Ignored advisories: ${[...ignoredAdvisories.entries()]
+    .map(([id, reason]) => `${id} (${reason})`)
+    .join('; ')}`,
+);
+
+if (warningCount > 0) {
+  const packages = [
+    ...new Set(
+      warningEntries
+        .flatMap(([, items]) => items)
+        .map((item) => {
+          const pkg = item.package ?? {};
+          return `${pkg.name ?? item.advisory?.package ?? 'unknown'}@${pkg.version ?? 'unknown'}`;
+        }),
+    ),
+  ];
+  const shownPackages = packages.slice(0, 12).join(', ');
+  const suffix = packages.length > 12 ? `, ... ${packages.length - 12} more` : '';
+
+  console.warn(`Allowed cargo-audit warnings: ${warningCount}${warningSummary ? ` (${warningSummary})` : ''}.`);
+  console.warn(`Warning packages: ${shownPackages}${suffix}.`);
+}

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.4.0",
+ "fastrand 2.3.0",
  "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
@@ -1148,7 +1148,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1437,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -1675,7 +1675,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.4.0",
+ "fastrand 2.3.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -2090,7 +2090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.12",
- "allocator-api2",
 ]
 
 [[package]]
@@ -2099,6 +2098,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2115,6 +2116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -2878,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3038,12 +3048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,16 +3176,6 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "notify"
@@ -3336,7 +3330,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3572,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3777,7 +3771,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "fastrand 2.4.0",
+ "fastrand 2.3.0",
  "phf_shared 0.13.1",
 ]
 
@@ -3870,7 +3864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.4.0",
+ "fastrand 2.3.0",
  "futures-io",
 ]
 
@@ -4492,14 +4486,14 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -4573,7 +4567,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4629,7 +4623,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4640,9 +4634,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5159,7 +5153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5274,20 +5268,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5298,38 +5282,33 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "atoi",
- "byteorder",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener 5.4.1",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
- "hashlink",
- "hex",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
  "indexmap 2.13.1",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
  "rust_decimal",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-stream",
@@ -5340,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5353,9 +5332,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
@@ -5372,16 +5351,15 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
- "tempfile",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -5415,7 +5393,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -5424,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -5437,7 +5415,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -5456,7 +5433,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
@@ -5465,9 +5442,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "flume",
@@ -5482,6 +5459,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
+ "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
@@ -6144,11 +6122,11 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.4.0",
+ "fastrand 2.3.0",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6587,7 +6565,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6669,12 +6647,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -7110,7 +7082,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ base64 = "0.21"
 rayon = "1.8"
 flate2 = "1.1.5"
 tauri-plugin-sql = { version = "2", features = ["sqlite"] }
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 notify = { version = "8.2.0", features = ["serde"] }
 regex = "1.12.2"
 tokio = { version = "1", features = ["sync", "time"] }

--- a/src-tauri/src/db/commands/filter_commands.rs
+++ b/src-tauri/src/db/commands/filter_commands.rs
@@ -1,4 +1,5 @@
 use super::run_blocking;
+use rusqlite::types::Value;
 use tauri::AppHandle;
 
 #[derive(serde::Serialize, specta::Type)]
@@ -20,6 +21,29 @@ pub struct ParameterRanges {
     pub guidance_subtypes: std::collections::HashMap<String, String>,
 }
 
+fn build_parameter_scope_from_clause(
+    collection_id: Option<&str>,
+    lora_name: Option<&str>,
+) -> (String, Vec<Value>) {
+    let mut from_clause = "FROM images".to_string();
+    let mut join_params = Vec::new();
+
+    if let Some(col_id) = collection_id {
+        from_clause.push_str(
+            " JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = ?",
+        );
+        join_params.push(Value::Text(col_id.to_string()));
+    }
+
+    if let Some(lora) = lora_name {
+        from_clause
+            .push_str(" JOIN image_loras il ON il.image_id = images.id AND il.lora_name = ?");
+        join_params.push(Value::Text(lora.to_string()));
+    }
+
+    (from_clause, join_params)
+}
+
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
 pub async fn get_parameter_ranges(
@@ -36,22 +60,22 @@ pub async fn get_parameter_ranges(
             Vec::new()
         };
 
-        let sql_params: Vec<rusqlite::types::Value> = params.iter().map(|p| match p {
-            serde_json::Value::String(s) => rusqlite::types::Value::Text(s.clone()),
+        let sql_params: Vec<Value> = params.iter().map(|p| match p {
+            serde_json::Value::String(s) => Value::Text(s.clone()),
             serde_json::Value::Number(n) => {
-                if let Some(i) = n.as_i64() { rusqlite::types::Value::Integer(i) }
-                else if let Some(f) = n.as_f64() { rusqlite::types::Value::Real(f) }
-                else { rusqlite::types::Value::Null }
+                if let Some(i) = n.as_i64() { Value::Integer(i) }
+                else if let Some(f) = n.as_f64() { Value::Real(f) }
+                else { Value::Null }
             }
-            serde_json::Value::Bool(b) => rusqlite::types::Value::Integer(if *b { 1 } else { 0 }),
-            serde_json::Value::Null => rusqlite::types::Value::Null,
-            _ => rusqlite::types::Value::Text(p.to_string()),
+            serde_json::Value::Bool(b) => Value::Integer(if *b { 1 } else { 0 }),
+            serde_json::Value::Null => Value::Null,
+            _ => Value::Text(p.to_string()),
         }).collect();
-        
+
         let reactive_where = where_clause.unwrap_or_else(|| "WHERE is_deleted = 0".to_string());
-        let mut from_clause = "FROM images".to_string();
-        if let Some(col_id) = collection_id { from_clause.push_str(&format!(" JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = '{}'", col_id)); }
-        if let Some(lora) = lora_name { from_clause.push_str(&format!(" JOIN image_loras il ON il.image_id = images.id AND il.lora_name = '{}'", lora)); }
+        let (from_clause, mut query_params) =
+            build_parameter_scope_from_clause(collection_id.as_deref(), lora_name.as_deref());
+        query_params.extend(sql_params);
 
         // Ranges
         let steps = conn.query_row("SELECT MIN(steps), MAX(steps) FROM images WHERE is_deleted = 0 AND steps > 0", [], |row| {
@@ -73,7 +97,7 @@ pub async fn get_parameter_ranges(
         let get_distinct = |conn: &rusqlite::Connection, field: &str| -> Result<Vec<String>, String> {
             let sql = format!("SELECT DISTINCT {} {} {} AND {} IS NOT NULL AND {} != '' AND {} != 'unknown' ORDER BY 1", field, from_clause, reactive_where, field, field, field);
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-            let items = stmt.query_map(rusqlite::params_from_iter(sql_params.iter()), |row| row.get(0))
+            let items = stmt.query_map(rusqlite::params_from_iter(query_params.iter()), |row| row.get(0))
                 .map_err(|e| e.to_string())?
                 .collect::<Result<Vec<String>, _>>()
                 .map_err(|e| e.to_string())?;
@@ -86,7 +110,7 @@ pub async fn get_parameter_ranges(
         let get_junction_distinct = |conn: &rusqlite::Connection, table: &str, field: &str| -> Result<Vec<String>, String> {
             let sql = format!("SELECT DISTINCT {}.{} {} JOIN {} ON {}.image_id = images.id {} ORDER BY 1", table, field, from_clause, table, table, reactive_where);
             let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
-            let items = stmt.query_map(rusqlite::params_from_iter(sql_params.iter()), |row| row.get(0))
+            let items = stmt.query_map(rusqlite::params_from_iter(query_params.iter()), |row| row.get(0))
                 .map_err(|e| e.to_string())?
                 .collect::<Result<Vec<String>, _>>()
                 .map_err(|e| e.to_string())?;
@@ -102,13 +126,39 @@ pub async fn get_parameter_ranges(
             .map_err(|e| e.to_string())?
             .collect::<Result<Vec<(String, String)>, _>>()
             .map_err(|e| e.to_string())?;
-        
+
         for (name, subtype) in rows {
             guidance_subtypes.insert(name, subtype);
         }
-        
+
         Ok(ParameterRanges { steps, cfg, denoising_strength, samplers, generation_types, control_nets, ip_adapters, guidance_subtypes })
     }).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parameter_scope_uses_bound_values_for_collection_and_lora() {
+        let collection_id = "col' OR 1=1 --";
+        let lora_name = "lora' OR 1=1 --";
+
+        let (from_clause, params) =
+            build_parameter_scope_from_clause(Some(collection_id), Some(lora_name));
+
+        assert!(from_clause.contains("ci.collection_id = ?"));
+        assert!(from_clause.contains("il.lora_name = ?"));
+        assert!(!from_clause.contains(collection_id));
+        assert!(!from_clause.contains(lora_name));
+        assert_eq!(
+            params,
+            vec![
+                Value::Text(collection_id.to_string()),
+                Value::Text(lora_name.to_string())
+            ]
+        );
+    }
 }
 
 #[tauri::command(rename_all = "camelCase")]

--- a/src-tauri/src/metadata/parsers.rs
+++ b/src-tauri/src/metadata/parsers.rs
@@ -3,6 +3,9 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 
+const MAX_PNG_METADATA_CHUNK_BYTES: u64 = 16 * 1024 * 1024;
+const MAX_PNG_DECOMPRESSED_TEXT_BYTES: u64 = 10 * 1024 * 1024;
+
 pub fn scan_jpeg_metadata(path: &std::path::Path) -> Result<HashMap<String, String>, String> {
     let mut file = File::open(path).map_err(|e| e.to_string())?;
     let mut buffer = [0; 2];
@@ -56,6 +59,25 @@ pub fn scan_jpeg_metadata(path: &std::path::Path) -> Result<HashMap<String, Stri
     Ok(chunks)
 }
 
+fn skip_chunk_data_and_crc<R: Seek>(reader: &mut R, length: u64) -> Result<(), String> {
+    reader
+        .seek(SeekFrom::Current((length + 4) as i64))
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
+fn read_limited_zlib_text(data: &[u8]) -> Option<String> {
+    let decoder = ZlibDecoder::new(data);
+    let mut limited = decoder.take(MAX_PNG_DECOMPRESSED_TEXT_BYTES + 1);
+    let mut s = String::new();
+
+    if limited.read_to_string(&mut s).is_ok() && s.len() as u64 <= MAX_PNG_DECOMPRESSED_TEXT_BYTES {
+        Some(s)
+    } else {
+        None
+    }
+}
+
 /// Extracts metadata chunks from a PNG file.
 ///
 /// **IMPORTANT**: This function expects the reader to be positioned at the **beginning** of the file
@@ -99,6 +121,11 @@ pub fn extract_png_chunks<R: Read + Seek>(
             || chunk_type == "zTXt"
             || chunk_type == "eXIf"
         {
+            if length > MAX_PNG_METADATA_CHUNK_BYTES {
+                skip_chunk_data_and_crc(reader, length)?;
+                continue;
+            }
+
             let mut chunk_data = vec![0; length as usize];
             if reader.read_exact(&mut chunk_data).is_err() {
                 break;
@@ -121,9 +148,7 @@ pub fn extract_png_chunks<R: Read + Seek>(
                 if chunk_type == "zTXt" {
                     if pos + 2 < chunk_data.len() && chunk_data[pos + 1] == 0 {
                         let compressed = &chunk_data[pos + 2..];
-                        let mut decoder = ZlibDecoder::new(compressed);
-                        let mut s = String::new();
-                        if decoder.read_to_string(&mut s).is_ok() {
+                        if let Some(s) = read_limited_zlib_text(compressed) {
                             chunks.insert(key, s);
                         }
                     }
@@ -153,9 +178,7 @@ pub fn extract_png_chunks<R: Read + Seek>(
                         if curr < chunk_data.len() {
                             let data_slice = &chunk_data[curr..];
                             if is_compressed {
-                                let mut decoder = ZlibDecoder::new(data_slice);
-                                let mut s = String::new();
-                                if decoder.read_to_string(&mut s).is_ok() {
+                                if let Some(s) = read_limited_zlib_text(data_slice) {
                                     chunks.insert(key, s);
                                 }
                             } else {
@@ -173,10 +196,7 @@ pub fn extract_png_chunks<R: Read + Seek>(
             break;
         } else {
             // Efficiently skip data + CRC O(1) without thrashing OS disk I/O
-            let skip_len = length + 4;
-            reader
-                .seek(SeekFrom::Current(skip_len as i64))
-                .map_err(|e| e.to_string())?;
+            skip_chunk_data_and_crc(reader, length)?;
         }
     }
 
@@ -431,6 +451,64 @@ mod tests {
         let mut cursor = Cursor::new(png);
         let chunks = extract_png_chunks(&mut cursor).unwrap();
         assert_eq!(chunks.get("Software").map(|s| s.as_str()), Some("Ambit"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_skips_oversized_metadata_chunk() {
+        let mut png = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let oversized_len = MAX_PNG_METADATA_CHUNK_BYTES + 1;
+
+        png.extend_from_slice(&(oversized_len as u32).to_be_bytes());
+        png.extend_from_slice(b"tEXt");
+        png.extend(std::iter::repeat(0u8).take(oversized_len as usize));
+        png.extend_from_slice(&[0; 4]);
+
+        png.extend_from_slice(&14u32.to_be_bytes());
+        png.extend_from_slice(b"tEXt");
+        png.extend_from_slice(b"Software\0Ambit");
+        png.extend_from_slice(&[0; 4]);
+
+        png.extend_from_slice(&0u32.to_be_bytes());
+        png.extend_from_slice(b"IEND");
+        png.extend_from_slice(&[0; 4]);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+        assert!(!chunks.contains_key(""));
+        assert_eq!(chunks.get("Software").map(|s| s.as_str()), Some("Ambit"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_rejects_compressed_text_bomb() {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut png = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let expanded = vec![b'a'; (MAX_PNG_DECOMPRESSED_TEXT_BYTES + 1) as usize];
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&expanded).unwrap();
+        let compressed_text = encoder.finish().unwrap();
+
+        let mut data = Vec::new();
+        data.extend_from_slice(b"Comment");
+        data.push(0);
+        data.push(0);
+        data.extend_from_slice(&compressed_text);
+
+        png.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        png.extend_from_slice(b"zTXt");
+        png.extend_from_slice(&data);
+        png.extend_from_slice(&[0; 4]);
+
+        png.extend_from_slice(&0u32.to_be_bytes());
+        png.extend_from_slice(b"IEND");
+        png.extend_from_slice(&[0; 4]);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+        assert!(!chunks.contains_key("Comment"));
     }
 
     #[test]

--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -394,3 +394,44 @@ describe('searchRepo getFacets', () => {
         });
     });
 });
+
+describe('searchRepo scoped stats queries', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('binds collection and lora values instead of interpolating them into stats SQL', async () => {
+        const collectionId = "col' OR 1=1 --";
+        const loraName = "lora' OR 1=1 --";
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as total')) {
+                    return [{ total: 0 }];
+                }
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { clearLibraryStatsCache, getLibraryStats } = await import('../searchRepo');
+        clearLibraryStatsCache();
+
+        await getLibraryStats('WHERE is_deleted = ?', [0], collectionId, loraName);
+
+        const [statsSql, statsParams] = db.select.mock.calls[0] as unknown as [string, unknown[]];
+        const [keywordSql, keywordParams] = db.select.mock.calls[2] as unknown as [string, unknown[]];
+
+        expect(statsSql).toContain('ci.collection_id = ?');
+        expect(statsSql).toContain('il.lora_name = ?');
+        expect(statsSql).not.toContain(collectionId);
+        expect(statsSql).not.toContain(loraName);
+        expect(statsParams).toEqual([collectionId, loraName, 0]);
+
+        expect(keywordSql).toContain('ci.collection_id = ?');
+        expect(keywordSql).toContain('il.lora_name = ?');
+        expect(keywordSql).not.toContain(collectionId);
+        expect(keywordSql).not.toContain(loraName);
+        expect(keywordParams).toEqual([collectionId, loraName, 0]);
+    });
+});

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -511,6 +511,26 @@ export const clearLibraryStatsCache = () => {
     globalStatsCache = null;
 };
 
+const buildScopedImageJoins = (collectionId?: string, loraName?: string): { joinClause: string; joinParams: unknown[] } => {
+    const joins: string[] = [];
+    const joinParams: unknown[] = [];
+
+    if (collectionId) {
+        joins.push('JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = ?');
+        joinParams.push(collectionId);
+    }
+
+    if (loraName) {
+        joins.push('JOIN image_loras il ON il.image_id = images.id AND il.lora_name = ?');
+        joinParams.push(loraName);
+    }
+
+    return {
+        joinClause: joins.join('\n'),
+        joinParams
+    };
+};
+
 export const getLibraryStats = async (whereClause: string = '', params: any[] = [], collectionId?: string, loraName?: string): Promise<LibraryStats> => {
     // Return cached result instantly for unfiltered dashboard loads
     if (!whereClause && !collectionId && !loraName && globalStatsCache) {
@@ -520,6 +540,7 @@ export const getLibraryStats = async (whereClause: string = '', params: any[] = 
     const db = await getDb();
     const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
     const reason = describeDbQueryReason(finalWhere, collectionId, loraName);
+    const { joinClause, joinParams } = buildScopedImageJoins(collectionId, loraName);
 
     try {
         const statsQuery = `
@@ -527,12 +548,11 @@ export const getLibraryStats = async (whereClause: string = '', params: any[] = 
                 count(*) as total
 
             FROM images 
-            ${collectionId ? `JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = '${collectionId}'` : ''}
-            ${loraName ? `JOIN image_loras il ON il.image_id = images.id AND il.lora_name = '${loraName}'` : ''}
+            ${joinClause}
             ${finalWhere}
         `;
 
-        const basicStats = await timeDbCall('libraryStats.basicStats', reason, () => db.select<any[]>(statsQuery, params));
+        const basicStats = await timeDbCall('libraryStats.basicStats', reason, () => db.select<any[]>(statsQuery, [...joinParams, ...params]));
         
         const total = basicStats[0]?.total || 0;
         const avgSteps = 0; // Temporarily disabled for performance
@@ -632,27 +652,11 @@ export const getKeywordStats = async (whereClause: string = '', params: any[] = 
          * But since we have a LIMIT, SQLite can sometimes optimize.
          * For a word cloud, we need a diverse sample.
          */
-        let joinClause = "JOIN images_fts ON images_fts.rowid = images.rowid";
-
-        // Prioritize Collection/LoRA filtering with INNER JOIN if present
-        // Prioritize Collection/LoRA filtering with INNER JOIN if present
-        if (collectionId && loraName) {
-            joinClause = `
-                JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = '${collectionId}'
-                JOIN image_loras il ON il.image_id = images.id AND il.lora_name = '${loraName}'
-                JOIN images_fts ON images_fts.rowid = images.rowid
-            `;
-        } else if (collectionId) {
-            joinClause = `
-                JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = '${collectionId}'
-                JOIN images_fts ON images_fts.rowid = images.rowid
-            `;
-        } else if (loraName) {
-            joinClause = `
-                JOIN image_loras il ON il.image_id = images.id AND il.lora_name = '${loraName}'
-                JOIN images_fts ON images_fts.rowid = images.rowid
-            `;
-        }
+        const { joinClause: scopedJoinClause, joinParams } = buildScopedImageJoins(collectionId, loraName);
+        const joinClause = `
+            ${scopedJoinClause}
+            JOIN images_fts ON images_fts.rowid = images.rowid
+        `;
 
         const promptQuery = `
             SELECT images_fts.positive_prompt 
@@ -663,7 +667,7 @@ export const getKeywordStats = async (whereClause: string = '', params: any[] = 
         `;
         
         const reason = describeDbQueryReason(finalWhere, collectionId, loraName);
-        const rows = await timeDbCall('keywordStats.promptSample', reason, () => db.select<any[]>(promptQuery, params));
+        const rows = await timeDbCall('keywordStats.promptSample', reason, () => db.select<any[]>(promptQuery, [...joinParams, ...params]));
         
         const stopWords = new Set(WORD_CLOUD_CONFIG.STOP_WORDS);
         const counts: Record<string, number> = {};


### PR DESCRIPTION
## Summary

This PR applies the confirmed public-beta security blockers from the audit branch and adds a Rust advisory gate for future PR/release checks.

## Changes

- Parameterizes beta-critical SQLite query paths in Rust and TypeScript search helpers.
- Adds regression coverage for SQL parameter binding around collection and LoRA filters.
- Adds PNG metadata extraction limits for oversized chunks and compressed text bombs.
- Updates fixable frontend production dependencies surfaced by `pnpm audit --prod`.
- Adds `pnpm run audit:rust` through `scripts/audit-rust.mjs`.
- Wires Rust advisory checks into PR CI and release workflows.
- Updates Rust dependencies for fixable advisories and moves `fastrand` off the yanked `2.4.0` release.

## Rust Advisory Decision

`RUSTSEC-2023-0071` is intentionally ignored in the audit wrapper for this beta because it is attached to `rsa` through optional `sqlx-mysql` lockfile resolution. Ambit beta enables the local SQLite path, not MySQL.

Policy for this exception:

- keep the ignore narrow and named in `scripts/audit-rust.mjs`
- fail CI/release for any unignored RustSec vulnerability
- remove the ignore if `sqlx-mysql`/`rsa` leaves the lockfile or if Ambit ever enables MySQL-backed SQL paths
- revisit this during dependency upgrade passes

## Tracked Follow-up Debt

The remaining Rust advisory warnings are tracked as non-blocking upstream dependency debt in #51.

Current local audit posture:

- 0 unignored RustSec vulnerabilities
- 1 ignored advisory: `RUSTSEC-2023-0071`
- 23 allowed warnings: 20 unmaintained, 3 unsound

## Recommended Next Hardening Pass

After this PR, I recommend one focused hardening pass rather than a broad refactor:

1. `register_library_path` scope expansion and path canonicalization behavior
2. `move_to_trash` / `delete_thumbnail` path provenance before destructive filesystem operations
3. `VACUUM INTO` backup path escaping and robustness
4. `ReactMarkdown` link/rendering behavior for remote or user-controlled content
5. `openExternalUrl` allowlist shape and browser fallback behavior

## Validation

- `pnpm audit --prod`
- `pnpm run audit:rust`
- `pnpm run verify:release`

The release verifier passed locally on Windows. It still emits existing Rust dead-code warnings and repeated frontend perf-label warnings, but no check failed.