### PR TITLE
[codex] Harden beta security surfaces

### DIFF
--- a/src-tauri/src/db/backup.rs
+++ b/src-tauri/src/db/backup.rs
@@ -1,8 +1,10 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::db::{configure_connection, resolve_db_path};
 use chrono::{DateTime, Local};
+use rusqlite::params;
 use std::fs;
+use std::io::ErrorKind;
 
 const BACKUP_RETENTION_COUNT: usize = 3;
 
@@ -78,41 +80,7 @@ pub async fn backup_database(app: tauri::AppHandle) -> Result<BackupInfo, String
     tauri::async_runtime::spawn_blocking(move || {
         let db_path = resolve_db_path(&app)?;
         let backup_dir = resolve_backup_dir(&app)?;
-
-        let now = Local::now();
-        let filename = format!("images_{}.db", now.format("%Y-%m-%d_%H-%M-%S"));
-        let backup_path = backup_dir.join(&filename);
-
-        // Use Rusqlite to perform VACUUM INTO
-        {
-            let conn = rusqlite::Connection::open(&db_path).map_err(|e| e.to_string())?;
-            configure_connection(&conn).map_err(|e| e.to_string())?;
-
-            // VACUUM INTO 'path/to/backup.db'
-            // Only works in SQLite 3.27.0+ (Rusqlite bundled is usually newer)
-            let sql = format!("VACUUM INTO '{}'", backup_path.to_string_lossy());
-            conn.execute(&sql, []).map_err(|e| e.to_string())?;
-        }
-
-        // Prune old backups after successful creation
-        if let Ok(backups) = list_backups_internal(&backup_dir) {
-            if backups.len() > BACKUP_RETENTION_COUNT {
-                let to_remove = &backups[BACKUP_RETENTION_COUNT..];
-                for backup in to_remove {
-                    let _ = fs::remove_file(&backup.path);
-                }
-            }
-        }
-
-        // Return info about the new backup
-        let metadata = fs::metadata(&backup_path).map_err(|e| e.to_string())?;
-
-        Ok(BackupInfo {
-            name: filename,
-            path: backup_path.to_string_lossy().to_string(),
-            created_at: now.to_rfc3339(),
-            size_bytes: metadata.len(),
-        })
+        create_backup_internal(&db_path, &backup_dir, Local::now())
     })
     .await
     .map_err(|e| e.to_string())?
@@ -141,38 +109,178 @@ pub async fn check_and_run_autobackup(app: tauri::AppHandle) -> Result<Option<Ba
 
         if should_backup {
             let db_path = resolve_db_path(&app)?;
-            let now = Local::now();
-            let filename = format!("images_{}.db", now.format("%Y-%m-%d_%H-%M-%S"));
-            let backup_path = backup_dir.join(&filename);
-
-            {
-                let conn = rusqlite::Connection::open(&db_path).map_err(|e| e.to_string())?;
-                configure_connection(&conn).map_err(|e| e.to_string())?;
-                let sql = format!("VACUUM INTO '{}'", backup_path.to_string_lossy());
-                conn.execute(&sql, []).map_err(|e| e.to_string())?;
-            }
-
-            // Prune
-            // Re-list to include new one and sort
-            if let Ok(updated_backups) = list_backups_internal(&backup_dir) {
-                if updated_backups.len() > BACKUP_RETENTION_COUNT {
-                    for backup in &updated_backups[BACKUP_RETENTION_COUNT..] {
-                        let _ = fs::remove_file(&backup.path);
-                    }
-                }
-            }
-
-            let metadata = fs::metadata(&backup_path).map_err(|e| e.to_string())?;
-            Ok(Some(BackupInfo {
-                name: filename,
-                path: backup_path.to_string_lossy().to_string(),
-                created_at: now.to_rfc3339(),
-                size_bytes: metadata.len(),
-            }))
+            create_backup_internal(&db_path, &backup_dir, Local::now()).map(Some)
         } else {
             Ok(None)
         }
     })
     .await
     .map_err(|e| e.to_string())?
