### PR TITLE
[codex] fix: make integration imports cancellable

### DIFF
--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -95,6 +95,46 @@ Status: Deferred
 - `src/services/invoke/syncService.ts`
 - `src/utils/liveWatchPerf.ts`
 
+## Rust-Side Cancellation For Integration Imports
+Status: Deferred
+Priority: P2
+
+### Why Cleanup Is Needed
+- Frontend-managed integration imports now use cooperative `AbortController` cancellation and return explicit `wasCancelled` state, so cancelled imports should not advance folder cursors.
+- The remaining cancellation gap is inside active Rust IPC work. Once a frontend import has entered a backend command such as directory traversal or bulk metadata extraction, the current call can continue until it returns.
+- This is mostly a responsiveness and resource-use issue after the frontend cancellation fix, but it can still make very large folder imports feel slow to stop.
+
+### Current Pain Points
+- `scanDirectoryWithStats` can keep walking a large directory after the user clicks Cancel.
+- Bulk metadata scan work can continue through the current native batch before the frontend observes cancellation.
+- The Activity Dock can hide cancelled import state promptly, but backend CPU/disk work may still be active briefly or for a long scan.
+
+### Safe-Change Warning
+- Do not mix this with the frontend cooperative cancellation pass. Backend cancellation likely needs Tauri command contract changes, shared cancellation state, and Rust tests.
+- If command signatures change, regenerate Specta bindings instead of editing `src/bindings.ts` manually.
+- Preserve path-scope checks and local-first filesystem safety while threading cancellation through recursive traversal.
+- Cancellation should be best-effort and explicit: partial imports must remain distinguishable from complete imports, and folder cursors must not advance after cancellation.
+
+### Suggested Future Direction
+- Add a backend import or scan session id that the frontend can associate with its `AbortController`.
+- Store cancellation tokens in Rust for active import/session work and expose a Tauri cancel command for that session.
+- Check the token inside directory traversal loops, bulk metadata extraction loops, and between filesystem/database batches.
+- Keep existing frontend `wasCancelled` handling as the UI and cursor-safety contract, and bridge it to Rust cancellation for faster stop behavior.
+- Add Rust tests or command-level integration tests for cancelled traversal and cancelled bulk metadata scanning.
+
+### Not Part of the Current Task
+- Do not block the current cooperative frontend cancellation fix on Rust interruption support.
+- Do not treat this as a data-correctness blocker unless a new path is found that still advances cursors after cancellation.
+
+### Related Code
+- `src/services/importService.ts`
+- `src/hooks/useImportOps.ts`
+- `src/hooks/useFolderMonitor.ts`
+- `src/features/settings/hooks/useFoldersTabLogic.ts`
+- `src-tauri/src/lib.rs`
+- `src-tauri/src/scanner/`
+- `src-tauri/src/metadata/`
+
 ## Evaluate FTS-Backed Search
 Status: Deferred
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,7 +219,7 @@ export default function App() {
     useFolderMonitor({
         isLoaded,
         monitoredFolders: settings.monitoredFolders,
-        onScan: (folders, isStartup) => fileOps.handleImportFolders(folders, isStartup),
+        onScan: (folders, options) => fileOps.handleImportFolders(folders, options),
         handleImportPaths: fileOps.handleImportPaths,
         addToast,
         refreshMetadata,

--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -34,7 +34,7 @@ const splitDetailItems = (detail?: string): string[] => (
 
 export const ActivityDock: React.FC = () => {
     const {
-        isImporting, importProgress,
+        isImporting, importProgress, importAbortController,
         syncStatus, syncProgress,
         liveWatchSession,
         isRegeneratingThumbnails, thumbnailProgress,
@@ -83,7 +83,7 @@ export const ActivityDock: React.FC = () => {
     if (isImporting) {
         progress = importProgress;
         label = "Importing";
-        supportsCancel = true;
+        supportsCancel = !!importAbortController;
     } else if (isManualSyncing) {
         progress = syncProgress;
         label = "Syncing";

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { act, render, screen } from '../../../test/testUtils';
+import { act, fireEvent, render, screen } from '../../../test/testUtils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ActivityDock } from '../ActivityDock';
 import { createInitialLiveWatchSessionState, useLibraryStore } from '../../../stores/libraryStore';
@@ -19,6 +19,7 @@ const resetLibraryStore = () => {
         syncProgress: { current: 0, total: 0, message: '' },
         isImporting: false,
         importProgress: null,
+        importAbortController: null,
         isRegeneratingThumbnails: false,
         thumbnailProgress: null,
         isResolvingModels: false,
@@ -97,6 +98,46 @@ describe('ActivityDock', () => {
         expect(screen.getByText('3 / 12')).toBeTruthy();
         expect(screen.getByText('Checking file paths for missing images...')).toBeTruthy();
         expect(screen.getByText('Cancel')).toBeTruthy();
+    });
+
+    it('renders import progress without cancel when no abort controller is registered', () => {
+        useLibraryStore.setState({
+            isImporting: true,
+            importProgress: {
+                current: 1,
+                total: 5,
+                message: 'Importing images...'
+            },
+            importAbortController: null
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Importing')).toBeTruthy();
+        expect(screen.getByText('Importing images...')).toBeTruthy();
+        expect(screen.queryByText('Cancel')).toBeNull();
+    });
+
+    it('aborts an import when cancel is clicked and a controller is registered', () => {
+        const abortController = new AbortController();
+        const abortSpy = vi.spyOn(abortController, 'abort');
+        useLibraryStore.setState({
+            isImporting: true,
+            importProgress: {
+                current: 1,
+                total: 5,
+                message: 'Importing images...'
+            },
+            importAbortController: abortController
+        });
+
+        render(<ActivityDock />);
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+        expect(abortSpy).toHaveBeenCalledTimes(1);
+        expect(useLibraryStore.getState().isImporting).toBe(false);
+        expect(useLibraryStore.getState().importProgress).toBeNull();
+        expect(useLibraryStore.getState().importAbortController).toBeNull();
     });
 
     it('renders running smart thumbnail progress without repeated checked counts', () => {

--- a/src/features/settings/components/A1111Tab.tsx
+++ b/src/features/settings/components/A1111Tab.tsx
@@ -163,7 +163,8 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
                                 ? {
                                     ...folder,
                                     lastScanned: importCompleted ? completedAt : undefined,
-                                    initialScanPending: false
+                                    initialScanPending: false,
+                                    initialScanCancelled: importCancelled
                                 }
                                 : folder
                         )
@@ -171,7 +172,7 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
                 }
 
                 if (importCancelled) {
-                    setLocalTestResult({ success: false, message: "Import cancelled. Folder cursor was not advanced." });
+                    setLocalTestResult({ success: false, message: "Import cancelled. Imported images were kept, and folder cursor was not advanced. Rescan to continue." });
                     return;
                 }
 
@@ -208,7 +209,7 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings,
                     ...prev,
                     monitoredFolders: prev.monitoredFolders.map(folder =>
                         newFolderIds.has(folder.id)
-                            ? { ...folder, lastScanned: undefined, initialScanPending: false }
+                            ? { ...folder, lastScanned: undefined, initialScanPending: false, initialScanCancelled: false }
                             : folder
                     )
                 }));

--- a/src/features/settings/components/A1111Tab.tsx
+++ b/src/features/settings/components/A1111Tab.tsx
@@ -7,11 +7,13 @@ import { useSearch } from '../../../contexts/SearchContext'; // Added
 import { A1111FolderType, type DiscoveryCandidate, WebUIVariant } from '../../../services/a1111/types';
 import { useToast } from '../../../hooks/useToast';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
+import type { ImportResult } from '../../../services/importService';
 
 interface TabProps {
     settings: AppSettings;
     setSettings: React.Dispatch<React.SetStateAction<AppSettings>>;
     onClose?: () => void;
+    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>;
 }
 
 const variantToGeneratorTool = (variant?: WebUIVariant): GeneratorTool | undefined => {
@@ -32,10 +34,8 @@ const variantToGeneratorTool = (variant?: WebUIVariant): GeneratorTool | undefin
 const variantToImportTool = (variant?: WebUIVariant): GeneratorTool =>
     variantToGeneratorTool(variant) ?? GeneratorTool.UNKNOWN;
 
-export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings }) => {
+export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings, onScanFolder }) => {
     const {
-        setIsImporting,
-        setImportProgress,
         refreshCollections
     } = useLibraryContext();
     const { refreshMetadata } = useSearch(); // Added hook usage
@@ -109,14 +109,16 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings 
     const handleLinkSelected = async () => {
         const toLink = candidates.filter(c => selectedPaths.has(c.path));
         if (toLink.length === 0) return;
+        if (!onScanFolder) {
+            setLocalTestResult({ success: false, message: "Import service is unavailable." });
+            addToast("Import service is unavailable", "error");
+            return;
+        }
 
         setIsDiscovering(true);
-        setIsImporting(true); // Ref-counting: +1
         let newFolderIds = new Set<string>();
 
         try {
-            const { processFoldersUnified } = await import('../../../services/importService');
-
             // 1. Prepare New Folders. Keep lastScanned empty until import succeeds.
             const brandNew = toLink.filter(c => !c.isAlreadyLinked);
             const alreadyLinked = toLink.filter(c => c.isAlreadyLinked);
@@ -148,14 +150,10 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings 
 
             // 4. Run Unified Import
             if (foldersToSync.length > 0) {
-                const result = await processFoldersUnified(foldersToSync, {
-                    onProgress: (current, total, message) => {
-                        setImportProgress({ current, total, message });
-                    },
-                    forceRescan: false
-                });
+                const result = await onScanFolder(foldersToSync);
                 const completedAt = Date.now();
-                const importCompleted = result.failedPaths.length === 0;
+                const importCancelled = !!result && result.wasCancelled;
+                const importCompleted = !!result && !result.wasCancelled && result.failedPaths.length === 0;
 
                 if (newFolderIds.size > 0) {
                     setSettings(prev => ({
@@ -170,6 +168,16 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings 
                                 : folder
                         )
                     }));
+                }
+
+                if (importCancelled) {
+                    setLocalTestResult({ success: false, message: "Import cancelled. Folder cursor was not advanced." });
+                    return;
+                }
+
+                if (!result) {
+                    setLocalTestResult({ success: false, message: "Import did not complete. Folder cursor was not advanced." });
+                    return;
                 }
 
                 let refreshFailed = false;
@@ -187,11 +195,9 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings 
                         ? `Processed ${totalCount} folders (${brandNew.length} new, ${alreadyLinked.length} rescanned), but refresh failed.`
                         : `Processed ${totalCount} folders (${brandNew.length} new, ${alreadyLinked.length} rescanned)`;
                     setLocalTestResult({ success: !refreshFailed, message: msg });
-                    addToast(msg, refreshFailed ? 'warning' : 'success');
                 } else {
                     const msg = `Processed ${totalCount} folders with ${result.failedPaths.length} failed file(s). Folder cursor was not advanced.`;
                     setLocalTestResult({ success: false, message: msg });
-                    addToast(msg, 'warning');
                 }
             }
 
@@ -211,8 +217,6 @@ export const A1111Tab: React.FC<TabProps> = React.memo(({ settings, setSettings 
             addToast("Import failed", "error");
         } finally {
             setIsDiscovering(false);
-            setIsImporting(false); // Ref-counting: -1
-            setImportProgress(null);
             setCandidates([]); // Clear selection
         }
     };

--- a/src/features/settings/components/ConnectionsTab.tsx
+++ b/src/features/settings/components/ConnectionsTab.tsx
@@ -79,6 +79,7 @@ export const ConnectionsTab: React.FC<ConnectionsTabProps> = ({
                         settings={settings}
                         setSettings={setSettings}
                         onClose={onClose || (() => { })}
+                        onScanFolder={onScanFolder}
                     />
                 )}
                 {activeTab === 'comfyui' && (

--- a/src/features/settings/components/FolderItem.tsx
+++ b/src/features/settings/components/FolderItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Folder, Monitor, RefreshCw, Trash2, FileJson } from 'lucide-react';
+import { Folder, Info, Monitor, RefreshCw, Trash2, FileJson } from 'lucide-react';
 import { GeneratorTool } from '../../../types';
 
 interface FolderItemProps {
@@ -49,7 +49,9 @@ export const FolderItem: React.FC<FolderItemProps> = ({ folder, scanningIds, onR
                         {path}
                     </span>
                     <span className="text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-1">
-                        {folder.isManaged ? (
+                        {folder.initialScanCancelled ? (
+                            <><Info className="w-3 h-3 text-amber-500" /> Import cancelled. Rescan to continue.</>
+                        ) : folder.isManaged ? (
                             <><Monitor className="w-3 h-3" /> Managed Integration</>
                         ) : (
                             <><Folder className="w-3 h-3" /> Monitored Folder</>

--- a/src/features/settings/components/__tests__/A1111Tab.test.tsx
+++ b/src/features/settings/components/__tests__/A1111Tab.test.tsx
@@ -184,4 +184,84 @@ describe('A1111Tab discovery warnings', () => {
         expect(await screen.findByText('Processed 1 folders with 1 failed file(s). Folder cursor was not advanced.')).toBeTruthy();
         expect(mocks.addToast).not.toHaveBeenCalled();
     });
+
+    it('marks only newly linked folders as cancelled when Link & Import is cancelled', async () => {
+        const settings = createSettings();
+        settings.monitoredFolders = [
+            {
+                id: 'existing-folder',
+                path: 'D:/SD/outputs/existing',
+                isActive: true,
+                imageCount: 4,
+                lastScanned: 123,
+                initialScanCancelled: false
+            }
+        ];
+        const setSettings = vi.fn();
+        const onScanFolder = vi.fn().mockResolvedValue({
+            images: [],
+            stats: { processed: 1, imported: 1, skipped: 0, errors: 0 },
+            handledPaths: ['D:/SD/outputs/txt2img-images/image.png'],
+            failedPaths: [],
+            touchedFacetTypes: [],
+            touchedFacetResources: {
+                checkpoints: [],
+                loras: [],
+                embeddings: [],
+                hypernetworks: [],
+                controlNets: [],
+                ipAdapters: [],
+                tools: []
+            },
+            wasCancelled: true
+        });
+        mocks.discoverA1111Candidates.mockResolvedValue({
+            detectedVariant: WebUIVariant.A1111,
+            candidates: [
+                {
+                    path: 'D:/SD/outputs/txt2img-images',
+                    name: 'txt2img-images',
+                    imageCount: 1,
+                    inferredType: 'txt2img',
+                    isPriority: true,
+                    isAlreadyLinked: false,
+                    variant: WebUIVariant.A1111
+                }
+            ],
+            logs: [],
+            warnings: []
+        });
+        mocks.getUnlinkedPriorityCandidatePaths.mockReturnValue(['D:/SD/outputs/txt2img-images']);
+
+        render(<A1111Tab settings={settings} setSettings={setSettings} onScanFolder={onScanFolder} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /scan for folders/i }));
+        fireEvent.click(await screen.findByRole('button', { name: /link & import 1 folders/i }));
+
+        expect(await screen.findByText('Import cancelled. Imported images were kept, and folder cursor was not advanced. Rescan to continue.')).toBeTruthy();
+        expect(onScanFolder).toHaveBeenCalledWith([
+            {
+                path: 'D:/SD/outputs/txt2img-images',
+                variant: GeneratorTool.AUTOMATIC1111
+            }
+        ]);
+
+        const addUpdate = setSettings.mock.calls[0][0] as (previous: AppSettings) => AppSettings;
+        const settingsAfterAdd = addUpdate(settings);
+        const cancelUpdate = setSettings.mock.calls[1][0] as (previous: AppSettings) => AppSettings;
+        const settingsAfterCancel = cancelUpdate(settingsAfterAdd);
+
+        expect(settingsAfterCancel.monitoredFolders.find(folder => folder.id === 'existing-folder')).toMatchObject({
+            id: 'existing-folder',
+            lastScanned: 123,
+            initialScanCancelled: false
+        });
+        expect(settingsAfterCancel.monitoredFolders.find(folder => folder.path === 'D:/SD/outputs/txt2img-images')).toMatchObject({
+            path: 'D:/SD/outputs/txt2img-images',
+            initialScanPending: false,
+            initialScanCancelled: true
+        });
+        expect(settingsAfterCancel.monitoredFolders.find(folder => folder.path === 'D:/SD/outputs/txt2img-images')?.lastScanned).toBeUndefined();
+        expect(mocks.addToast).not.toHaveBeenCalled();
+    });
 });

--- a/src/features/settings/components/__tests__/A1111Tab.test.tsx
+++ b/src/features/settings/components/__tests__/A1111Tab.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '../../../../test/testUtils';
-import type { AppSettings } from '../../../../types';
+import { GeneratorTool, type AppSettings } from '../../../../types';
 import { WebUIVariant } from '../../../../services/a1111/types';
 import { A1111Tab } from '../A1111Tab';
 
@@ -83,5 +83,105 @@ describe('A1111Tab discovery warnings', () => {
                 'Auto'
             );
         });
+    });
+
+    it('routes Link & Import through the provided cancellable scan callback', async () => {
+        const onScanFolder = vi.fn().mockResolvedValue({
+            images: [],
+            stats: { processed: 1, imported: 1, skipped: 0, errors: 0 },
+            handledPaths: ['D:/SD/outputs/txt2img-images/image.png'],
+            failedPaths: [],
+            touchedFacetTypes: [],
+            touchedFacetResources: {
+                checkpoints: [],
+                loras: [],
+                embeddings: [],
+                hypernetworks: [],
+                controlNets: [],
+                ipAdapters: [],
+                tools: []
+            },
+            wasCancelled: false
+        });
+        mocks.discoverA1111Candidates.mockResolvedValue({
+            detectedVariant: WebUIVariant.A1111,
+            candidates: [
+                {
+                    path: 'D:/SD/outputs/txt2img-images',
+                    name: 'txt2img-images',
+                    imageCount: 1,
+                    inferredType: 'txt2img',
+                    isPriority: true,
+                    isAlreadyLinked: false,
+                    variant: WebUIVariant.A1111
+                }
+            ],
+            logs: [],
+            warnings: []
+        });
+        mocks.getUnlinkedPriorityCandidatePaths.mockReturnValue(['D:/SD/outputs/txt2img-images']);
+
+        render(<A1111Tab settings={createSettings()} setSettings={vi.fn()} onScanFolder={onScanFolder} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /scan for folders/i }));
+        fireEvent.click(await screen.findByRole('button', { name: /link & import 1 folders/i }));
+
+        await waitFor(() => {
+            expect(onScanFolder).toHaveBeenCalledWith([
+                {
+                    path: 'D:/SD/outputs/txt2img-images',
+                    variant: GeneratorTool.AUTOMATIC1111
+                }
+            ]);
+        });
+        expect(await screen.findByText('Processed 1 folders (1 new, 0 rescanned)')).toBeTruthy();
+        expect(mocks.addToast).not.toHaveBeenCalled();
+        expect(mocks.setIsImporting).not.toHaveBeenCalled();
+        expect(mocks.setImportProgress).not.toHaveBeenCalled();
+    });
+
+    it('shows partial failure inline without emitting a duplicate completion toast', async () => {
+        const onScanFolder = vi.fn().mockResolvedValue({
+            images: [],
+            stats: { processed: 1, imported: 0, skipped: 0, errors: 1 },
+            handledPaths: [],
+            failedPaths: ['D:/SD/outputs/txt2img-images/bad.png'],
+            touchedFacetTypes: [],
+            touchedFacetResources: {
+                checkpoints: [],
+                loras: [],
+                embeddings: [],
+                hypernetworks: [],
+                controlNets: [],
+                ipAdapters: [],
+                tools: []
+            },
+            wasCancelled: false
+        });
+        mocks.discoverA1111Candidates.mockResolvedValue({
+            detectedVariant: WebUIVariant.A1111,
+            candidates: [
+                {
+                    path: 'D:/SD/outputs/txt2img-images',
+                    name: 'txt2img-images',
+                    imageCount: 1,
+                    inferredType: 'txt2img',
+                    isPriority: true,
+                    isAlreadyLinked: false,
+                    variant: WebUIVariant.A1111
+                }
+            ],
+            logs: [],
+            warnings: []
+        });
+        mocks.getUnlinkedPriorityCandidatePaths.mockReturnValue(['D:/SD/outputs/txt2img-images']);
+
+        render(<A1111Tab settings={createSettings()} setSettings={vi.fn()} onScanFolder={onScanFolder} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /scan for folders/i }));
+        fireEvent.click(await screen.findByRole('button', { name: /link & import 1 folders/i }));
+
+        expect(await screen.findByText('Processed 1 folders with 1 failed file(s). Folder cursor was not advanced.')).toBeTruthy();
+        expect(mocks.addToast).not.toHaveBeenCalled();
     });
 });

--- a/src/features/settings/hooks/__tests__/useFoldersTabLogic.test.tsx
+++ b/src/features/settings/hooks/__tests__/useFoldersTabLogic.test.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { act, renderHook, waitFor } from '../../../../test/testUtils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { AppSettings } from '../../../../types';
+import { AppSettings, GeneratorTool } from '../../../../types';
 import { useLibraryStore } from '../../../../stores/libraryStore';
+import { useSettingsStore } from '../../../../stores/settingsStore';
 import { useFoldersTabLogic } from '../useFoldersTabLogic';
+import { commands } from '../../../../bindings';
+import { processNativePaths } from '../../../../services/importService';
 
 const addToastMock = vi.hoisted(() => vi.fn());
 const scanResourceThumbnailsMock = vi.hoisted(() => vi.fn());
 const rebuildFacetCacheIncrementalBatchMock = vi.hoisted(() => vi.fn());
 const refreshFacetCacheForResourcesStrictMock = vi.hoisted(() => vi.fn());
 const openMock = vi.hoisted(() => vi.fn());
+const getThumbnailDirMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../../hooks/useToast', () => ({
     useToast: () => ({
@@ -25,6 +29,10 @@ vi.mock('../../../../services/importService', () => ({
 vi.mock('../../../../services/db/imageRepo', () => ({
     rebuildFacetCacheIncrementalBatch: (...args: Parameters<typeof rebuildFacetCacheIncrementalBatchMock>) => rebuildFacetCacheIncrementalBatchMock(...args),
     refreshFacetCacheForResourcesStrict: (...args: Parameters<typeof refreshFacetCacheForResourcesStrictMock>) => refreshFacetCacheForResourcesStrictMock(...args),
+}));
+
+vi.mock('../../../../services/thumbnailService', () => ({
+    getThumbnailDir: (...args: Parameters<typeof getThumbnailDirMock>) => getThumbnailDirMock(...args),
 }));
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
@@ -90,10 +98,14 @@ describe('useFoldersTabLogic resource discovery', () => {
         });
         rebuildFacetCacheIncrementalBatchMock.mockResolvedValue(2);
         refreshFacetCacheForResourcesStrictMock.mockResolvedValue(2);
+        getThumbnailDirMock.mockResolvedValue('C:/thumbs');
         useLibraryStore.setState({
             facetCacheVersion: 0,
             isScanningDiscovery: false,
             discoveryScanProgress: null,
+            isImporting: false,
+            importProgress: null,
+            importAbortController: null,
         });
     });
 
@@ -265,5 +277,64 @@ describe('useFoldersTabLogic resource discovery', () => {
         expect(addToastMock).toHaveBeenCalledWith('Resource scan cancelled', 'info');
         expect(useLibraryStore.getState().discoveryScanProgress).toBeNull();
         expect(useLibraryStore.getState().isScanningDiscovery).toBe(false);
+    });
+
+    it('does not advance a monitored folder cursor when incremental import is cancelled', async () => {
+        const updateLastScannedMock = vi.fn();
+        useLibraryStore.setState({ importAbortController: null });
+        const updateFolderLastScannedSpy = vi
+            .spyOn(useSettingsStore.getState(), 'updateFolderLastScanned')
+            .mockImplementation(updateLastScannedMock);
+        vi.mocked(commands.scanDirectorySince).mockResolvedValueOnce({
+            status: 'ok',
+            data: [{ path: 'D:/AI/Comfy/output/new.png', modified: 100, size: 10 }]
+        });
+        vi.mocked(processNativePaths).mockResolvedValueOnce({
+            images: [],
+            stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+            handledPaths: [],
+            failedPaths: [],
+            touchedFacetTypes: [],
+            touchedFacetResources: emptyResources,
+            wasCancelled: true
+        });
+        const settings = {
+            ...baseSettings,
+            monitoredFolders: [
+                {
+                    id: 'folder-1',
+                    path: 'D:/AI/Comfy/output',
+                    isActive: true,
+                    imageCount: 0,
+                    variant: GeneratorTool.COMFYUI,
+                    lastScanned: 10
+                }
+            ]
+        };
+        const { result } = renderHook(() => useFoldersTabLogic({
+            settings,
+            setSettings: vi.fn(),
+            onScanFolder: vi.fn()
+        }));
+
+        await act(async () => {
+            await result.current.handleRescan('folder-1', 'D:/AI/Comfy/output', GeneratorTool.COMFYUI, false);
+        });
+
+        expect(processNativePaths).toHaveBeenCalledWith(
+            ['D:/AI/Comfy/output/new.png'],
+            expect.any(String),
+            expect.any(Function),
+            GeneratorTool.COMFYUI,
+            expect.any(AbortSignal),
+            false,
+            true,
+            true
+        );
+        expect(updateLastScannedMock).not.toHaveBeenCalled();
+        expect(addToastMock).toHaveBeenCalledWith('Import cancelled', 'info');
+        expect(useLibraryStore.getState().importAbortController).toBeNull();
+
+        updateFolderLastScannedSpy.mockRestore();
     });
 });

--- a/src/features/settings/hooks/__tests__/useFoldersTabLogic.test.tsx
+++ b/src/features/settings/hooks/__tests__/useFoldersTabLogic.test.tsx
@@ -6,7 +6,7 @@ import { useLibraryStore } from '../../../../stores/libraryStore';
 import { useSettingsStore } from '../../../../stores/settingsStore';
 import { useFoldersTabLogic } from '../useFoldersTabLogic';
 import { commands } from '../../../../bindings';
-import { processNativePaths } from '../../../../services/importService';
+import { processNativePaths, type ImportResult } from '../../../../services/importService';
 
 const addToastMock = vi.hoisted(() => vi.fn());
 const scanResourceThumbnailsMock = vi.hoisted(() => vi.fn());
@@ -61,11 +61,15 @@ const baseSettings: AppSettings = {
     enableAI: false,
 };
 
-const renderFoldersHook = (settings: AppSettings = baseSettings) => {
+const renderFoldersHook = (
+    settings: AppSettings = baseSettings,
+    onScanFolder?: (folders: { path: string, variant?: string }[]) => Promise<ImportResult | void>
+) => {
     const setSettings = vi.fn();
     const rendered = renderHook(() => useFoldersTabLogic({
         settings,
         setSettings,
+        onScanFolder,
     }));
 
     return { ...rendered, setSettings };
@@ -81,7 +85,30 @@ const emptyResources = {
     tools: []
 };
 
+const emptyImportResult = (overrides: Partial<ImportResult> = {}): ImportResult => {
+    const base: ImportResult = {
+        images: [],
+        stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+        handledPaths: [],
+        failedPaths: [],
+        touchedFacetTypes: [],
+        touchedFacetResources: emptyResources,
+        wasCancelled: false
+    };
+
+    return {
+        ...base,
+        ...overrides,
+        stats: {
+            ...base.stats,
+            ...overrides.stats
+        }
+    };
+};
+
 describe('useFoldersTabLogic resource discovery', () => {
+    const manualCancellationMessage = 'Import cancelled. Imported images were kept; rescan to continue.';
+
     beforeEach(() => {
         vi.clearAllMocks();
         addToastMock.mockReset();
@@ -99,6 +126,11 @@ describe('useFoldersTabLogic resource discovery', () => {
         rebuildFacetCacheIncrementalBatchMock.mockResolvedValue(2);
         refreshFacetCacheForResourcesStrictMock.mockResolvedValue(2);
         getThumbnailDirMock.mockResolvedValue('C:/thumbs');
+        vi.mocked(commands.getImageCountForPathPrefix).mockResolvedValue({
+            status: 'ok',
+            data: 0
+        });
+        useSettingsStore.setState({ settings: baseSettings });
         useLibraryStore.setState({
             facetCacheVersion: 0,
             isScanningDiscovery: false,
@@ -332,9 +364,115 @@ describe('useFoldersTabLogic resource discovery', () => {
             true
         );
         expect(updateLastScannedMock).not.toHaveBeenCalled();
-        expect(addToastMock).toHaveBeenCalledWith('Import cancelled', 'info');
+        expect(addToastMock).toHaveBeenCalledWith(manualCancellationMessage, 'info');
         expect(useLibraryStore.getState().importAbortController).toBeNull();
 
         updateFolderLastScannedSpy.mockRestore();
+    });
+
+    it('marks a cancelled added-folder initial import as cancelled', async () => {
+        vi.useFakeTimers();
+        try {
+            const onScanFolder = vi.fn().mockResolvedValue(emptyImportResult({ wasCancelled: true }));
+            const { result, setSettings } = renderFoldersHook(baseSettings, onScanFolder);
+
+            act(() => {
+                result.current.setNewFolderPath('D:\\AI\\Cancelled');
+            });
+
+            act(() => {
+                result.current.handleAddFolder({
+                    preventDefault: vi.fn(),
+                } as unknown as React.FormEvent);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(500);
+            });
+
+            expect(onScanFolder).toHaveBeenCalledWith([{ path: 'D:/AI/Cancelled', variant: GeneratorTool.UNKNOWN }]);
+            const addUpdate = setSettings.mock.calls[0][0] as (previous: AppSettings) => AppSettings;
+            const addedSettings = addUpdate(baseSettings);
+            const finalizeUpdate = setSettings.mock.calls[1][0] as (previous: AppSettings) => AppSettings;
+            const finalSettings = finalizeUpdate(addedSettings);
+
+            expect(finalSettings.monitoredFolders[0]).toMatchObject({
+                path: 'D:/AI/Cancelled',
+                initialScanPending: false,
+                initialScanCancelled: true
+            });
+            expect(finalSettings.monitoredFolders[0].lastScanned).toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('keeps added-folder partial failures retryable without marking cancellation', async () => {
+        vi.useFakeTimers();
+        try {
+            const onScanFolder = vi.fn().mockResolvedValue(emptyImportResult({
+                stats: { processed: 1, imported: 0, skipped: 0, errors: 1 },
+                failedPaths: ['D:/AI/Partial/bad.png']
+            }));
+            const { result, setSettings } = renderFoldersHook(baseSettings, onScanFolder);
+
+            act(() => {
+                result.current.setNewFolderPath('D:\\AI\\Partial');
+            });
+
+            act(() => {
+                result.current.handleAddFolder({
+                    preventDefault: vi.fn(),
+                } as unknown as React.FormEvent);
+            });
+
+            await act(async () => {
+                await vi.advanceTimersByTimeAsync(500);
+            });
+
+            const addUpdate = setSettings.mock.calls[0][0] as (previous: AppSettings) => AppSettings;
+            const addedSettings = addUpdate(baseSettings);
+            const finalizeUpdate = setSettings.mock.calls[1][0] as (previous: AppSettings) => AppSettings;
+            const finalSettings = finalizeUpdate(addedSettings);
+
+            expect(finalSettings.monitoredFolders[0]).toMatchObject({
+                path: 'D:/AI/Partial',
+                initialScanPending: false,
+                initialScanCancelled: false
+            });
+            expect(finalSettings.monitoredFolders[0].lastScanned).toBeUndefined();
+            expect(addToastMock).toHaveBeenCalledWith('Folder scan completed with import errors', 'warning');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('clears initial cancellation after a successful manual rescan', async () => {
+        const folder = {
+            id: 'folder-1',
+            path: 'D:/AI/Cancelled',
+            isActive: true,
+            imageCount: 0,
+            variant: GeneratorTool.COMFYUI,
+            initialScanCancelled: true
+        };
+        const settings = {
+            ...baseSettings,
+            monitoredFolders: [folder]
+        };
+        useSettingsStore.setState({ settings });
+        const onScanFolder = vi.fn().mockResolvedValue(emptyImportResult({
+            stats: { processed: 1, imported: 1, skipped: 0, errors: 0 }
+        }));
+        const { result } = renderFoldersHook(settings, onScanFolder);
+
+        await act(async () => {
+            await result.current.handleRescan('folder-1', 'D:/AI/Cancelled', GeneratorTool.COMFYUI, false);
+        });
+
+        const updatedFolder = useSettingsStore.getState().settings.monitoredFolders[0];
+        expect(updatedFolder.lastScanned).toEqual(expect.any(Number));
+        expect(updatedFolder.initialScanPending).toBe(false);
+        expect(updatedFolder.initialScanCancelled).toBe(false);
     });
 });

--- a/src/features/settings/hooks/useFoldersTabLogic.ts
+++ b/src/features/settings/hooks/useFoldersTabLogic.ts
@@ -193,8 +193,8 @@ export const useFoldersTabLogic = ({
         return { result, indexedRows };
     }, [refreshResourceFacetCache]);
 
-    const isCompleteImport = (result: ImportResult | void): result is ImportResult =>
-        !!result && result.failedPaths.length === 0;
+    const isCompleteImport = (result: ImportResult | void): boolean =>
+        !!result && !result.wasCancelled && result.failedPaths.length === 0;
 
     const fetchCounts = useCallback(async () => {
         if (!settings.monitoredFolders.length && !settings.invokeAiPath) return;
@@ -268,8 +268,10 @@ export const useFoldersTabLogic = ({
 
                     if (newFiles.length > 0) {
                         const changedPaths = newFiles.map(f => f.path);
-                        const { setIsImporting, setImportProgress } = useLibraryStore.getState();
+                        const { setIsImporting, setImportProgress, setImportAbortController } = useLibraryStore.getState();
+                        const abortCtrl = new AbortController();
                         setIsImporting(true);
+                        setImportAbortController(abortCtrl);
                         setImportProgress({ current: 0, total: changedPaths.length, message: 'Syncing changed files...' });
 
                         try {
@@ -282,20 +284,25 @@ export const useFoldersTabLogic = ({
                                     setImportProgress({ current, total, message });
                                 },
                                 variant as GeneratorTool | undefined,
-                                undefined,
+                                abortCtrl.signal,
                                 false,
                                 true,
                                 true
                             );
-                            addToast(`Synced ${result.images.length} new files`, 'success');
-                            if (result.failedPaths.length === 0) {
-                                updateFolderLastScanned(id, Date.now());
+                            if (result.wasCancelled) {
+                                addToast('Import cancelled', 'info');
                             } else {
+                                addToast(`Synced ${result.images.length} new files`, 'success');
+                            }
+                            if (isCompleteImport(result)) {
+                                updateFolderLastScanned(id, Date.now());
+                            } else if (!result.wasCancelled) {
                                 console.warn(`[Resync] Keeping cursor unchanged for ${path}; ${result.failedPaths.length} file(s) failed.`);
                             }
                         } finally {
                             setIsImporting(false);
                             setImportProgress(null);
+                            setImportAbortController(null);
                         }
                     } else {
                         const allFiles = await unwrap(commands.scanDirectoryWithStats(path));
@@ -303,9 +310,12 @@ export const useFoldersTabLogic = ({
 
                         if (allFiles.length > knownCount) {
                             const repairPaths = allFiles.map(f => f.path);
-                            const { setIsImporting, setImportProgress } = useLibraryStore.getState();
+                            const { setIsImporting, setImportProgress, setImportAbortController } = useLibraryStore.getState();
+                            const abortCtrl = new AbortController();
                             let repairFailedCount = 0;
+                            let repairWasCancelled = false;
                             setIsImporting(true);
+                            setImportAbortController(abortCtrl);
                             setImportProgress({ current: 0, total: repairPaths.length, message: 'Repairing incomplete import...' });
 
                             try {
@@ -318,23 +328,29 @@ export const useFoldersTabLogic = ({
                                         setImportProgress({ current, total, message });
                                     },
                                     variant as GeneratorTool | undefined,
-                                    undefined,
+                                    abortCtrl.signal,
                                     false
                                 );
                                 repairFailedCount = result.failedPaths.length;
-                                addToast(
-                                    result.images.length > 0
-                                        ? `Repair scan imported ${result.images.length} missing files`
-                                        : 'Repair scan found no additional importable files',
-                                    result.images.length > 0 ? 'success' : 'info'
-                                );
+                                repairWasCancelled = result.wasCancelled;
+                                if (result.wasCancelled) {
+                                    addToast('Import cancelled', 'info');
+                                } else {
+                                    addToast(
+                                        result.images.length > 0
+                                            ? `Repair scan imported ${result.images.length} missing files`
+                                            : 'Repair scan found no additional importable files',
+                                        result.images.length > 0 ? 'success' : 'info'
+                                    );
+                                }
                             } finally {
                                 setIsImporting(false);
                                 setImportProgress(null);
+                                setImportAbortController(null);
                             }
-                            if (repairFailedCount === 0) {
+                            if (!repairWasCancelled && repairFailedCount === 0) {
                                 updateFolderLastScanned(id, Date.now());
-                            } else {
+                            } else if (!repairWasCancelled) {
                                 console.warn(`[Resync] Keeping cursor unchanged for ${path}; ${repairFailedCount} repair file(s) failed.`);
                             }
                         } else {
@@ -347,6 +363,8 @@ export const useFoldersTabLogic = ({
                     if (isCompleteImport(result)) {
                         updateFolderLastScanned(id, Date.now());
                         addToast(`Rescan complete`, 'success');
+                    } else if (result && result.wasCancelled) {
+                        console.info(`[Resync] Keeping cursor unchanged for ${path}; import was cancelled.`);
                     } else {
                         console.warn(`[Resync] Keeping cursor unchanged for ${path}; full scan did not fully complete.`);
                         addToast(`Rescan completed with import errors`, 'warning');
@@ -412,6 +430,15 @@ export const useFoldersTabLogic = ({
                         monitoredFolders: prev.monitoredFolders.map(folder =>
                             foldersToScan.some(pending => pending.id === folder.id)
                                 ? { ...folder, lastScanned: completedAt, initialScanPending: false }
+                            : folder
+                        )
+                    }));
+                } else if (result && result.wasCancelled) {
+                    setSettings(prev => ({
+                        ...prev,
+                        monitoredFolders: prev.monitoredFolders.map(folder =>
+                            foldersToScan.some(pending => pending.id === folder.id)
+                                ? { ...folder, lastScanned: undefined, initialScanPending: false }
                                 : folder
                         )
                     }));

--- a/src/features/settings/hooks/useFoldersTabLogic.ts
+++ b/src/features/settings/hooks/useFoldersTabLogic.ts
@@ -101,6 +101,8 @@ const getErrorMessage = (error: unknown): string =>
 const isCancellationError = (error: unknown): boolean =>
     getErrorMessage(error).toLowerCase().includes('cancel');
 
+const MANUAL_IMPORT_CANCELLED_MESSAGE = 'Import cancelled. Imported images were kept; rescan to continue.';
+
 // Helper to detect generator from path
 const detectGeneratorVariant = (path: string): GeneratorTool => {
     const lower = path.toLowerCase();
@@ -290,7 +292,7 @@ export const useFoldersTabLogic = ({
                                 true
                             );
                             if (result.wasCancelled) {
-                                addToast('Import cancelled', 'info');
+                                addToast(MANUAL_IMPORT_CANCELLED_MESSAGE, 'info');
                             } else {
                                 addToast(`Synced ${result.images.length} new files`, 'success');
                             }
@@ -334,7 +336,7 @@ export const useFoldersTabLogic = ({
                                 repairFailedCount = result.failedPaths.length;
                                 repairWasCancelled = result.wasCancelled;
                                 if (result.wasCancelled) {
-                                    addToast('Import cancelled', 'info');
+                                    addToast(MANUAL_IMPORT_CANCELLED_MESSAGE, 'info');
                                 } else {
                                     addToast(
                                         result.images.length > 0
@@ -365,6 +367,14 @@ export const useFoldersTabLogic = ({
                         addToast(`Rescan complete`, 'success');
                     } else if (result && result.wasCancelled) {
                         console.info(`[Resync] Keeping cursor unchanged for ${path}; import was cancelled.`);
+                        setSettings(prev => ({
+                            ...prev,
+                            monitoredFolders: prev.monitoredFolders.map(folder =>
+                                folder.id === id
+                                    ? { ...folder, lastScanned: undefined, initialScanPending: false, initialScanCancelled: true }
+                                    : folder
+                            )
+                        }));
                     } else {
                         console.warn(`[Resync] Keeping cursor unchanged for ${path}; full scan did not fully complete.`);
                         addToast(`Rescan completed with import errors`, 'warning');
@@ -429,7 +439,7 @@ export const useFoldersTabLogic = ({
                         ...prev,
                         monitoredFolders: prev.monitoredFolders.map(folder =>
                             foldersToScan.some(pending => pending.id === folder.id)
-                                ? { ...folder, lastScanned: completedAt, initialScanPending: false }
+                                ? { ...folder, lastScanned: completedAt, initialScanPending: false, initialScanCancelled: false }
                             : folder
                         )
                     }));
@@ -438,7 +448,7 @@ export const useFoldersTabLogic = ({
                         ...prev,
                         monitoredFolders: prev.monitoredFolders.map(folder =>
                             foldersToScan.some(pending => pending.id === folder.id)
-                                ? { ...folder, lastScanned: undefined, initialScanPending: false }
+                                ? { ...folder, lastScanned: undefined, initialScanPending: false, initialScanCancelled: true }
                                 : folder
                         )
                     }));
@@ -447,7 +457,7 @@ export const useFoldersTabLogic = ({
                         ...prev,
                         monitoredFolders: prev.monitoredFolders.map(folder =>
                             foldersToScan.some(pending => pending.id === folder.id)
-                                ? { ...folder, lastScanned: undefined, initialScanPending: false }
+                                ? { ...folder, lastScanned: undefined, initialScanPending: false, initialScanCancelled: false }
                                 : folder
                         )
                     }));
@@ -460,7 +470,7 @@ export const useFoldersTabLogic = ({
                     ...prev,
                     monitoredFolders: prev.monitoredFolders.map(folder =>
                         foldersToScan.some(pending => pending.id === folder.id)
-                            ? { ...folder, lastScanned: undefined, initialScanPending: false }
+                            ? { ...folder, lastScanned: undefined, initialScanPending: false, initialScanCancelled: false }
                             : folder
                     )
                 }));

--- a/src/hooks/__tests__/useFolderMonitor.test.ts
+++ b/src/hooks/__tests__/useFolderMonitor.test.ts
@@ -3,6 +3,7 @@ import { renderHook, waitFor } from '../../test/testUtils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useFolderMonitor } from '../useFolderMonitor';
 import type { MonitoredFolder } from '../../types';
+import { useLibraryStore } from '../../stores/libraryStore';
 
 const mocks = vi.hoisted(() => ({
     scanDirectorySince: vi.fn(),
@@ -31,9 +32,32 @@ vi.mock('../../contexts/WatcherContext', () => ({
 describe('useFolderMonitor', () => {
     const mockOnScan = vi.fn();
     const mockAddToast = vi.fn();
+    const cancelledImportResult = {
+        images: [],
+        stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+        handledPaths: [],
+        failedPaths: [],
+        touchedFacetTypes: [],
+        touchedFacetResources: {
+            checkpoints: [],
+            loras: [],
+            embeddings: [],
+            hypernetworks: [],
+            controlNets: [],
+            ipAdapters: [],
+            tools: []
+        },
+        wasCancelled: true
+    };
 
     beforeEach(() => {
         vi.clearAllMocks();
+        useLibraryStore.setState({
+            isLiveWatching: false,
+            isImporting: false,
+            importProgress: null,
+            importAbortController: null
+        });
         mocks.scanDirectorySince.mockResolvedValue({ status: 'ok', data: [] });
         mocks.refreshStartupFacetCache.mockResolvedValue({
             strategy: 'resource-incremental',
@@ -79,7 +103,7 @@ describe('useFolderMonitor', () => {
 
         rerender({ folders: updatedFolders });
 
-        expect(mockOnScan).toHaveBeenCalledWith([{ path: '/test2', variant: undefined }], false);
+        expect(mockOnScan).toHaveBeenCalledWith([{ path: '/test2', variant: undefined }]);
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('/test2'), 'info');
     });
 
@@ -150,7 +174,7 @@ describe('useFolderMonitor', () => {
         // Set loaded and add folder
         rerender({ folders: [{ id: '1', path: '/test', isActive: true, imageCount: 0 }], isLoaded: true });
 
-        expect(mockOnScan).toHaveBeenCalledWith([{ path: '/test', variant: undefined }], true);
+        expect(mockOnScan).toHaveBeenCalledWith([{ path: '/test', variant: undefined }], { mode: 'startup' });
         expect(mockAddToast).not.toHaveBeenCalled(); // No toast on startup scan
         expect(mocks.refreshStartupFacetCache).not.toHaveBeenCalled();
     });
@@ -170,7 +194,8 @@ describe('useFolderMonitor', () => {
                 controlNets: [],
                 ipAdapters: [],
                 tools: []
-            }
+            },
+            wasCancelled: false
         });
         const refreshMetadata = vi.fn().mockResolvedValue(undefined);
         mocks.scanDirectorySince.mockResolvedValueOnce({
@@ -198,7 +223,7 @@ describe('useFolderMonitor', () => {
                 ['C:/watch/new.png'],
                 undefined,
                 expect.objectContaining({
-                    isStartup: true,
+                    mode: 'startup',
                     skipStateManagement: true,
                     forceRescan: true,
                     waitForStableFiles: true,
@@ -219,5 +244,261 @@ describe('useFolderMonitor', () => {
         });
         expect(refreshMetadata).toHaveBeenCalled();
         expect(mockOnScan).not.toHaveBeenCalled();
+    });
+
+    it('passes one parent abort signal through aggregated startup imports and stops after cancellation', async () => {
+        let firstAbortSignal: AbortSignal | undefined;
+        const handleImportPaths = vi.fn().mockImplementation(async (_paths, _variant, options) => {
+            firstAbortSignal = options.abortSignal;
+            return {
+                images: [],
+                stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+                handledPaths: [],
+                failedPaths: [],
+                touchedFacetTypes: [],
+                touchedFacetResources: {
+                    checkpoints: [],
+                    loras: [],
+                    embeddings: [],
+                    hypernetworks: [],
+                    controlNets: [],
+                    ipAdapters: [],
+                    tools: []
+                },
+                wasCancelled: true
+            };
+        });
+        const refreshMetadata = vi.fn().mockResolvedValue(undefined);
+        mocks.scanDirectorySince
+            .mockResolvedValueOnce({
+                status: 'ok',
+                data: [{ path: 'C:/watch-a/new.png', modified: 100, size: 10 }]
+            })
+            .mockResolvedValueOnce({
+                status: 'ok',
+                data: [{ path: 'C:/watch-b/new.png', modified: 100, size: 10 }]
+            });
+
+        renderHook(() => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: [
+                {
+                    id: 'watch-1',
+                    path: 'C:/watch-a',
+                    isActive: true,
+                    imageCount: 0,
+                    lastScanned: 10
+                },
+                {
+                    id: 'watch-2',
+                    path: 'C:/watch-b',
+                    isActive: true,
+                    imageCount: 0,
+                    lastScanned: 10
+                }
+            ],
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata
+        }));
+
+        await waitFor(() => {
+            expect(handleImportPaths).toHaveBeenCalledTimes(1);
+        });
+
+        expect(firstAbortSignal).toBeInstanceOf(AbortSignal);
+        expect(handleImportPaths).toHaveBeenCalledWith(
+            ['C:/watch-a/new.png'],
+            undefined,
+            expect.objectContaining({
+                mode: 'startup',
+                abortSignal: firstAbortSignal,
+                skipStateManagement: true,
+                forceRescan: true
+            })
+        );
+        expect(mocks.refreshStartupFacetCache).not.toHaveBeenCalled();
+        expect(refreshMetadata).not.toHaveBeenCalled();
+    });
+
+    it('stops startup full scans after a cancelled folder import', async () => {
+        mockOnScan.mockResolvedValue(cancelledImportResult);
+        const handleImportPaths = vi.fn();
+
+        renderHook(() => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: [
+                { id: 'watch-1', path: 'C:/watch-a', isActive: true, imageCount: 0 },
+                { id: 'watch-2', path: 'C:/watch-b', isActive: true, imageCount: 0 }
+            ],
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata: vi.fn()
+        }));
+
+        await waitFor(() => {
+            expect(mockOnScan).toHaveBeenCalledTimes(1);
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(mockOnScan).toHaveBeenCalledWith([{ path: 'C:/watch-a', variant: undefined }], { mode: 'startup' });
+        expect(handleImportPaths).not.toHaveBeenCalled();
+    });
+
+    it('skips queued startup incremental imports after a startup full-scan cancellation', async () => {
+        mockOnScan.mockResolvedValue(cancelledImportResult);
+        mocks.scanDirectorySince.mockResolvedValueOnce({
+            status: 'ok',
+            data: [{ path: 'C:/watch-a/new.png', modified: 100, size: 10 }]
+        });
+        const handleImportPaths = vi.fn();
+        const refreshMetadata = vi.fn().mockResolvedValue(undefined);
+
+        renderHook(() => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: [
+                {
+                    id: 'watch-1',
+                    path: 'C:/watch-a',
+                    isActive: true,
+                    imageCount: 0,
+                    lastScanned: 10
+                },
+                {
+                    id: 'watch-2',
+                    path: 'C:/watch-b',
+                    isActive: true,
+                    imageCount: 0
+                }
+            ],
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata
+        }));
+
+        await waitFor(() => {
+            expect(mockOnScan).toHaveBeenCalledWith([{ path: 'C:/watch-b', variant: undefined }], { mode: 'startup' });
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(handleImportPaths).not.toHaveBeenCalled();
+        expect(mocks.refreshStartupFacetCache).not.toHaveBeenCalled();
+        expect(refreshMetadata).not.toHaveBeenCalled();
+    });
+
+    it('stops catch-up full scans after cancellation and skips queued incremental imports', async () => {
+        const handleImportPaths = vi.fn();
+        const refreshMetadata = vi.fn().mockResolvedValue(undefined);
+        mockOnScan.mockResolvedValue(cancelledImportResult);
+        const initialProps = {
+            folders: [] as MonitoredFolder[],
+            invokeAiPath: 'C:/invokeai'
+        };
+
+        const { rerender } = renderHook(({ folders, invokeAiPath }) => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata,
+            invokeAiPath
+        }), { initialProps });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        vi.clearAllMocks();
+        mocks.scanDirectorySince.mockResolvedValueOnce({
+            status: 'ok',
+            data: [{ path: 'C:/watch-a/new.png', modified: 100, size: 10 }]
+        });
+
+        rerender({
+            folders: [
+                {
+                    id: 'watch-1',
+                    path: 'C:/watch-a',
+                    isActive: true,
+                    imageCount: 0,
+                    lastScanned: 10
+                },
+                {
+                    id: 'watch-2',
+                    path: 'C:/watch-b',
+                    isActive: true,
+                    imageCount: 0,
+                    initialScanPending: true
+                }
+            ],
+            invokeAiPath: 'C:/invokeai'
+        });
+
+        useLibraryStore.setState({ isLiveWatching: true });
+
+        await waitFor(() => {
+            expect(mockOnScan).toHaveBeenCalledWith([{ path: 'C:/watch-b', variant: undefined }], { mode: 'background' });
+        });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(handleImportPaths).not.toHaveBeenCalled();
+        expect(refreshMetadata).not.toHaveBeenCalled();
+    });
+
+    it('passes background mode through queued catch-up incremental imports', async () => {
+        const handleImportPaths = vi.fn().mockResolvedValue(cancelledImportResult);
+        const refreshMetadata = vi.fn().mockResolvedValue(undefined);
+        const initialProps = {
+            folders: [] as MonitoredFolder[],
+            invokeAiPath: 'C:/invokeai'
+        };
+
+        const { rerender } = renderHook(({ folders, invokeAiPath }) => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata,
+            invokeAiPath
+        }), { initialProps });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        vi.clearAllMocks();
+        mocks.scanDirectorySince.mockResolvedValueOnce({
+            status: 'ok',
+            data: [{ path: 'C:/watch-a/new.png', modified: 100, size: 10 }]
+        });
+
+        rerender({
+            folders: [
+                {
+                    id: 'watch-1',
+                    path: 'C:/watch-a',
+                    isActive: true,
+                    imageCount: 0,
+                    lastScanned: 10
+                }
+            ],
+            invokeAiPath: 'C:/invokeai'
+        });
+
+        useLibraryStore.setState({ isLiveWatching: true });
+
+        await waitFor(() => {
+            expect(handleImportPaths).toHaveBeenCalledWith(
+                ['C:/watch-a/new.png'],
+                undefined,
+                expect.objectContaining({
+                    mode: 'background',
+                    skipStateManagement: true,
+                    forceRescan: true,
+                    waitForStableFiles: true
+                })
+            );
+        });
+        expect(refreshMetadata).not.toHaveBeenCalled();
+        expect(mockAddToast).not.toHaveBeenCalled();
     });
 });

--- a/src/hooks/__tests__/useFolderMonitor.test.ts
+++ b/src/hooks/__tests__/useFolderMonitor.test.ts
@@ -2,8 +2,9 @@
 import { renderHook, waitFor } from '../../test/testUtils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useFolderMonitor } from '../useFolderMonitor';
-import type { MonitoredFolder } from '../../types';
+import type { AppSettings, MonitoredFolder } from '../../types';
 import { useLibraryStore } from '../../stores/libraryStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 
 const mocks = vi.hoisted(() => ({
     scanDirectorySince: vi.fn(),
@@ -32,6 +33,17 @@ vi.mock('../../contexts/WatcherContext', () => ({
 describe('useFolderMonitor', () => {
     const mockOnScan = vi.fn();
     const mockAddToast = vi.fn();
+    const baseSettings: AppSettings = {
+        hasCompletedOnboarding: true,
+        theme: 'dark',
+        thumbnailSize: 200,
+        confirmDelete: true,
+        defaultTheaterMode: false,
+        monitoredFolders: [],
+        maskedKeywords: [],
+        maskingMode: 'blur',
+        enableAI: false
+    };
     const cancelledImportResult = {
         images: [],
         stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
@@ -52,6 +64,8 @@ describe('useFolderMonitor', () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockOnScan.mockReset();
+        mockAddToast.mockReset();
         useLibraryStore.setState({
             isLiveWatching: false,
             isImporting: false,
@@ -66,6 +80,7 @@ describe('useFolderMonitor', () => {
             touchedFacetTypes: ['loras'],
             touchedResourceCount: 1
         });
+        useSettingsStore.setState({ settings: baseSettings });
     });
 
     it('should NOT scan if not loaded', () => {
@@ -159,6 +174,32 @@ describe('useFolderMonitor', () => {
         expect(mockAddToast).not.toHaveBeenCalled();
     });
 
+    it('should not auto-scan newly added folders whose initial import was cancelled', () => {
+        const initialFolders: MonitoredFolder[] = [{ id: '1', path: '/test1', isActive: true, imageCount: 0 }];
+        const { rerender } = renderHook(({ folders }) => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths: vi.fn(),
+            refreshMetadata: vi.fn()
+        }), {
+            initialProps: { folders: initialFolders }
+        });
+
+        vi.clearAllMocks();
+
+        rerender({
+            folders: [
+                ...initialFolders,
+                { id: '2', path: '/test2', isActive: true, imageCount: 0, initialScanCancelled: true }
+            ]
+        });
+
+        expect(mockOnScan).not.toHaveBeenCalled();
+        expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
     it('should detect startup scan (prevFolders empty)', () => {
         const { rerender } = renderHook(({ folders, isLoaded }) => useFolderMonitor({
             isLoaded,
@@ -177,6 +218,56 @@ describe('useFolderMonitor', () => {
         expect(mockOnScan).toHaveBeenCalledWith([{ path: '/test', variant: undefined }], { mode: 'startup' });
         expect(mockAddToast).not.toHaveBeenCalled(); // No toast on startup scan
         expect(mocks.refreshStartupFacetCache).not.toHaveBeenCalled();
+    });
+
+    it('skips cancelled initial imports during startup scans', async () => {
+        const handleImportPaths = vi.fn();
+
+        renderHook(() => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: [
+                { id: 'watch-1', path: 'C:/cancelled', isActive: true, imageCount: 0, initialScanCancelled: true },
+                { id: 'watch-2', path: 'C:/ready', isActive: true, imageCount: 0 }
+            ],
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata: vi.fn()
+        }));
+
+        await waitFor(() => {
+            expect(mockOnScan).toHaveBeenCalledTimes(1);
+        });
+        expect(mockOnScan).toHaveBeenCalledWith([{ path: 'C:/ready', variant: undefined }], { mode: 'startup' });
+        expect(handleImportPaths).not.toHaveBeenCalled();
+    });
+
+    it('marks startup full-scan cancellation as an initial import cancellation', async () => {
+        const folders: MonitoredFolder[] = [
+            { id: 'watch-1', path: 'C:/watch-a', isActive: true, imageCount: 0 },
+            { id: 'watch-2', path: 'C:/watch-b', isActive: true, imageCount: 0 }
+        ];
+        useSettingsStore.setState({
+            settings: {
+                ...baseSettings,
+                monitoredFolders: folders
+            }
+        });
+        mockOnScan.mockResolvedValue(cancelledImportResult);
+
+        renderHook(() => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths: vi.fn(),
+            refreshMetadata: vi.fn()
+        }));
+
+        await waitFor(() => {
+            expect(useSettingsStore.getState().settings.monitoredFolders[0].initialScanCancelled).toBe(true);
+        });
+        expect(useSettingsStore.getState().settings.monitoredFolders[1].initialScanCancelled).toBeUndefined();
     });
 
     it('defers startup incremental folder facet refresh to the startup coordinator', async () => {
@@ -500,5 +591,47 @@ describe('useFolderMonitor', () => {
         });
         expect(refreshMetadata).not.toHaveBeenCalled();
         expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
+    it('skips cancelled initial imports during Live Watch catch-up', async () => {
+        const handleImportPaths = vi.fn();
+        const refreshMetadata = vi.fn().mockResolvedValue(undefined);
+        const initialProps = {
+            folders: [] as MonitoredFolder[],
+            invokeAiPath: 'C:/invokeai'
+        };
+
+        const { rerender } = renderHook(({ folders, invokeAiPath }) => useFolderMonitor({
+            isLoaded: true,
+            monitoredFolders: folders,
+            onScan: mockOnScan,
+            addToast: mockAddToast,
+            handleImportPaths,
+            refreshMetadata,
+            invokeAiPath
+        }), { initialProps });
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        vi.clearAllMocks();
+
+        rerender({
+            folders: [
+                {
+                    id: 'watch-1',
+                    path: 'C:/watch-a',
+                    isActive: true,
+                    imageCount: 0,
+                    initialScanCancelled: true
+                }
+            ],
+            invokeAiPath: 'C:/invokeai'
+        });
+
+        useLibraryStore.setState({ isLiveWatching: true });
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(mockOnScan).not.toHaveBeenCalled();
+        expect(handleImportPaths).not.toHaveBeenCalled();
+        expect(refreshMetadata).not.toHaveBeenCalled();
     });
 });

--- a/src/hooks/__tests__/useImportOps.test.ts
+++ b/src/hooks/__tests__/useImportOps.test.ts
@@ -92,6 +92,7 @@ const importResult = (overrides: Partial<ImportResult> = {}): ImportResult => {
 const importedImage = (id: string): AIImage => ({ id } as AIImage);
 
 describe('useImportOps', () => {
+    const manualCancellationMessage = 'Import cancelled. Imported images were kept; rescan to continue.';
     const settings = {
         theme: 'dark',
         thumbnailSize: 200,
@@ -134,7 +135,7 @@ describe('useImportOps', () => {
             await result.current.handleImportPaths(['C:/watch/new.png']);
         });
 
-        expect(mocks.addToast).toHaveBeenCalledWith('Import cancelled', 'info');
+        expect(mocks.addToast).toHaveBeenCalledWith(manualCancellationMessage, 'info');
     });
 
     it('keeps background path cancellation quiet', async () => {
@@ -191,6 +192,51 @@ describe('useImportOps', () => {
         });
 
         expect(mocks.addToast).toHaveBeenCalledWith('Imported 1 images from 1 folder(s)', 'success');
+    });
+
+    it('uses aggregate Activity Dock messages for multi-folder imports', async () => {
+        const messages: Array<string | undefined> = [];
+        mocks.processFoldersUnified.mockImplementationOnce(async (_folders, options) => {
+            options.onProgress(0, 0, 'Scanning C:/watch-a');
+            messages.push(useLibraryStore.getState().importProgress?.message);
+            options.onProgress(5, 10, 'Processing C:/watch-a/new.png');
+            messages.push(useLibraryStore.getState().importProgress?.message);
+            return emptyImportResult();
+        });
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportFolders([
+                { path: 'C:/watch-a' },
+                { path: 'C:/watch-b' }
+            ]);
+        });
+
+        expect(messages).toEqual([
+            'Scanning 2 folders...',
+            'Importing images from 2 folders...'
+        ]);
+    });
+
+    it('keeps detailed Activity Dock messages for single-folder imports', async () => {
+        const messages: Array<string | undefined> = [];
+        mocks.processFoldersUnified.mockImplementationOnce(async (_folders, options) => {
+            options.onProgress(0, 0, 'Scanning C:/watch-a');
+            messages.push(useLibraryStore.getState().importProgress?.message);
+            options.onProgress(5, 10, 'Processing C:/watch-a/new.png');
+            messages.push(useLibraryStore.getState().importProgress?.message);
+            return emptyImportResult();
+        });
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportFolders([{ path: 'C:/watch-a' }]);
+        });
+
+        expect(messages).toEqual([
+            'Scanning C:/watch-a',
+            'Processing C:/watch-a/new.png'
+        ]);
     });
 
     it('does not advance folder cursor when incremental resync is cancelled before a zero-file scan result', async () => {

--- a/src/hooks/__tests__/useImportOps.test.ts
+++ b/src/hooks/__tests__/useImportOps.test.ts
@@ -1,0 +1,263 @@
+import { renderHook, act, waitFor } from '../../test/testUtils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useImportOps } from '../useImportOps';
+import { useLibraryStore } from '../../stores/libraryStore';
+import type { AIImage, AppSettings, MonitoredFolder } from '../../types';
+import type { ImportResult } from '../../services/importService';
+import type { Dispatch, SetStateAction } from 'react';
+
+type ScanFileEntry = { path: string; modified: number; size: number };
+type CommandOk<T> = { status: 'ok'; data: T };
+
+const mocks = vi.hoisted(() => ({
+    scanDirectorySince: vi.fn(),
+    scanDirectoryWithStats: vi.fn(),
+    processNativePaths: vi.fn(),
+    processWebFiles: vi.fn(),
+    processFoldersUnified: vi.fn(),
+    getThumbnailDir: vi.fn(),
+    addToast: vi.fn(),
+    refreshHiddenAvailability: vi.fn(),
+    refreshMetadata: vi.fn()
+}));
+
+vi.mock('../../bindings', () => ({
+    commands: {
+        scanDirectorySince: mocks.scanDirectorySince,
+        scanDirectoryWithStats: mocks.scanDirectoryWithStats
+    }
+}));
+
+vi.mock('../../services/importService', () => ({
+    processNativePaths: mocks.processNativePaths,
+    processWebFiles: mocks.processWebFiles,
+    processFoldersUnified: mocks.processFoldersUnified
+}));
+
+vi.mock('../../services/thumbnailService', () => ({
+    getThumbnailDir: mocks.getThumbnailDir
+}));
+
+vi.mock('../../contexts/SearchContext', () => ({
+    useSearch: () => ({
+        refreshHiddenAvailability: mocks.refreshHiddenAvailability,
+        refreshMetadata: mocks.refreshMetadata
+    })
+}));
+
+vi.mock('../useToast', () => ({
+    useToast: () => ({
+        addToast: mocks.addToast
+    })
+}));
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(res => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+const emptyImportResult = (wasCancelled = false): ImportResult => ({
+    images: [],
+    stats: { processed: 0, imported: 0, skipped: 0, errors: 0 },
+    handledPaths: [],
+    failedPaths: [],
+    touchedFacetTypes: [],
+    touchedFacetResources: {
+        checkpoints: [],
+        loras: [],
+        embeddings: [],
+        hypernetworks: [],
+        controlNets: [],
+        ipAdapters: [],
+        tools: []
+    },
+    wasCancelled
+});
+
+const importResult = (overrides: Partial<ImportResult> = {}): ImportResult => {
+    const base = emptyImportResult();
+    return {
+        ...base,
+        ...overrides,
+        stats: {
+            ...base.stats,
+            ...overrides.stats
+        }
+    };
+};
+
+const importedImage = (id: string): AIImage => ({ id } as AIImage);
+
+describe('useImportOps', () => {
+    const settings = {
+        theme: 'dark',
+        thumbnailSize: 200,
+        confirmDelete: true,
+        defaultTheaterMode: false,
+        monitoredFolders: [],
+        maskedKeywords: [],
+        maskingMode: 'blur',
+        enableAI: false,
+        hasCompletedOnboarding: true
+    } as AppSettings;
+
+    const renderImportOps = () => {
+        const setImages = vi.fn() as Dispatch<SetStateAction<AIImage[]>>;
+        return renderHook(() => useImportOps({
+            images: [],
+            setImages,
+            refreshCollections: vi.fn().mockResolvedValue(undefined),
+            settings
+        }));
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useLibraryStore.setState({
+            isImporting: false,
+            importProgress: null,
+            importAbortController: null
+        });
+        mocks.getThumbnailDir.mockResolvedValue('C:/thumbs');
+        mocks.processNativePaths.mockResolvedValue(emptyImportResult());
+        mocks.processFoldersUnified.mockResolvedValue(emptyImportResult());
+    });
+
+    it('shows a cancellation toast for manual path imports', async () => {
+        mocks.processNativePaths.mockResolvedValueOnce(emptyImportResult(true));
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportPaths(['C:/watch/new.png']);
+        });
+
+        expect(mocks.addToast).toHaveBeenCalledWith('Import cancelled', 'info');
+    });
+
+    it('keeps background path cancellation quiet', async () => {
+        mocks.processNativePaths.mockResolvedValueOnce(emptyImportResult(true));
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportPaths(['C:/watch/new.png'], undefined, { mode: 'background' });
+        });
+
+        expect(mocks.addToast).not.toHaveBeenCalled();
+    });
+
+    it('keeps background folder cancellation quiet', async () => {
+        mocks.processFoldersUnified.mockResolvedValueOnce(emptyImportResult(true));
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportFolders([{ path: 'C:/watch' }], { mode: 'background' });
+        });
+
+        expect(mocks.addToast).not.toHaveBeenCalled();
+        expect(mocks.processFoldersUnified).toHaveBeenCalledWith(
+            [{ path: 'C:/watch', variant: undefined }],
+            expect.objectContaining({ isStartup: false })
+        );
+    });
+
+    it('warns when a manual folder import has imported images and failed files', async () => {
+        mocks.processFoldersUnified.mockResolvedValueOnce(importResult({
+            images: [importedImage('C:/watch/imported.png')],
+            stats: { processed: 2, imported: 1, skipped: 0, errors: 1 },
+            failedPaths: ['C:/watch/failed.png']
+        }));
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportFolders([{ path: 'C:/watch' }]);
+        });
+
+        expect(mocks.addToast).toHaveBeenCalledWith('Imported 1 images from 1 folder(s), but 1 file(s) failed', 'warning');
+        expect(mocks.addToast).not.toHaveBeenCalledWith('Imported 1 images from 1 folder(s)', 'success');
+    });
+
+    it('shows success when a manual folder import has images and no failures', async () => {
+        mocks.processFoldersUnified.mockResolvedValueOnce(importResult({
+            images: [importedImage('C:/watch/imported.png')],
+            stats: { processed: 1, imported: 1, skipped: 0, errors: 0 }
+        }));
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportFolders([{ path: 'C:/watch' }]);
+        });
+
+        expect(mocks.addToast).toHaveBeenCalledWith('Imported 1 images from 1 folder(s)', 'success');
+    });
+
+    it('does not advance folder cursor when incremental resync is cancelled before a zero-file scan result', async () => {
+        const scan = deferred<CommandOk<ScanFileEntry[]>>();
+        mocks.scanDirectorySince.mockReturnValueOnce(scan.promise);
+        const updateLastScanned = vi.fn();
+        const folder: MonitoredFolder = {
+            id: 'folder-1',
+            path: 'C:/watch',
+            isActive: true,
+            imageCount: 0,
+            lastScanned: 10
+        };
+        const { result } = renderImportOps();
+        let resyncPromise!: Promise<{ newFiles: number; totalScanned: number }>;
+
+        act(() => {
+            resyncPromise = result.current.resyncFolder(folder, updateLastScanned);
+        });
+        await waitFor(() => {
+            expect(useLibraryStore.getState().importAbortController).toBeInstanceOf(AbortController);
+        });
+
+        useLibraryStore.getState().importAbortController?.abort();
+        scan.resolve({ status: 'ok', data: [] });
+
+        await act(async () => {
+            await resyncPromise;
+        });
+
+        expect(updateLastScanned).not.toHaveBeenCalled();
+        expect(mocks.processNativePaths).not.toHaveBeenCalled();
+    });
+
+    it('does not start native import when resync is cancelled before a non-empty scan result returns', async () => {
+        const scan = deferred<CommandOk<ScanFileEntry[]>>();
+        mocks.scanDirectorySince.mockReturnValueOnce(scan.promise);
+        const updateLastScanned = vi.fn();
+        const folder: MonitoredFolder = {
+            id: 'folder-1',
+            path: 'C:/watch',
+            isActive: true,
+            imageCount: 0,
+            lastScanned: 10
+        };
+        const { result } = renderImportOps();
+        let resyncPromise!: Promise<{ newFiles: number; totalScanned: number }>;
+
+        act(() => {
+            resyncPromise = result.current.resyncFolder(folder, updateLastScanned);
+        });
+        await waitFor(() => {
+            expect(useLibraryStore.getState().importAbortController).toBeInstanceOf(AbortController);
+        });
+
+        useLibraryStore.getState().importAbortController?.abort();
+        scan.resolve({
+            status: 'ok',
+            data: [{ path: 'C:/watch/new.png', modified: 100, size: 10 }]
+        });
+
+        await act(async () => {
+            await resyncPromise;
+        });
+
+        expect(updateLastScanned).not.toHaveBeenCalled();
+        expect(mocks.processNativePaths).not.toHaveBeenCalled();
+        expect(mocks.getThumbnailDir).not.toHaveBeenCalled();
+    });
+});

--- a/src/hooks/useFolderMonitor.ts
+++ b/src/hooks/useFolderMonitor.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { MonitoredFolder, GeneratorTool, FacetType } from '../types';
+import { MonitoredFolder, GeneratorTool, FacetType, ImportMode } from '../types';
 import { useSettingsStore } from '../stores/settingsStore';
 import { commands } from '../bindings';
 import { unwrap } from '../utils/spectaUtils';
@@ -16,24 +16,28 @@ import { isBrowserMockMode } from '../services/runtime';
 import type { ImportResult } from '../services/importService';
 
 interface ImportOptions {
-    isStartup?: boolean;
+    mode?: ImportMode;
     skipStateManagement?: boolean;
     onProgress?: (current: number, total: number, message?: string) => void;
     forceRescan?: boolean;
     waitForStableFiles?: boolean;
     deferFacetCacheRefresh?: boolean;
+    abortSignal?: AbortSignal;
+}
+
+interface FolderScanOptions {
+    mode?: ImportMode;
 }
 
 interface UseFolderMonitorProps {
     isLoaded: boolean;
     monitoredFolders: MonitoredFolder[];
-    onScan: (folders: { path: string, variant?: string }[], isStartup: boolean) => Promise<ImportResult | void>;
-    // Update signature to match new options
+    onScan: (folders: { path: string, variant?: string }[], options?: FolderScanOptions) => Promise<ImportResult | void>;
     handleImportPaths: (paths: string[], defaultTool?: GeneratorTool, options?: ImportOptions) => Promise<ImportResult | void>;
     addToast: (msg: string, type: 'info' | 'success' | 'error') => void;
     refreshMetadata: () => Promise<void>;
     invokeAiPath?: string;
-    startInvokeSync?: (options?: any) => Promise<void>;
+    startInvokeSync?: (options?: { mode?: 'startup' }) => Promise<void>;
 }
 
 export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImportPaths, addToast, refreshMetadata, invokeAiPath, startInvokeSync }: UseFolderMonitorProps) {
@@ -42,8 +46,8 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
     const updateFolderLastScanned = useSettingsStore(s => s.updateFolderLastScanned);
     const browserMockMode = isBrowserMockMode();
 
-    const isCompleteImport = (result: ImportResult | void): result is ImportResult =>
-        !!result && result.failedPaths.length === 0;
+    const isCompleteImport = (result: ImportResult | void): boolean =>
+        !!result && !result.wasCancelled && result.failedPaths.length === 0;
 
     const warnCursorHeld = (source: string, folderId: string, result: ImportResult | void) => {
         const failedCount = result ? result.failedPaths.length : null;
@@ -76,9 +80,10 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
             const performStartupScan = async () => {
                 const startupStartedAt = Date.now();
                 const folderScanStartedAt = Date.now();
-                const { setIsImporting, setImportProgress } = useLibraryStore.getState();
+                const { setIsImporting, setImportProgress, setImportAbortController } = useLibraryStore.getState();
                 const tasks: { paths: string[], variant: GeneratorTool | undefined, folderId: string }[] = [];
                 let totalFilesFound = 0;
+                let startupScanWasCancelled = false;
                 const scanTime = Date.now();
 
                 // Phase 1: Aggregation - Collect all new files from all valid folders
@@ -103,11 +108,14 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     } else {
                         // Full scan usage (rare on startup if already configured)
                         console.log(`[FolderMonitor] Full Scan for ${folder.path} (first time)`);
-                        const result = await onScan([{ path: folder.path, variant: folder.variant }], true);
+                        const result = await onScan([{ path: folder.path, variant: folder.variant }], { mode: 'startup' });
                         if (isCompleteImport(result)) {
                             updateFolderLastScanned(folder.id, scanTime);
-                        } else {
+                        } else if (!result || !result.wasCancelled) {
                             warnCursorHeld('Startup full scan', folder.id, result);
+                        } else {
+                            startupScanWasCancelled = true;
+                            break;
                         }
                     }
                 }
@@ -118,26 +126,34 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                 });
 
                 // Phase 2: Execution - Run single unified batch for smart updates
-                if (totalFilesFound > 0) {
+                if (!startupScanWasCancelled && totalFilesFound > 0) {
                     const importStartedAt = Date.now();
+                    const abortCtrl = new AbortController();
                     console.log(`[FolderMonitor] Starting aggregated import for ${totalFilesFound} files`);
                     setIsImporting(true);
+                    setImportAbortController(abortCtrl);
                     setImportProgress({ current: 0, total: totalFilesFound, message: 'Starting aggregated import...' });
 
                     let globalCurrent = 0;
                     let totalImported = 0;
                     let touchedFacetTypes: FacetType[] = [];
                     let touchedFacetResources = createEmptyTouchedFacetResources();
+                    let wasCancelled = false;
 
                     try {
                         for (const task of tasks) {
+                            if (abortCtrl.signal.aborted) {
+                                wasCancelled = true;
+                                break;
+                            }
                             // We use skipStateManagement: true to prevent handleImportPaths from resetting our global progress
                             const result = await handleImportPaths(task.paths, task.variant, {
-                                isStartup: true,
+                                mode: 'startup',
                                 skipStateManagement: true,
                                 forceRescan: true,
                                 waitForStableFiles: true,
                                 deferFacetCacheRefresh: true,
+                                abortSignal: abortCtrl.signal,
                                 onProgress: (current, total, message) => {
                                     // Add accumulated count from previous batches
                                     const actualCurrent = globalCurrent + current;
@@ -148,6 +164,9 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                                     });
                                 }
                             });
+                            if ((result && result.wasCancelled) || abortCtrl.signal.aborted) {
+                                wasCancelled = true;
+                            }
                             globalCurrent += task.paths.length;
 
                             if (result) {
@@ -165,32 +184,38 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                             // ONLY update once successfully imported
                             if (isCompleteImport(result)) {
                                 updateFolderLastScanned(task.folderId, scanTime);
-                            } else {
+                            } else if (!result || !result.wasCancelled) {
                                 warnCursorHeld('Startup incremental scan', task.folderId, result);
                             }
+                            if (wasCancelled) break;
                         }
 
-                        setImportProgress({ current: totalFilesFound, total: totalFilesFound, message: 'Updating startup filters...' });
-                        await refreshStartupFacetCache({
-                            source: 'folder',
-                            totalProcessed: totalImported,
-                            touchedFacetTypes,
-                            touchedFacetResources,
-                            onRefreshApplied: () => useLibraryStore.getState().incrementFacetCacheVersion()
-                        });
+                        if (!wasCancelled) {
+                            setImportProgress({ current: totalFilesFound, total: totalFilesFound, message: 'Updating startup filters...' });
+                            await refreshStartupFacetCache({
+                                source: 'folder',
+                                totalProcessed: totalImported,
+                                touchedFacetTypes,
+                                touchedFacetResources,
+                                onRefreshApplied: () => useLibraryStore.getState().incrementFacetCacheVersion()
+                            });
+                        }
                     } catch (error) {
                         console.error('[Startup Catch-up] Folder incremental facet refresh failed.', error);
                     } finally {
                         setIsImporting(false);
                         setImportProgress(null);
+                        setImportAbortController(null);
                     }
 
                     // Force UI Refresh
-                    await refreshMetadata();
-                    console.info('[Startup Catch-up] Folder import phase complete.', {
-                        filesImported: totalFilesFound,
-                        durationMs: Date.now() - importStartedAt
-                    });
+                    if (!wasCancelled) {
+                        await refreshMetadata();
+                        console.info('[Startup Catch-up] Folder import phase complete.', {
+                            filesImported: totalFilesFound,
+                            durationMs: Date.now() - importStartedAt
+                        });
+                    }
                 }
 
                 // Unconditionally catch up InvokeAI DB if configured
@@ -233,12 +258,12 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     }
 
                     const scanData = activeNew.map(f => ({ path: f.path, variant: f.variant }));
-                    const result = await onScan(scanData, false);
+                    const result = await onScan(scanData);
 
                     if (isCompleteImport(result)) {
                         const completedAt = Date.now();
                         activeNew.forEach(f => updateFolderLastScanned(f.id, completedAt));
-                    } else {
+                    } else if (!result || !result.wasCancelled) {
                         activeNew.forEach(f => warnCursorHeld('New folder scan', f.id, result));
                     }
                 })();
@@ -279,8 +304,9 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
 
     // Reusable Scan Logic (Extracted from previous effect)
     const performUnifiedScan = async (folders: MonitoredFolder[], source: string) => {
-        const { setIsImporting, setImportProgress } = useLibraryStore.getState();
+        const { setIsImporting, setImportProgress, setImportAbortController } = useLibraryStore.getState();
         let totalFilesFound = 0;
+        let scanWasCancelled = false;
         const tasks: { paths: string[], variant: GeneratorTool | undefined, folderId: string }[] = [];
         const scanTime = Date.now();
 
@@ -296,11 +322,14 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     }
                 } else {
                     console.log(`[FolderMonitor] ${source}: Full scan needed for ${folder.path}`);
-                    const result = await onScan([{ path: folder.path, variant: folder.variant }], false);
+                    const result = await onScan([{ path: folder.path, variant: folder.variant }], { mode: 'background' });
                     if (isCompleteImport(result)) {
                         updateFolderLastScanned(folder.id, scanTime);
-                    } else {
+                    } else if (!result || !result.wasCancelled) {
                         warnCursorHeld(`${source} full scan`, folder.id, result);
+                    } else {
+                        scanWasCancelled = true;
+                        break;
                     }
                 }
             } catch (e) {
@@ -308,32 +337,53 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
             }
         }
 
+        if (scanWasCancelled) return;
+
         if (totalFilesFound > 0) {
+            const abortCtrl = new AbortController();
             setIsImporting(true);
+            setImportAbortController(abortCtrl);
             setImportProgress({ current: 0, total: totalFilesFound, message: `${source}: Importing images...` });
             let currentCount = 0;
-            for (const task of tasks) {
-                const result = await handleImportPaths(task.paths, task.variant, {
-                    skipStateManagement: true,
-                    forceRescan: true,
-                    waitForStableFiles: true,
-                    onProgress: (c, t, m) => setImportProgress({ 
-                        current: currentCount + c, 
-                        total: totalFilesFound, 
-                        message: m ? `${source}: ${m}` : `${source}: Importing images...`
-                    })
-                });
-                currentCount += task.paths.length;
-                if (isCompleteImport(result)) {
-                    updateFolderLastScanned(task.folderId, scanTime);
-                } else {
-                    warnCursorHeld(`${source} incremental scan`, task.folderId, result);
+            let wasCancelled = false;
+            try {
+                for (const task of tasks) {
+                    if (abortCtrl.signal.aborted) {
+                        wasCancelled = true;
+                        break;
+                    }
+                    const result = await handleImportPaths(task.paths, task.variant, {
+                        mode: 'background',
+                        skipStateManagement: true,
+                        forceRescan: true,
+                        waitForStableFiles: true,
+                        abortSignal: abortCtrl.signal,
+                        onProgress: (c, t, m) => setImportProgress({
+                            current: currentCount + c,
+                            total: totalFilesFound,
+                            message: m ? `${source}: ${m}` : `${source}: Importing images...`
+                        })
+                    });
+                    if ((result && result.wasCancelled) || abortCtrl.signal.aborted) {
+                        wasCancelled = true;
+                    }
+                    currentCount += task.paths.length;
+                    if (isCompleteImport(result)) {
+                        updateFolderLastScanned(task.folderId, scanTime);
+                    } else if (!result || !result.wasCancelled) {
+                        warnCursorHeld(`${source} incremental scan`, task.folderId, result);
+                    }
+                    if (wasCancelled) break;
                 }
+            } finally {
+                setIsImporting(false);
+                setImportProgress(null);
+                setImportAbortController(null);
             }
-            setIsImporting(false);
-            setImportProgress(null);
 
             // Force UI Refresh
+            if (wasCancelled) return;
+
             await refreshMetadata();
 
             addToast(`${source}: Synced ${totalFilesFound} new images`, 'success');

--- a/src/hooks/useFolderMonitor.ts
+++ b/src/hooks/useFolderMonitor.ts
@@ -40,14 +40,25 @@ interface UseFolderMonitorProps {
     startInvokeSync?: (options?: { mode?: 'startup' }) => Promise<void>;
 }
 
+const isCompleteImport = (result: ImportResult | void): boolean =>
+    !!result && !result.wasCancelled && result.failedPaths.length === 0;
+
+const markInitialScanCancelled = (folderIds: string[]) => {
+    const idSet = new Set(folderIds);
+    useSettingsStore.getState().setSettings((prev) => ({
+        monitoredFolders: prev.monitoredFolders.map(folder =>
+            idSet.has(folder.id)
+                ? { ...folder, lastScanned: undefined, initialScanPending: false, initialScanCancelled: true }
+                : folder
+        )
+    }));
+};
+
 export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImportPaths, addToast, refreshMetadata, invokeAiPath, startInvokeSync }: UseFolderMonitorProps) {
     const prevFoldersRef = useRef(monitoredFolders);
     const hasScannedOnStartup = useRef(false);
     const updateFolderLastScanned = useSettingsStore(s => s.updateFolderLastScanned);
     const browserMockMode = isBrowserMockMode();
-
-    const isCompleteImport = (result: ImportResult | void): boolean =>
-        !!result && !result.wasCancelled && result.failedPaths.length === 0;
 
     const warnCursorHeld = (source: string, folderId: string, result: ImportResult | void) => {
         const failedCount = result ? result.failedPaths.length : null;
@@ -69,7 +80,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
         const hasStartups = monitoredFolders.length > 0 || !!invokeAiPath;
         if (hasStartups && !hasScannedOnStartup.current) {
             hasScannedOnStartup.current = true;
-            const activeFolders = monitoredFolders.filter(f => f.isActive);
+            const activeFolders = monitoredFolders.filter(f => f.isActive && !f.initialScanCancelled);
 
             console.log('[FolderMonitor] Startup Check:', {
                 allFolders: monitoredFolders.length,
@@ -114,6 +125,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                         } else if (!result || !result.wasCancelled) {
                             warnCursorHeld('Startup full scan', folder.id, result);
                         } else {
+                            markInitialScanCancelled([folder.id]);
                             startupScanWasCancelled = true;
                             break;
                         }
@@ -247,7 +259,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
         const newFolders = currentFolders.filter(f => !prevFolders.find(pf => pf.id === f.id));
 
         if (newFolders.length > 0) {
-            const activeNew = newFolders.filter(f => f.isActive && !f.lastScanned && !f.initialScanPending);
+            const activeNew = newFolders.filter(f => f.isActive && !f.lastScanned && !f.initialScanPending && !f.initialScanCancelled);
 
             if (activeNew.length > 0) {
                 void (async () => {
@@ -265,6 +277,8 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                         activeNew.forEach(f => updateFolderLastScanned(f.id, completedAt));
                     } else if (!result || !result.wasCancelled) {
                         activeNew.forEach(f => warnCursorHeld('New folder scan', f.id, result));
+                    } else {
+                        markInitialScanCancelled(activeNew.map(f => f.id));
                     }
                 })();
             }
@@ -281,8 +295,11 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
     useEffect(() => {
         if (browserMockMode) return;
 
-        const activeFolders = monitoredFolders.filter(f => f.isActive);
-        if (activeFolders.length === 0) return;
+        const activeFolders = monitoredFolders.filter(f => f.isActive && !f.initialScanCancelled);
+        if (activeFolders.length === 0) {
+            hasLiveWatchStartedRef.current = isLiveWatching;
+            return;
+        }
 
         // CRITICAL: If an import is already running (e.g. manual re-scan), DO NOT start another scan.
         // This prevents lock contention on the database (Read lock vs Write lock).
@@ -328,6 +345,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     } else if (!result || !result.wasCancelled) {
                         warnCursorHeld(`${source} full scan`, folder.id, result);
                     } else {
+                        markInitialScanCancelled([folder.id]);
                         scanWasCancelled = true;
                         break;
                     }

--- a/src/hooks/useImportOps.ts
+++ b/src/hooks/useImportOps.ts
@@ -24,6 +24,8 @@ interface CommitImportOptions {
     toastMode?: CommitToastMode;
 }
 
+const MANUAL_IMPORT_CANCELLED_MESSAGE = 'Import cancelled. Imported images were kept; rescan to continue.';
+
 interface UseImportOpsProps {
     images: AIImage[];
     setImages: React.Dispatch<React.SetStateAction<AIImage[]>>;
@@ -111,7 +113,7 @@ export const useImportOps = ({
                     setImportProgress({ current, total, message });
                 }, undefined, abortCtrl.signal);
                 if (result.wasCancelled) {
-                    addToast('Import cancelled', 'info');
+                    addToast(MANUAL_IMPORT_CANCELLED_MESSAGE, 'info');
                     return;
                 }
                 await commitImportResult(result);
@@ -144,7 +146,7 @@ export const useImportOps = ({
                     setImportProgress({ current, total, message });
                 }, undefined, abortCtrl.signal);
                 if (result.wasCancelled) {
-                    addToast('Import cancelled', 'info');
+                    addToast(MANUAL_IMPORT_CANCELLED_MESSAGE, 'info');
                     return;
                 }
                 await commitImportResult(result);
@@ -206,7 +208,7 @@ export const useImportOps = ({
                 deferFacetCacheRefresh
             );
             if (result.wasCancelled) {
-                if (isManual) addToast('Import cancelled', 'info');
+                if (isManual) addToast(MANUAL_IMPORT_CANCELLED_MESSAGE, 'info');
                 return result;
             }
             await commitImportResult(result, { toastMode: isManual ? 'detailed' : 'none' });
@@ -214,7 +216,7 @@ export const useImportOps = ({
         } catch (error) {
             console.error("Import error", error);
             if (isManual) {
-                addToast(abortSignal?.aborted ? 'Import cancelled' : 'Import failed or cancelled', abortSignal?.aborted ? 'info' : 'error');
+                addToast(abortSignal?.aborted ? MANUAL_IMPORT_CANCELLED_MESSAGE : 'Import failed or cancelled', abortSignal?.aborted ? 'info' : 'error');
             }
         } finally {
             if (!skipStateManagement) {
@@ -229,9 +231,13 @@ export const useImportOps = ({
         const mode = options.mode ?? 'manual';
         const isStartup = mode === 'startup';
         const isManual = mode === 'manual';
+        const isMultiFolderImport = folders.length > 1;
         setIsImporting(true);
         const abortCtrl = new AbortController();
         setImportAbortController(abortCtrl);
+        if (isMultiFolderImport) {
+            setImportProgress({ current: 0, total: 0, message: `Scanning ${folders.length} folders...` });
+        }
 
         try {
             const typedFolders = folders.map(f => ({
@@ -241,7 +247,10 @@ export const useImportOps = ({
 
             const result = await processFoldersUnified(typedFolders, {
                 onProgress: (current, total, message) => {
-                    setImportProgress({ current, total, message });
+                    const progressMessage = isMultiFolderImport
+                        ? (total > 0 ? `Importing images from ${folders.length} folders...` : `Scanning ${folders.length} folders...`)
+                        : message;
+                    setImportProgress({ current, total, message: progressMessage });
                 },
                 abortSignal: abortCtrl.signal,
                 isStartup,
@@ -249,7 +258,7 @@ export const useImportOps = ({
             });
 
             if (result.wasCancelled) {
-                if (isManual) addToast('Import cancelled', 'info');
+                if (isManual) addToast(MANUAL_IMPORT_CANCELLED_MESSAGE, 'info');
                 return result;
             }
 

--- a/src/hooks/useImportOps.ts
+++ b/src/hooks/useImportOps.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useCallback } from 'react';
-import { AIImage, AppSettings, GeneratorTool, MonitoredFolder } from '../types';
+import { AIImage, AppSettings, GeneratorTool, ImportMode, MonitoredFolder } from '../types';
 import { useToast } from './useToast';
 import { useLibraryStore } from '../stores/libraryStore';
 import { useSearch } from '../contexts/SearchContext';
@@ -9,12 +9,19 @@ import { commands } from '../bindings';
 import { unwrap } from '../utils/spectaUtils';
 
 interface ImportOptions {
-    isStartup?: boolean;
+    mode?: ImportMode;
     skipStateManagement?: boolean;
     onProgress?: (current: number, total: number, message?: string) => void;
     forceRescan?: boolean;
     waitForStableFiles?: boolean;
     deferFacetCacheRefresh?: boolean;
+    abortSignal?: AbortSignal;
+}
+
+type CommitToastMode = 'detailed' | 'compact' | 'none';
+
+interface CommitImportOptions {
+    toastMode?: CommitToastMode;
 }
 
 interface UseImportOpsProps {
@@ -43,8 +50,9 @@ export const useImportOps = ({
             .filter((path): path is string => typeof path === 'string' && path.length > 0);
     }, []);
 
-    const commitImportResult = useCallback(async (result: ImportResult, silent = false) => {
+    const commitImportResult = useCallback(async (result: ImportResult, options: CommitImportOptions = {}) => {
         const { images: newImages, stats } = result;
+        const toastMode = options.toastMode ?? 'detailed';
 
         const uniqueNewImages = newImages.filter(
             newImg => !images.some(existingImg => existingImg.id === newImg.id)
@@ -70,9 +78,9 @@ export const useImportOps = ({
             if (stats.skipped > 0) msg += ` Ignored ${stats.skipped} intermediate files.`;
             if (stats.errors > 0) msg += ` ${stats.errors} failed.`;
 
-            if (!silent) {
+            if (toastMode === 'detailed') {
                 addToast(msg, stats.errors > 0 ? 'info' : 'success');
-            } else {
+            } else if (toastMode === 'compact') {
                 addToast(`Imported ${uniqueNewImages.length} new images`, 'success');
             }
 
@@ -81,8 +89,8 @@ export const useImportOps = ({
             if (dupeCount > 0 && stats.skipped === 0 && stats.errors === 0) {
                 console.log(`Scan complete: ${dupeCount} duplicates found.`);
             } else {
-                if (!silent && stats.skipped > 0) addToast(`Ignored ${stats.skipped} intermediate files.`, 'info');
-                if (!silent && stats.errors > 0) addToast(`Failed to load ${stats.errors} files.`, 'error');
+                if (toastMode === 'detailed' && stats.skipped > 0) addToast(`Ignored ${stats.skipped} intermediate files.`, 'info');
+                if (toastMode === 'detailed' && stats.errors > 0) addToast(`Failed to load ${stats.errors} files.`, 'error');
             }
         }
     }, [images, setImages, addToast, refreshCollections, refreshMetadata, refreshHiddenAvailability]);
@@ -95,11 +103,17 @@ export const useImportOps = ({
             const nativePaths = extractNativePaths(files);
 
             if (nativePaths.length === files.length && nativePaths.length > 0) {
+                const abortCtrl = new AbortController();
+                setImportAbortController(abortCtrl);
                 const { getThumbnailDir } = await import('../services/thumbnailService');
                 const thumbDir = await getThumbnailDir();
                 const result = await processNativePaths(nativePaths, thumbDir, (current, total, message) => {
                     setImportProgress({ current, total, message });
-                });
+                }, undefined, abortCtrl.signal);
+                if (result.wasCancelled) {
+                    addToast('Import cancelled', 'info');
+                    return;
+                }
                 await commitImportResult(result);
                 return;
             }
@@ -122,11 +136,17 @@ export const useImportOps = ({
             const nativePaths = extractNativePaths(files);
 
             if (nativePaths.length === files.length && nativePaths.length > 0) {
+                const abortCtrl = new AbortController();
+                setImportAbortController(abortCtrl);
                 const { getThumbnailDir } = await import('../services/thumbnailService');
                 const thumbDir = await getThumbnailDir();
                 const result = await processNativePaths(nativePaths, thumbDir, (current, total, message) => {
                     setImportProgress({ current, total, message });
-                });
+                }, undefined, abortCtrl.signal);
+                if (result.wasCancelled) {
+                    addToast('Import cancelled', 'info');
+                    return;
+                }
                 await commitImportResult(result);
                 return;
             }
@@ -144,19 +164,24 @@ export const useImportOps = ({
 
     const handleImportPaths = useCallback(async (paths: string[], defaultTool?: GeneratorTool, options: ImportOptions = {}) => {
         const {
-            isStartup = false,
+            mode = 'manual',
             skipStateManagement = false,
             onProgress: externalOnProgress,
             forceRescan = false,
-            waitForStableFiles = isStartup,
-            deferFacetCacheRefresh = false
+            waitForStableFiles,
+            deferFacetCacheRefresh = false,
+            abortSignal: externalAbortSignal
         } = options;
+        const isStartup = mode === 'startup';
+        const isManual = mode === 'manual';
+        const shouldWaitForStableFiles = waitForStableFiles ?? isStartup;
 
         if (paths.length === 0 && isStartup) return;
 
         if (!skipStateManagement) setIsImporting(true);
-        const abortCtrl = new AbortController();
-        if (!skipStateManagement) setImportAbortController(abortCtrl);
+        const localAbortCtrl = externalAbortSignal ? null : new AbortController();
+        const abortSignal = externalAbortSignal ?? localAbortCtrl?.signal;
+        if (!skipStateManagement && localAbortCtrl) setImportAbortController(localAbortCtrl);
         try {
             const { getThumbnailDir } = await import('../services/thumbnailService');
             const thumbDir = await getThumbnailDir();
@@ -174,17 +199,23 @@ export const useImportOps = ({
                 thumbDir,
                 onProgress,
                 defaultTool,
-                abortCtrl.signal,
+                abortSignal,
                 isStartup,
                 forceRescan,
-                waitForStableFiles,
+                shouldWaitForStableFiles,
                 deferFacetCacheRefresh
             );
-            await commitImportResult(result, isStartup);
+            if (result.wasCancelled) {
+                if (isManual) addToast('Import cancelled', 'info');
+                return result;
+            }
+            await commitImportResult(result, { toastMode: isManual ? 'detailed' : 'none' });
             return result;
         } catch (error) {
             console.error("Import error", error);
-            if (!isStartup) addToast("Import failed or cancelled", "error");
+            if (isManual) {
+                addToast(abortSignal?.aborted ? 'Import cancelled' : 'Import failed or cancelled', abortSignal?.aborted ? 'info' : 'error');
+            }
         } finally {
             if (!skipStateManagement) {
                 setIsImporting(false);
@@ -194,7 +225,10 @@ export const useImportOps = ({
         }
     }, [setIsImporting, setImportAbortController, setImportProgress, commitImportResult, addToast]);
 
-    const handleImportFolders = useCallback(async (folders: { path: string, variant?: string }[], isStartup = false) => {
+    const handleImportFolders = useCallback(async (folders: { path: string, variant?: string }[], options: { mode?: ImportMode } = {}) => {
+        const mode = options.mode ?? 'manual';
+        const isStartup = mode === 'startup';
+        const isManual = mode === 'manual';
         setIsImporting(true);
         const abortCtrl = new AbortController();
         setImportAbortController(abortCtrl);
@@ -214,12 +248,20 @@ export const useImportOps = ({
                 forceRescan: false
             });
 
-            if (result.images.length > 0) {
-                await commitImportResult(result, isStartup);
+            if (result.wasCancelled) {
+                if (isManual) addToast('Import cancelled', 'info');
+                return result;
             }
 
-            if (!isStartup) {
-                if (result.images.length > 0) {
+            if (result.images.length > 0) {
+                await commitImportResult(result, { toastMode: 'none' });
+            }
+
+            if (isManual) {
+                const failedFileCount = result.failedPaths.length > 0 ? result.failedPaths.length : result.stats.errors;
+                if (result.images.length > 0 && failedFileCount > 0) {
+                    addToast(`Imported ${result.images.length} images from ${folders.length} folder(s), but ${failedFileCount} file(s) failed`, 'warning');
+                } else if (result.images.length > 0) {
                     addToast(`Imported ${result.images.length} images from ${folders.length} folder(s)`, 'success');
                 } else if (result.stats.skipped > 0) {
                     addToast(`Scan complete. No new images found.`, 'info');
@@ -232,7 +274,7 @@ export const useImportOps = ({
             return result;
         } catch (error) {
             console.error('[ImportFolders] Error:', error);
-            if (!isStartup) addToast('Import failed', 'error');
+            if (isManual) addToast('Import failed', 'error');
         } finally {
             setIsImporting(false);
             setImportProgress(null);
@@ -250,8 +292,8 @@ export const useImportOps = ({
             const result = await processNativePaths([dirPath], thumbDir, (current, total, message) => {
                 setImportProgress({ current, total, message });
             }, undefined, abortCtrl.signal, false);
-            if (result.images.length > 0) {
-                await commitImportResult(result, true);
+            if (!result.wasCancelled && result.images.length > 0) {
+                await commitImportResult(result, { toastMode: 'compact' });
             }
         } catch (e) {
             console.error(`Failed to scan directory ${dirPath}`, e);
@@ -291,6 +333,11 @@ export const useImportOps = ({
                 }
             );
 
+            if (abortCtrl.signal.aborted) {
+                addToast('Import cancelled', 'info');
+                return;
+            }
+
             await syncCollectionImages();
             await rebuildFacetCache();
             await refreshCollections();
@@ -298,7 +345,7 @@ export const useImportOps = ({
             addToast(`InvokeAI sync complete: ${result.imported} imported, ${result.updated} updated`, 'success');
         } catch (e) {
             console.error('InvokeAI sync failed', e);
-            addToast('InvokeAI sync failed', 'error');
+            addToast(abortCtrl.signal.aborted ? 'Import cancelled' : 'InvokeAI sync failed', abortCtrl.signal.aborted ? 'info' : 'error');
         } finally {
             setIsImporting(false);
             setImportProgress(null);
@@ -333,6 +380,10 @@ export const useImportOps = ({
                 console.log(`[Resync] Found ${filesToScan.length} total files`);
             }
 
+            if (abortCtrl.signal.aborted) {
+                return { newFiles: 0, totalScanned: filesToScan.length };
+            }
+
             if (filesToScan.length === 0) {
                 setImportProgress({ current: 0, total: 0, message: 'No changes detected' });
                 updateLastScanned(id, Date.now());
@@ -357,8 +408,11 @@ export const useImportOps = ({
                 isIncremental
             );
 
-            if (result.images.length > 0) {
-                await commitImportResult(result, true);
+            if (!result.wasCancelled && result.images.length > 0) {
+                await commitImportResult(result, { toastMode: 'compact' });
+            }
+            if (result.wasCancelled) {
+                return { newFiles: result.images.length, totalScanned: filesToScan.length };
             }
             updateLastScanned(id, Date.now());
 

--- a/src/services/__tests__/importService.test.ts
+++ b/src/services/__tests__/importService.test.ts
@@ -117,6 +117,7 @@ describe('processTargetedFiles', () => {
         );
 
         expect(result.stats.imported).toBe(2);
+        expect(result.wasCancelled).toBe(false);
         expect(result.failedPaths).toEqual([]);
         expect(result.handledPaths).toEqual([
             'C:/library/updated-image.png',
@@ -178,6 +179,7 @@ describe('processTargetedFiles', () => {
         );
 
         expect(result.stats.imported).toBe(1);
+        expect(result.wasCancelled).toBe(false);
         expect(result.touchedFacetTypes).toEqual([
             'checkpoints',
             'loras',
@@ -192,6 +194,62 @@ describe('processTargetedFiles', () => {
             ipAdapters: [],
             tools: ['ComfyUI']
         });
+        expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();
+    });
+
+    it('returns a cancelled result and skips work when aborted before discovery', async () => {
+        const abortCtrl = new AbortController();
+        abortCtrl.abort();
+
+        const result = await processFoldersUnified(
+            [{ path: 'C:/library' }],
+            {
+                abortSignal: abortCtrl.signal
+            }
+        );
+
+        expect(result.wasCancelled).toBe(true);
+        expect(result.failedPaths).toEqual([]);
+        expect(mocks.scanDirectoryWithStats).not.toHaveBeenCalled();
+        expect(mocks.scanImagesBulk).not.toHaveBeenCalled();
+        expect(mocks.insertImagesBatch).not.toHaveBeenCalled();
+        expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();
+    });
+
+    it('returns a cancelled result and skips facet cleanup when aborted after metadata scan', async () => {
+        const abortCtrl = new AbortController();
+        mocks.getExistingMetadata.mockResolvedValue(new Map());
+        mocks.scanImagesBulk.mockImplementationOnce(async () => {
+            abortCtrl.abort();
+            return [
+                {
+                    metadata: {
+                        tool: 'ComfyUI',
+                        model: 'Cancelled Model'
+                    },
+                    timestamp: 3000,
+                    width: 768,
+                    height: 768,
+                    fileSize: 333,
+                    thumbnail: 'C:/thumbs/cancelled.webp',
+                    thumbnailSource: 'ambit',
+                    microThumbnail: 'mini-cancelled',
+                    originalChunks: {}
+                }
+            ];
+        });
+
+        const result = await processFoldersUnified(
+            [{ path: 'C:/library' }],
+            {
+                forceRescan: true,
+                abortSignal: abortCtrl.signal
+            }
+        );
+
+        expect(result.wasCancelled).toBe(true);
+        expect(result.failedPaths).toEqual([]);
+        expect(mocks.insertImagesBatch).not.toHaveBeenCalled();
         expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();
     });
 });

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -68,6 +68,7 @@ export interface ImportResult {
     failedPaths: string[];
     touchedFacetTypes: FacetType[];
     touchedFacetResources: TouchedFacetResources;
+    wasCancelled: boolean;
 }
 
 export interface ImportOptions {
@@ -95,19 +96,22 @@ const delay = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, m
 
 async function waitForStableFileSizes(
     paths: string[],
-    onProgress?: (current: number, total: number, message?: string) => void
-) {
-    if (paths.length === 0) return;
+    onProgress?: (current: number, total: number, message?: string) => void,
+    abortSignal?: AbortSignal
+): Promise<boolean> {
+    if (paths.length === 0) return true;
 
     const states = new Map<string, { size: number; stablePolls: number }>();
     let pendingPaths = [...paths];
 
     for (let poll = 0; poll < FILE_STABILITY_MAX_POLLS && pendingPaths.length > 0; poll++) {
+        if (abortSignal?.aborted) return false;
         onProgress?.(0, paths.length, `Waiting for ${pendingPaths.length} file(s) to finish writing...`);
 
         let sizes: number[] = [];
         try {
             sizes = await unwrap(commands.getFileSizesBulk(pendingPaths));
+            if (abortSignal?.aborted) return false;
         } catch (error) {
             console.warn('[Import] File stability probe failed; retrying before import.', error);
             await delay(FILE_STABILITY_POLL_MS);
@@ -133,6 +137,8 @@ async function waitForStableFileSizes(
     if (pendingPaths.length > 0) {
         console.warn(`[Import] ${pendingPaths.length} file(s) did not stabilize before import; continuing.`);
     }
+
+    return !abortSignal?.aborted;
 }
 
 const mapMetadata = (meta: any) => ({
@@ -154,7 +160,7 @@ async function processFileEntries(
     stats: ImportStats,
     options: ImportOptions = {},
     defaultTool?: GeneratorTool
-): Promise<{ images: AIImage[]; handledPaths: string[]; failedPaths: string[]; touchedFacetTypes: FacetType[]; touchedFacetResources: TouchedFacetResources }> {
+): Promise<{ images: AIImage[]; handledPaths: string[]; failedPaths: string[]; touchedFacetTypes: FacetType[]; touchedFacetResources: TouchedFacetResources; wasCancelled: boolean }> {
     const { onProgress, abortSignal, forceRescan, skipThumbnail = true, waitForStableFiles, perfContext } = options;
     const newImages: AIImage[] = [];
     const handledPaths: string[] = [];
@@ -163,19 +169,26 @@ async function processFileEntries(
     const cycleId = perfContext?.cycleId ?? createLiveWatchPerfId('import');
     const touchedFacetTypes = new Set<FacetType>();
     let touchedFacetResources = createEmptyTouchedFacetResources();
+    let wasCancelled = false;
 
     // Sort by Modified Date (Newest First)
     entries.sort((a, b) => b.modified - a.modified);
 
     const allPaths = entries.map(e => e.path);
+    if (abortSignal?.aborted) {
+        wasCancelled = true;
+    }
 
     // Filter duplicates
     let pathsToProcess = allPaths;
-    if (!forceRescan) {
+    if (!wasCancelled && !forceRescan) {
         if (onProgress) onProgress(0, allPaths.length, 'Checking for duplicates...');
 
         const existingLookupStartedAt = liveWatchNow();
         const existingPaths = await getExistingPaths(allPaths);
+        if (abortSignal?.aborted) {
+            wasCancelled = true;
+        }
         pathsToProcess = allPaths.filter(p => !existingPaths.has(normalizePath(p)));
         stats.skipped += (allPaths.length - pathsToProcess.length);
         debugLiveWatchPerf('Import duplicate check complete', {
@@ -187,7 +200,7 @@ async function processFileEntries(
         });
     }
 
-    if (pathsToProcess.length === 0) {
+    if (wasCancelled || pathsToProcess.length === 0) {
         infoLiveWatchPerf('Import processing complete', {
             cycleId,
             source: perfContext?.source,
@@ -200,19 +213,30 @@ async function processFileEntries(
             failedPathCount: failedPaths.length,
             totalMs: elapsedMs(importStartedAt)
         });
-        return { images: [], handledPaths, failedPaths, touchedFacetTypes: [], touchedFacetResources: createEmptyTouchedFacetResources() };
+        return {
+            images: [],
+            handledPaths,
+            failedPaths,
+            touchedFacetTypes: [],
+            touchedFacetResources: createEmptyTouchedFacetResources(),
+            wasCancelled
+        };
     }
 
     if (waitForStableFiles) {
-        await waitForStableFileSizes(pathsToProcess, onProgress);
+        const stable = await waitForStableFileSizes(pathsToProcess, onProgress, abortSignal);
+        if (!stable) {
+            wasCancelled = true;
+        }
     }
 
     const BATCH_SIZE = 300;
     const totalToProcess = pathsToProcess.length;
 
-    for (let i = 0; i < totalToProcess; i += BATCH_SIZE) {
+    for (let i = 0; i < totalToProcess && !wasCancelled; i += BATCH_SIZE) {
         if (abortSignal?.aborted) {
             console.log('Import cancelled by user');
+            wasCancelled = true;
             break;
         }
 
@@ -235,6 +259,10 @@ async function processFileEntries(
             const scanStartedAt = liveWatchNow();
             const results = await scanImagesBulk(chunk, '', skipThumbnail, true, defaultTool);
             const scanMs = elapsedMs(scanStartedAt);
+            if (abortSignal?.aborted) {
+                wasCancelled = true;
+                break;
+            }
 
 
             const batchImages: AIImage[] = [];
@@ -281,8 +309,16 @@ async function processFileEntries(
                 const ids = batchImages.map(img => img.id);
                 const { insertImagesBatch, getExistingMetadata } = await import('./db/imageRepo');
                 const existingMetaStartedAt = liveWatchNow();
+                if (abortSignal?.aborted) {
+                    wasCancelled = true;
+                    break;
+                }
                 const existingMeta = await getExistingMetadata(ids);
                 const existingMetadataMs = elapsedMs(existingMetaStartedAt);
+                if (abortSignal?.aborted) {
+                    wasCancelled = true;
+                    break;
+                }
 
                 batchImages.forEach(img => {
                     const existing = existingMeta.get(img.id);
@@ -332,9 +368,16 @@ async function processFileEntries(
 
                 let upsertMs = 0;
                 if (imagesToUpdate.length > 0) {
+                    if (abortSignal?.aborted) {
+                        wasCancelled = true;
+                        break;
+                    }
                     const upsertStartedAt = liveWatchNow();
                     await insertImagesBatch(imagesToUpdate);
                     upsertMs = elapsedMs(upsertStartedAt);
+                    if (abortSignal?.aborted) {
+                        wasCancelled = true;
+                    }
                     stats.imported += imagesToUpdate.length;
                 }
                 debugLiveWatchPerf('Import batch stage timings', {
@@ -374,6 +417,10 @@ async function processFileEntries(
             }
 
         } catch (e) {
+            if (abortSignal?.aborted) {
+                wasCancelled = true;
+                break;
+            }
             console.error('Import batch error:', e);
             stats.errors += chunk.length;
             failedPaths.push(...chunk.map(path => normalizePath(path)));
@@ -395,7 +442,14 @@ async function processFileEntries(
         totalMs: elapsedMs(importStartedAt)
     });
 
-    return { images: newImages, handledPaths, failedPaths, touchedFacetTypes: orderFacetTypes(touchedFacetTypes), touchedFacetResources };
+    return {
+        images: newImages,
+        handledPaths,
+        failedPaths,
+        touchedFacetTypes: orderFacetTypes(touchedFacetTypes),
+        touchedFacetResources,
+        wasCancelled: wasCancelled || !!abortSignal?.aborted
+    };
 }
 
 // --- Unified Folder Import ---
@@ -414,7 +468,8 @@ export async function processFoldersUnified(
         handledPaths: [],
         failedPaths: [],
         touchedFacetTypes: [],
-        touchedFacetResources: createEmptyTouchedFacetResources()
+        touchedFacetResources: createEmptyTouchedFacetResources(),
+        wasCancelled: false
     };
 
     const { onProgress, abortSignal, deferFacetCacheRefresh = false } = options;
@@ -440,16 +495,27 @@ export async function processFoldersUnified(
 
     // B. Execute Scans
     for (const [variant, folderPaths] of byVariant.entries()) {
-        if (abortSignal?.aborted) break;
+        if (abortSignal?.aborted) {
+            result.wasCancelled = true;
+            break;
+        }
 
         const filesForVariant: FileEntry[] = [];
         for (const folderPath of folderPaths) {
+            if (abortSignal?.aborted) {
+                result.wasCancelled = true;
+                break;
+            }
             try {
                 if (onProgress) onProgress(0, 0, `Scanning ${normalizePath(folderPath)}...`);
 
                 // Attempt to scan as directory first
                 // Note: scanDirectoryWithStats should be recursive on backend
                 const files = await unwrap(commands.scanDirectoryWithStats(folderPath));
+                if (abortSignal?.aborted) {
+                    result.wasCancelled = true;
+                    break;
+                }
 
                 if (files && files.length > 0) {
                     filesForVariant.push(...files);
@@ -469,11 +535,17 @@ export async function processFoldersUnified(
                     }
                 }
             } catch (e) {
+                if (abortSignal?.aborted) {
+                    result.wasCancelled = true;
+                    break;
+                }
                 console.warn(`[ImportUnified] Failed to scan ${folderPath} as directory. Treating as file?`, e);
                 // Fallback for single files passed to this function
                 filesForVariant.push({ path: folderPath, modified: Date.now(), size: 0 });
             }
         }
+
+        if (result.wasCancelled) break;
 
         if (filesForVariant.length > 0) {
             tasks.push({ variant, files: filesForVariant });
@@ -482,6 +554,10 @@ export async function processFoldersUnified(
     }
 
     console.log(`[ImportUnified] Discovery Complete. Total files to process: ${grandTotalFiles}`);
+
+    if (result.wasCancelled) {
+        return result;
+    }
 
     // If grandTotal is 0, we should probably still return, but let's notify
     if (grandTotalFiles === 0) {
@@ -493,7 +569,10 @@ export async function processFoldersUnified(
     let globalProcessed = 0;
 
     for (const task of tasks) {
-        if (abortSignal?.aborted) break;
+        if (abortSignal?.aborted) {
+            result.wasCancelled = true;
+            break;
+        }
 
         // Adapter maps "Current Task Progress" -> "Global Progress"
         const progressAdapter = (current: number, total: number, message?: string) => {
@@ -516,6 +595,10 @@ export async function processFoldersUnified(
             task.variant
         );
 
+        if (imported.wasCancelled) {
+            result.wasCancelled = true;
+        }
+
         result.images.push(...imported.images);
         result.handledPaths.push(...imported.handledPaths);
         result.failedPaths.push(...imported.failedPaths);
@@ -530,18 +613,19 @@ export async function processFoldersUnified(
 
         // precise increment
         globalProcessed += task.files.length;
+        if (result.wasCancelled) break;
     }
 
     // 3. Post-Import Cleanup
     // Fire-and-forget so we do not block the UI from immediately fetching and displaying the images.
     // Startup smart scans can defer this so useFolderMonitor can run one bounded incremental refresh.
-    if (!deferFacetCacheRefresh) {
+    if (!deferFacetCacheRefresh && !result.wasCancelled) {
         import('./db/imageRepo').then(({ rebuildFacetCache }) => {
             rebuildFacetCache()
                 .then(() => useLibraryStore.getState().incrementFacetCacheVersion())
                 .catch(e => console.error('[Import] Failed cleanup', e));
         });
-    } else {
+    } else if (deferFacetCacheRefresh) {
         console.info('[ImportUnified] Deferred facet cache refresh to startup catch-up coordinator.', {
             processed: result.stats.processed,
             imported: result.stats.imported,
@@ -604,7 +688,8 @@ export const processWebFiles = async (files: File[]): Promise<ImportResult> => {
         handledPaths: [],
         failedPaths: [],
         touchedFacetTypes: [],
-        touchedFacetResources: createEmptyTouchedFacetResources()
+        touchedFacetResources: createEmptyTouchedFacetResources(),
+        wasCancelled: false
     };
 };
 
@@ -664,7 +749,8 @@ export const processTargetedFiles = async (
         handledPaths: [],
         failedPaths: [],
         touchedFacetTypes: [],
-        touchedFacetResources: createEmptyTouchedFacetResources()
+        touchedFacetResources: createEmptyTouchedFacetResources(),
+        wasCancelled: false
     };
 
     if (paths.length === 0) return result;
@@ -683,6 +769,7 @@ export const processTargetedFiles = async (
     result.failedPaths = imported.failedPaths;
     result.touchedFacetTypes = imported.touchedFacetTypes;
     result.touchedFacetResources = imported.touchedFacetResources;
+    result.wasCancelled = imported.wasCancelled;
 
     // Live Watch keeps the grid responsive here and lets SyncContext queue the
     // targeted incremental facet refresh immediately after the import settles.

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -146,7 +146,9 @@ export const useSettingsStore = create<SettingsState>()(
             updateFolderLastScanned: (id: string, timestamp: number) => {
                 get().setSettings((prev) => ({
                     monitoredFolders: prev.monitoredFolders.map(f =>
-                        f.id === id ? { ...f, lastScanned: timestamp } : f
+                        f.id === id
+                            ? { ...f, lastScanned: timestamp, initialScanPending: false, initialScanCancelled: false }
+                            : f
                     )
                 }));
             },

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,7 @@ export interface MonitoredFolder {
   lastScanned?: number; // Timestamp of last successful full/partial scan
   variant?: GeneratorTool; // Store the detected/assigned variant
   initialScanPending?: boolean; // Suppress duplicate auto-scan until the first queued scan completes
+  initialScanCancelled?: boolean; // User cancelled initial import; do not auto-retry until manual rescan
 }
 
 export interface InvokeDbSnapshotFile {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export type LayoutMode = 'grid' | 'masonry' | 'justified';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'none';
 
+export type ImportMode = 'manual' | 'startup' | 'background';
+
 export type RecoveryStyle = 'generic' | 'midjourney' | 'sdxl' | 'danbooru';
 
 export interface ImageMetadata {


### PR DESCRIPTION
## Summary
- Add cooperative cancellation state to frontend import results and import callers.
- Route integration imports through registered AbortController-backed paths.
- Prevent cancelled or partially failed imports from advancing folder cursors.
- Treat cancelled initial folder imports as paused so startup/live-watch auto scans do not immediately retry them.
- Stabilize multi-folder Activity Dock progress and clarify cancellation messaging.
- Document Rust-side cancellation as follow-up work.

## Why
The Activity Dock could expose cancel for integration imports without a registered controller, and partial/cancelled imports could still look complete to callers that only checked failed paths. After the first fix, user testing showed another UX issue: cancelling an initial A1111 import left active folders with no cursor, so refresh/startup treated them as ready for another automatic full import.

## User impact
Users can cancel cancellable integration imports from the Activity Dock without seeing stale no-op controls. Already imported images remain in the DB, folder cursors stay unset, and cancelled initial imports show a "Rescan to continue" state instead of auto-retrying on app restart. Background/startup cancellation remains quiet.

## Validation
- `pnpm exec vitest run src/hooks/__tests__/useFolderMonitor.test.ts src/hooks/__tests__/useImportOps.test.ts src/features/settings/hooks/__tests__/useFoldersTabLogic.test.tsx src/features/settings/components/__tests__/A1111Tab.test.tsx`
- `pnpm exec vitest run src/hooks/__tests__/useFolderMonitor.test.ts src/hooks/__tests__/useImportOps.test.ts src/features/settings/components/__tests__/A1111Tab.test.tsx src/features/settings/hooks/__tests__/useFoldersTabLogic.test.tsx src/services/__tests__/importService.test.ts src/components/ui/__tests__/ActivityDock.test.tsx`
- `pnpm run typecheck`
- `git diff --check --cached`