+}
+
+fn create_backup_internal(
+    db_path: &Path,
+    backup_dir: &Path,
+    now: DateTime<Local>,
+) -> Result<BackupInfo, String> {
+    let (filename, backup_path) = resolve_unique_backup_path(backup_dir, &now)?;
+    ensure_backup_path_stays_in_dir(backup_dir, &backup_path)?;
+    vacuum_database_into(db_path, &backup_path)?;
+    prune_old_backups(backup_dir);
+
+    let metadata = fs::metadata(&backup_path).map_err(|e| e.to_string())?;
+
+    Ok(BackupInfo {
+        name: filename,
+        path: backup_path.to_string_lossy().to_string(),
+        created_at: now.to_rfc3339(),
+        size_bytes: metadata.len(),
+    })
+}
+
+fn resolve_unique_backup_path(
+    backup_dir: &Path,
+    now: &DateTime<Local>,
+) -> Result<(String, PathBuf), String> {
+    let timestamp = now.format("%Y-%m-%d_%H-%M-%S");
+
+    for suffix in 0..10_000 {
+        let filename = if suffix == 0 {
+            format!("images_{}.db", timestamp)
+        } else {
+            format!("images_{}_{}.db", timestamp, suffix)
+        };
+        let backup_path = backup_dir.join(&filename);
+
+        match fs::symlink_metadata(&backup_path) {
+            Ok(_) => continue,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Ok((filename, backup_path))
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Failed to inspect candidate backup path {}: {}",
+                    backup_path.to_string_lossy(),
+                    error
+                ));
+            }
+        }
+    }
+
+    Err("Failed to find a unique backup filename".to_string())
+}
+
+fn ensure_backup_path_stays_in_dir(backup_dir: &Path, backup_path: &Path) -> Result<(), String> {
+    let canonical_backup_dir =
+        fs::canonicalize(backup_dir).map_err(|e| format!("Failed to resolve backup dir: {}", e))?;
+    let backup_parent = backup_path
+        .parent()
+        .ok_or_else(|| "Backup path has no parent directory".to_string())?;
+    let canonical_parent = fs::canonicalize(backup_parent)
+        .map_err(|e| format!("Failed to resolve backup path parent: {}", e))?;
+
+    if canonical_parent != canonical_backup_dir {
+        return Err("Backup path escaped the backup directory".to_string());
+    }
+
+    Ok(())
+}
+
+fn vacuum_database_into(db_path: &Path, backup_path: &Path) -> Result<(), String> {
+    let conn = rusqlite::Connection::open(db_path).map_err(|e| e.to_string())?;
+    configure_connection(&conn).map_err(|e| e.to_string())?;
+
+    let backup_path = backup_path.to_string_lossy().to_string();
+    conn.execute("VACUUM INTO ?1", params![backup_path])
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
+}
+
+fn prune_old_backups(backup_dir: &Path) {
+    let Ok(backups) = list_backups_internal(&backup_dir.to_path_buf()) else {
+        return;
+    };
+
+    if backups.len() <= BACKUP_RETENTION_COUNT {
+        return;
+    }
+
+    for backup in &backups[BACKUP_RETENTION_COUNT..] {
+        let _ = fs::remove_file(&backup.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_unique_backup_path, vacuum_database_into};
+    use chrono::Local;
+    use rusqlite::Connection;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn vacuum_backup_accepts_paths_with_quotes() {
+        let temp_root = temp_dir("quoted_backup");
+        let backup_dir = temp_root.join("backups with ' quote");
+        fs::create_dir_all(&backup_dir).unwrap();
+        let db_path = temp_root.join("source.db");
+        let backup_path = backup_dir.join("images_quote's.db");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute("CREATE TABLE sample (value TEXT)", [])
+                .unwrap();
+            conn.execute("INSERT INTO sample (value) VALUES ('ok')", [])
+                .unwrap();
+        }
+
+        vacuum_database_into(&db_path, &backup_path).unwrap();
+
+        let backup_conn = Connection::open(&backup_path).unwrap();
+        let value: String = backup_conn
+            .query_row("SELECT value FROM sample", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(value, "ok");
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn backup_filename_uses_suffix_when_timestamp_collides() {
+        let temp_root = temp_dir("backup_collision");
+        fs::create_dir_all(&temp_root).unwrap();
+        let now = Local::now();
+        let timestamp = now.format("%Y-%m-%d_%H-%M-%S");
+        fs::write(
+            temp_root.join(format!("images_{}.db", timestamp)),
+            b"existing",
+        )
+        .unwrap();
+        fs::write(
+            temp_root.join(format!("images_{}_1.db", timestamp)),
+            b"existing",
+        )
+        .unwrap();
+
+        let (filename, path) = resolve_unique_backup_path(&temp_root, &now).unwrap();
+
+        assert_eq!(filename, format!("images_{}_2.db", timestamp));
+        assert_eq!(path, temp_root.join(&filename));
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ambit_backup_{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
 }

--- a/src-tauri/src/fs_commands.rs
+++ b/src-tauri/src/fs_commands.rs
@@ -1,3 +1,6 @@
+use crate::db::{configure_connection, resolve_db_path};
+use rusqlite::{params, Connection};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 use tauri::{Manager, Wry};
@@ -21,25 +24,38 @@ pub struct InvokeDbSnapshot {
 
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
-pub fn move_to_trash(path: String) -> Result<(), String> {
-    trash::delete(&path).map_err(|e| format!("Failed to move to trash: {}", e))
+pub fn move_to_trash(app: tauri::AppHandle<Wry>, path: String) -> Result<(), String> {
+    let canonical_file = resolve_existing_regular_file(&path)?;
+    let conn = open_configured_app_db(&app)?;
+
+    if !path_is_known_media_file(&conn, &path, &canonical_file)? {
+        return Err("Refusing to move an untracked file to trash".to_string());
+    }
+
+    trash::delete(&canonical_file).map_err(|e| format!("Failed to move to trash: {}", e))
 }
 
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
-pub fn delete_thumbnail(path: String) -> Result<(), String> {
-    let p = Path::new(&path);
-    if p.exists() {
-        trash::delete(p).map_err(|e| format!("Failed to move thumbnail to trash: {}", e))
-    } else {
-        Ok(()) // If it doesn't exist, we consider it "handled"
+pub fn delete_thumbnail(app: tauri::AppHandle<Wry>, path: String) -> Result<(), String> {
+    let thumbnail_dir = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| format!("Failed to resolve app local data directory: {}", e))?
+        .join(".thumbnails");
+
+    if let Some(thumbnail_file) = resolve_eligible_thumbnail_file(&path, &thumbnail_dir)? {
+        trash::delete(thumbnail_file)
+            .map_err(|e| format!("Failed to move thumbnail to trash: {}", e))?;
     }
+
+    Ok(())
 }
 
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
 pub fn register_library_path(app: tauri::AppHandle<Wry>, path: String) -> Result<(), String> {
-    let path_buf = Path::new(&path).to_path_buf();
+    let path_buf = validate_library_scope_directory(&path)?;
 
     // Add to FS scope
     app.fs_scope()
@@ -52,6 +68,122 @@ pub fn register_library_path(app: tauri::AppHandle<Wry>, path: String) -> Result
         .map_err(|e| format!("Failed to add to Asset Protocol scope: {}", e))?;
 
     Ok(())
+}
+
+fn validate_library_scope_directory(path: &str) -> Result<PathBuf, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+
+    let canonical = fs::canonicalize(Path::new(trimmed))
+        .map_err(|e| format!("Failed to resolve library path: {}", e))?;
+    let metadata =
+        fs::metadata(&canonical).map_err(|e| format!("Failed to inspect library path: {}", e))?;
+
+    if !metadata.is_dir() {
+        return Err("Library path must be an existing directory".to_string());
+    }
+
+    if is_filesystem_root(&canonical) {
+        return Err("Refusing to register a filesystem root as a library path".to_string());
+    }
+
+    Ok(canonical)
+}
+
+fn is_filesystem_root(path: &Path) -> bool {
+    path.parent().is_none()
+}
+
+fn resolve_existing_regular_file(path: &str) -> Result<PathBuf, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+
+    let candidate = PathBuf::from(trimmed);
+    let metadata = fs::symlink_metadata(&candidate)
+        .map_err(|e| format!("Failed to inspect file path: {}", e))?;
+
+    if !metadata.is_file() {
+        return Err("Path must be an existing regular file".to_string());
+    }
+
+    fs::canonicalize(candidate).map_err(|e| format!("Failed to resolve file path: {}", e))
+}
+
+fn open_configured_app_db(app: &tauri::AppHandle<Wry>) -> Result<Connection, String> {
+    let db_path = resolve_db_path(app)?;
+    let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
+    configure_connection(&conn).map_err(|e| e.to_string())?;
+    Ok(conn)
+}
+
+fn path_is_known_media_file(
+    conn: &Connection,
+    requested_path: &str,
+    canonical_path: &Path,
+) -> Result<bool, String> {
+    let requested = normalize_path_string(requested_path);
+    let canonical = normalize_path_for_frontend(canonical_path);
+
+    let is_known: i64 = conn
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM images
+                WHERE id IN (?1, ?2) OR path IN (?1, ?2)
+                UNION ALL
+                SELECT 1 FROM removed_images
+                WHERE id IN (?1, ?2) OR path IN (?1, ?2)
+            )",
+            params![requested, canonical],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+
+    Ok(is_known != 0)
+}
+
+fn resolve_eligible_thumbnail_file(
+    path: &str,
+    thumbnail_dir: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let candidate = PathBuf::from(trimmed);
+    if !candidate.exists() {
+        return Ok(None);
+    }
+
+    let metadata = fs::symlink_metadata(&candidate)
+        .map_err(|e| format!("Failed to inspect thumbnail path: {}", e))?;
+    if !metadata.is_file() {
+        return Ok(None);
+    }
+
+    if !candidate
+        .extension()
+        .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("webp"))
+    {
+        return Ok(None);
+    }
+
+    let canonical_file =
+        fs::canonicalize(&candidate).map_err(|e| format!("Failed to resolve thumbnail: {}", e))?;
+    let canonical_dir = match fs::canonicalize(thumbnail_dir) {
+        Ok(dir) => dir,
+        Err(_) => return Ok(None),
+    };
+
+    if canonical_file.parent() == Some(canonical_dir.as_path()) {
+        Ok(Some(canonical_file))
+    } else {
+        Ok(None)
+    }
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -123,11 +255,19 @@ fn normalize_path_for_frontend(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
+fn normalize_path_string(path: &str) -> String {
+    path.trim().replace('\\', "/")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{get_invoke_db_snapshot, resolve_invoke_db_path};
+    use super::{
+        get_invoke_db_snapshot, path_is_known_media_file, resolve_eligible_thumbnail_file,
+        resolve_invoke_db_path, validate_library_scope_directory,
+    };
+    use rusqlite::Connection;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
@@ -175,7 +315,127 @@ mod tests {
         let _ = fs::remove_dir_all(temp_root);
     }
 
+    #[test]
+    fn library_scope_requires_existing_non_root_directory() {
+        let temp_root = temp_dir("library_scope");
+        let library_dir = temp_root.join("library");
+        let file_path = temp_root.join("file.txt");
+        fs::create_dir_all(&library_dir).unwrap();
+        fs::write(&file_path, b"not a directory").unwrap();
+
+        assert_eq!(
+            validate_library_scope_directory(&library_dir.to_string_lossy()).unwrap(),
+            fs::canonicalize(&library_dir).unwrap()
+        );
+        assert!(validate_library_scope_directory("").is_err());
+        assert!(validate_library_scope_directory(&file_path.to_string_lossy()).is_err());
+        assert!(
+            validate_library_scope_directory(&temp_root.join("missing").to_string_lossy()).is_err()
+        );
+
+        let filesystem_root = temp_root.ancestors().last().unwrap();
+        assert!(validate_library_scope_directory(&filesystem_root.to_string_lossy()).is_err());
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn known_media_file_matches_images_and_removed_images_only() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE images (id TEXT, path TEXT)", [])
+            .unwrap();
+        conn.execute("CREATE TABLE removed_images (id TEXT, path TEXT)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO images (id, path) VALUES (?1, ?1)",
+            ["C:/library/kept.png"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO removed_images (id, path) VALUES (?1, ?1)",
+            ["C:/library/removed.png"],
+        )
+        .unwrap();
+
+        assert!(path_is_known_media_file(
+            &conn,
+            "C:\\library\\kept.png",
+            Path::new("C:/other/alias.png")
+        )
+        .unwrap());
+        assert!(path_is_known_media_file(
+            &conn,
+            "C:/library/removed.png",
+            Path::new("C:/other/alias.png")
+        )
+        .unwrap());
+        assert!(!path_is_known_media_file(
+            &conn,
+            "C:/library/untracked.png",
+            Path::new("C:/library/untracked.png")
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn thumbnail_delete_only_allows_direct_app_webp_thumbnails() {
+        let app_data = temp_dir("thumbnail_scope");
+        let thumbnail_dir = app_data.join(".thumbnails");
+        let nested_dir = thumbnail_dir.join("nested");
+        let external_dir = app_data.join("external");
+        fs::create_dir_all(&nested_dir).unwrap();
+        fs::create_dir_all(&external_dir).unwrap();
+
+        let valid = thumbnail_dir.join("thumb.webp");
+        let nested = nested_dir.join("thumb.webp");
+        let wrong_ext = thumbnail_dir.join("thumb.png");
+        let external = external_dir.join("thumb.webp");
+        fs::write(&valid, b"webp").unwrap();
+        fs::write(&nested, b"webp").unwrap();
+        fs::write(&wrong_ext, b"png").unwrap();
+        fs::write(&external, b"webp").unwrap();
+
+        assert_eq!(
+            resolve_eligible_thumbnail_file(&valid.to_string_lossy(), &thumbnail_dir).unwrap(),
+            Some(fs::canonicalize(&valid).unwrap())
+        );
+        assert_eq!(
+            resolve_eligible_thumbnail_file(&nested.to_string_lossy(), &thumbnail_dir).unwrap(),
+            None
+        );
+        assert_eq!(
+            resolve_eligible_thumbnail_file(&wrong_ext.to_string_lossy(), &thumbnail_dir).unwrap(),
+            None
+        );
+        assert_eq!(
+            resolve_eligible_thumbnail_file(&external.to_string_lossy(), &thumbnail_dir).unwrap(),
+            None
+        );
+        assert_eq!(
+            resolve_eligible_thumbnail_file(
+                &thumbnail_dir.join("missing.webp").to_string_lossy(),
+                &thumbnail_dir
+            )
+            .unwrap(),
+            None
+        );
+
+        let _ = fs::remove_dir_all(app_data);
+    }
+
     fn normalize(path: PathBuf) -> String {
         path.to_string_lossy().replace('\\', "/")
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ambit_fs_commands_{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
     }
 }

--- a/src/components/ui/OnboardingWizard.tsx
+++ b/src/components/ui/OnboardingWizard.tsx
@@ -7,6 +7,7 @@ import { APP_NAME } from '../../constants/app';
 import { useToast } from '../../hooks/useToast';
 import { ApiKeyInput } from './ApiKeyInput';
 import { useSettingsStore } from '../../stores/settingsStore';
+import { GOOGLE_AI_STUDIO_API_KEY_URL, openExternalUrl } from '../../utils/externalLinks';
 
 interface OnboardingWizardProps {
     isOpen: boolean;
@@ -282,9 +283,13 @@ export const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
                                         >
                                             <div className="flex justify-between items-end">
                                                 <label className="text-xs font-bold text-gray-500 uppercase tracking-widest">Gemini API Key</label>
-                                                <a href="https://aistudio.google.com/app/apikey" target="_blank" rel="noreferrer" className="text-xs text-sage-500 hover:text-sage-400 font-bold flex items-center gap-1 transition-colors">
+                                                <button
+                                                    type="button"
+                                                    onClick={() => openExternalUrl(GOOGLE_AI_STUDIO_API_KEY_URL)}
+                                                    className="text-xs text-sage-500 hover:text-sage-400 font-bold flex items-center gap-1 transition-colors"
+                                                >
                                                     Get Free Key <ChevronRight className="w-3 h-3" />
-                                                </a>
+                                                </button>
                                             </div>
 
                                             <ApiKeyInput

--- a/src/features/settings/components/IntelligenceTab.tsx
+++ b/src/features/settings/components/IntelligenceTab.tsx
@@ -5,7 +5,7 @@ import { useToast } from '../../../hooks/useToast';
 import { AI_MODELS, DEFAULT_AI_MODEL } from '../../../constants/aiModels';
 import { ApiKeyInput } from '../../../components/ui/ApiKeyInput';
 import { useSettingsStore } from '../../../stores/settingsStore';
-import { openExternalUrl } from '../../../utils/externalLinks';
+import { GOOGLE_AI_STUDIO_API_KEY_URL, openExternalUrl } from '../../../utils/externalLinks';
 
 interface TabProps {
     settings: AppSettings;
@@ -170,7 +170,7 @@ export const IntelligenceTab: React.FC<TabProps> = React.memo(({ settings, setSe
                                 Your key is stored locally. Get one at{' '}
                                 <button
                                     type="button"
-                                    onClick={() => openExternalUrl('https://aistudio.google.com/app/apikey')}
+                                    onClick={() => openExternalUrl(GOOGLE_AI_STUDIO_API_KEY_URL)}
                                     className="text-sage-600 hover:underline"
                                 >
                                     Google AI Studio

--- a/src/features/viewer/components/AIResultModal.tsx
+++ b/src/features/viewer/components/AIResultModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { X, Wand2, Shuffle, Copy, Check, Sparkles, LayoutPanelLeft, Lightbulb, ChevronLeft, ChevronRight } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '../../../utils/cn';
 
@@ -159,12 +159,7 @@ export const AIResultModal: React.FC<AIResultModalProps> = ({
                                             <div className="bg-gray-50 dark:bg-white/[0.02] rounded-xl border border-gray-100 dark:border-white/5 p-5">
                                                 <div className="prose prose-sm dark:prose-invert max-w-none text-gray-600 dark:text-gray-300 leading-relaxed">
                                                     <ReactMarkdown
-                                                        components={{
-                                                            h3: () => null,
-                                                            p: ({ node, ...props }) => <p {...props} className="mb-3 last:mb-0 text-sm" />,
-                                                            strong: ({ node, ...props }) => <strong {...props} className="text-gray-800 dark:text-white font-semibold" />,
-                                                            em: ({ node, ...props }) => <em {...props} className="text-amethyst-600 dark:text-amethyst-400 not-italic font-medium" />
-                                                        }}
+                                                        components={safeMarkdownComponents}
                                                     >
                                                         {analysisText}
                                                     </ReactMarkdown>
@@ -264,6 +259,15 @@ const MasteredPromptCard: React.FC<{ prompt: string; onCopy: (text: string) => v
             </p>
         </div>
     );
+};
+
+const safeMarkdownComponents: Components = {
+    h3: () => null,
+    p: ({ children }) => <p className="mb-3 last:mb-0 text-sm">{children}</p>,
+    strong: ({ children }) => <strong className="text-gray-800 dark:text-white font-semibold">{children}</strong>,
+    em: ({ children }) => <em className="text-amethyst-600 dark:text-amethyst-400 not-italic font-medium">{children}</em>,
+    a: ({ children }) => <span>{children}</span>,
+    img: () => null,
 };
 
 /* Variation Display Component (for tabbed view) */

--- a/src/features/viewer/components/ImageViewer.tsx
+++ b/src/features/viewer/components/ImageViewer.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useEffect, useState, useRef, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { X, Share2, Minimize2, Maximize2, Heart, Trash2, PanelRightClose, PanelRightOpen, Copy, Wand2, Shuffle, Layers, ArrowRight, Layout, ExternalLink } from 'lucide-react';
-import ReactMarkdown from 'react-markdown';
 import { AIImage, GeneratorTool } from '../../../types';
 import { useZoomPan } from '../../../hooks/useZoomPan';
 import { ImageCanvas } from './ImageCanvas';

--- a/src/features/viewer/components/__tests__/AIResultModal.test.tsx
+++ b/src/features/viewer/components/__tests__/AIResultModal.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '../../../../test/testUtils';
+import { AIResultModal } from '../AIResultModal';
+
+describe('AIResultModal', () => {
+    it('renders AI markdown links as inert text and drops markdown images', () => {
+        render(
+            <AIResultModal
+                isOpen
+                onClose={vi.fn()}
+                type="analysis"
+                content={'### Analysis\n[unsafe link](javascript:alert(1))\n\n![remote](https://evil.example/pixel.png)\n\n**Safe** text'}
+                onCopy={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText('unsafe link')).toBeTruthy();
+        expect(screen.getByText('Safe')).toBeTruthy();
+        expect(document.querySelector('a')).toBeNull();
+        expect(document.querySelector('img[src="https://evil.example/pixel.png"]')).toBeNull();
+    });
+});

--- a/src/services/db/__tests__/imageRepo.test.ts
+++ b/src/services/db/__tests__/imageRepo.test.ts
@@ -271,4 +271,27 @@ describe('imageRepo batch removal', () => {
         expect(Math.max(...allExecuteParamCounts)).toBeLessThanOrEqual(900);
         expect(removedRows.get(ids[0])?.collectionIdsJson).toBe(JSON.stringify(['collection-a']));
     });
+
+    it('skips thumbnail trashing when the thumbnail path is the source image path', async () => {
+        const db = {
+            select: vi.fn(),
+            execute: vi.fn(),
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { commands } = await import('../../../bindings');
+        vi.mocked(commands.moveToTrash).mockResolvedValue({ status: 'ok', data: null });
+        vi.mocked(commands.deleteThumbnail).mockResolvedValue({ status: 'ok', data: null });
+
+        const { deleteImageFromDisk, shouldTrashThumbnail } = await import('../imageRepo');
+
+        expect(shouldTrashThumbnail('C:/images/source.png', 'C:\\images\\source.png')).toBe(false);
+        expect(shouldTrashThumbnail('C:/images/source.png', 'C:/thumbs/source.webp')).toBe(true);
+
+        await deleteImageFromDisk('C:/images/source.png', 'C:/images/source.png', 'C:\\images\\source.png');
+
+        expect(commands.moveToTrash).toHaveBeenCalledWith('C:/images/source.png');
+        expect(commands.deleteThumbnail).not.toHaveBeenCalled();
+        expect(db.execute).toHaveBeenCalledWith('DELETE FROM images WHERE id = $1', ['C:/images/source.png']);
+    });
 });

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -56,6 +56,19 @@ const chunkItems = <T>(items: T[], chunkSize = SQLITE_PARAM_CHUNK_SIZE): T[][] =
     return chunks;
 };
 
+export const shouldTrashThumbnail = (
+    imagePath: string | null | undefined,
+    thumbnailPath: string | null | undefined
+): boolean => {
+    if (!thumbnailPath) return false;
+    if (!imagePath) return true;
+
+    const normalizedImagePath = normalizePath(urlToPath(imagePath) || imagePath);
+    const normalizedThumbnailPath = normalizePath(urlToPath(thumbnailPath) || thumbnailPath);
+
+    return normalizedImagePath.toLowerCase() !== normalizedThumbnailPath.toLowerCase();
+};
+
 const buildPersistableImageRecord = (image: AIImage): PersistableImageRecord => ({
     id: normalizePath(image.id),
     path: normalizePath(image.id),
@@ -861,7 +874,7 @@ export const deleteImageFromDisk = async (id: string, path: string, thumbnailPat
     }
 
     // 2. Trash Thumbnail
-    if (thumbnailPath) {
+    if (shouldTrashThumbnail(path, thumbnailPath)) {
         try {
             await unwrap(commands.deleteThumbnail(thumbnailPath));
         } catch (e) {
@@ -915,7 +928,7 @@ export const deleteRemovedImagesFromDisk = async (ids: string[]): Promise<Delete
                 }
             }
 
-            if (row.thumbnail_path) {
+            if (shouldTrashThumbnail(row.path, row.thumbnail_path)) {
                 try {
                     await unwrap(commands.deleteThumbnail(row.thumbnail_path));
                 } catch (e) {

--- a/src/utils/__tests__/externalLinks.test.ts
+++ b/src/utils/__tests__/externalLinks.test.ts
@@ -1,0 +1,50 @@
+import { open } from '@tauri-apps/plugin-shell';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+    GOOGLE_AI_STUDIO_API_KEY_URL,
+    isAllowedExternalUrl,
+    openExternalUrl,
+} from '../externalLinks';
+
+describe('externalLinks', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.spyOn(window, 'open').mockImplementation(() => null);
+    });
+
+    it('opens allowlisted HTTPS URLs through Tauri shell first', async () => {
+        await openExternalUrl('https://github.com/AsuraAce/ambit/issues');
+
+        expect(open).toHaveBeenCalledWith('https://github.com/AsuraAce/ambit/issues');
+        expect(window.open).not.toHaveBeenCalled();
+    });
+
+    it('falls back to window.open only for allowlisted URLs after Tauri shell fails', async () => {
+        vi.mocked(open).mockRejectedValueOnce(new Error('shell unavailable'));
+
+        await openExternalUrl(GOOGLE_AI_STUDIO_API_KEY_URL);
+
+        expect(open).toHaveBeenCalledWith(GOOGLE_AI_STUDIO_API_KEY_URL);
+        expect(window.open).toHaveBeenCalledWith(
+            GOOGLE_AI_STUDIO_API_KEY_URL,
+            '_blank',
+            'noopener,noreferrer'
+        );
+    });
+
+    it.each([
+        'javascript:alert(1)',
+        'data:text/html,<script>alert(1)</script>',
+        'file:///C:/Windows/System32/calc.exe',
+        'http://github.com/AsuraAce/ambit',
+        'https://evil.example/ambit',
+        'https://user:pass@github.com/AsuraAce/ambit',
+        'https://github.com/AsuraAce/ambit?tab=readme',
+    ])('rejects disallowed external URL %s', async (url) => {
+        await expect(openExternalUrl(url)).rejects.toThrow('External URL is not allowed');
+
+        expect(open).not.toHaveBeenCalled();
+        expect(window.open).not.toHaveBeenCalled();
+        expect(isAllowedExternalUrl(url)).toBe(false);
+    });
+});

--- a/src/utils/externalLinks.ts
+++ b/src/utils/externalLinks.ts
@@ -1,11 +1,56 @@
-export const openExternalUrl = async (url: string): Promise<void> => {
+import {
+    GITHUB_SPONSORS_URL,
+    ISSUES_URL,
+    KO_FI_URL,
+    RELEASES_URL,
+    REPOSITORY_URL,
+} from '../constants/support';
+
+export const GOOGLE_AI_STUDIO_API_KEY_URL = 'https://aistudio.google.com/app/apikey';
+
+const normalizeAllowedExternalUrl = (value: string): string | null => {
     try {
-        const { open } = await import('@tauri-apps/plugin-shell');
-        await open(url);
-        return;
-    } catch (error) {
-        console.error('Failed to open external URL via Tauri shell:', error);
+        const parsed = new URL(value);
+
+        if (parsed.protocol !== 'https:') return null;
+        if (parsed.username || parsed.password) return null;
+        if (parsed.search || parsed.hash) return null;
+
+        return parsed.href.replace(/\/$/, '');
+    } catch {
+        return null;
+    }
+};
+
+const allowedExternalUrls = new Set(
+    [
+        REPOSITORY_URL,
+        ISSUES_URL,
+        RELEASES_URL,
+        GITHUB_SPONSORS_URL,
+        KO_FI_URL,
+        GOOGLE_AI_STUDIO_API_KEY_URL,
+    ].map((url) => normalizeAllowedExternalUrl(url)).filter((url): url is string => !!url)
+);
+
+export const isAllowedExternalUrl = (url: string): boolean => {
+    const normalized = normalizeAllowedExternalUrl(url);
+    return !!normalized && allowedExternalUrls.has(normalized);
+};
+
+export const openExternalUrl = async (url: string): Promise<void> => {
+    const normalizedUrl = normalizeAllowedExternalUrl(url);
+    if (!normalizedUrl || !allowedExternalUrls.has(normalizedUrl)) {
+        throw new Error(`External URL is not allowed: ${url}`);
     }
 
-    window.open(url, '_blank', 'noopener,noreferrer');
+    try {
+        const { open } = await import('@tauri-apps/plugin-shell');
+        await open(normalizedUrl);
+        return;
+    } catch {
+        // Browser mock mode has no Tauri shell bridge; fall back only after allowlist validation.
+    }
+
+    window.open(normalizedUrl, '_blank', 'noopener,noreferrer');
 };


### PR DESCRIPTION
## Summary
- Harden Tauri path scope registration and destructive file commands around canonical paths, known Ambit media, and app-local thumbnail scope.
- Replace string-built SQLite backup SQL with bound `VACUUM INTO ?1`, share manual/auto backup creation, and avoid timestamp collisions.
- Treat AI Markdown as text-first content, centralize external URL allowlisting, and route onboarding/settings links through the same helper.

## Validation
- `pnpm run bindings:generate` (no `src/bindings.ts` changes)
- `pnpm run bindings:check`
- `pnpm run typecheck`
- `pnpm run test:run`
- `pnpm run test:rust`
- `pnpm audit --prod`
- `pnpm run audit:rust`
- `pnpm run verify:release`
- Browser smoke at `http://127.0.0.1:1421/`: app loaded, no framework overlay, GitHub external-link control resolved uniquely, and the allowlisted fallback added no new console error after the logging fix.

## Notes
- `RUSTSEC-2023-0071` remains handled by the existing ignored-advisory policy for the optional `sqlx-mysql` path.
- The 23 remaining Rust advisory warnings remain tracked as non-blocking upstream dependency debt in issue #51.