### PR TITLE
fix: harden os open path provenance

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -130,10 +130,22 @@
       "identifier": "shell:allow-open",
       "allow": [
         {
-          "href": "https?://**"
+          "href": "https://github.com/AsuraAce/ambit"
         },
         {
-          "href": "mailto:**"
+          "href": "https://github.com/AsuraAce/ambit/issues"
+        },
+        {
+          "href": "https://github.com/AsuraAce/ambit/releases"
+        },
+        {
+          "href": "https://github.com/sponsors/AsuraAce"
+        },
+        {
+          "href": "https://ko-fi.com/astraoriondev"
+        },
+        {
+          "href": "https://aistudio.google.com/app/apikey"
         }
       ]
     }

--- a/src-tauri/src/scanner/mod.rs
+++ b/src-tauri/src/scanner/mod.rs
@@ -193,14 +193,18 @@ pub async fn scan_directory_recursive(path: String) -> Result<Vec<String>, Strin
 
 #[tauri::command]
 #[specta::specta]
-pub async fn open_file(path: String) -> Result<(), String> {
-    utils::open_file_impl(path)
+pub async fn open_file(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || utils::open_file_impl(&app, path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
 #[specta::specta]
-pub async fn show_in_folder(path: String) -> Result<(), String> {
-    utils::show_in_folder_impl(path)
+pub async fn show_in_folder(app: tauri::AppHandle, path: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || utils::show_in_folder_impl(&app, path))
+        .await
+        .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]

--- a/src-tauri/src/scanner/utils.rs
+++ b/src-tauri/src/scanner/utils.rs
@@ -1,5 +1,8 @@
+use crate::db::{configure_connection, resolve_db_path};
 use rayon::prelude::*;
-use std::path::Path;
+use rusqlite::{params, Connection};
+use std::fs;
+use std::path::{Path, PathBuf};
 
 pub fn verify_image_paths_impl(paths: Vec<String>) -> Vec<String> {
     paths
@@ -18,17 +21,29 @@ pub fn get_file_sizes_bulk_impl(paths: Vec<String>) -> Vec<u64> {
     sizes
 }
 
-pub fn open_file_impl(path: String) -> Result<(), String> {
-    let path_obj = Path::new(&path);
-    if !path_obj.exists() {
-        return Err("File not found".to_string());
+pub fn open_file_impl(app: &tauri::AppHandle, path: String) -> Result<(), String> {
+    let conn = open_configured_app_db(app)?;
+    let target = resolve_known_media_file_target(&conn, &path)?;
+    open_file_path(&target)
+}
+
+pub fn show_in_folder_impl(app: &tauri::AppHandle, path: String) -> Result<(), String> {
+    let backup_dir = resolve_backup_dir_path(app)?;
+    let (canonical_file, is_backup_file) = resolve_existing_show_target(&path, &backup_dir)?;
+    if is_backup_file {
+        return show_path_in_folder(&canonical_file);
     }
 
+    let conn = open_configured_app_db(app)?;
+    let target = resolve_known_media_show_target(&conn, &path, canonical_file)?;
+    show_path_in_folder(&target)
+}
+
+fn open_file_path(path: &Path) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        let windows_path = path.replace("/", "\\");
         std::process::Command::new("explorer")
-            .arg(&windows_path)
+            .arg(path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
@@ -52,17 +67,12 @@ pub fn open_file_impl(path: String) -> Result<(), String> {
     Ok(())
 }
 
-pub fn show_in_folder_impl(path: String) -> Result<(), String> {
-    let path_obj = Path::new(&path);
-    if !path_obj.exists() {
-        return Err("File not found".to_string());
-    }
-
+fn show_path_in_folder(path: &Path) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        let windows_path = path.replace("/", "\\");
         std::process::Command::new("explorer")
-            .args(["/select,", &windows_path])
+            .arg("/select,")
+            .arg(path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
@@ -78,7 +88,7 @@ pub fn show_in_folder_impl(path: String) -> Result<(), String> {
 
     #[cfg(target_os = "linux")]
     {
-        let parent = path_obj.parent().ok_or("No parent directory")?;
+        let parent = path.parent().ok_or("No parent directory")?;
         std::process::Command::new("xdg-open")
             .arg(parent)
             .spawn()
@@ -86,4 +96,312 @@ pub fn show_in_folder_impl(path: String) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+fn resolve_known_media_file_target(conn: &Connection, path: &str) -> Result<PathBuf, String> {
+    let canonical_file = resolve_existing_regular_file(path)?;
+    if !path_is_known_media_file(conn, path, &canonical_file)? {
+        return Err("Refusing to open an untracked file".to_string());
+    }
+
+    Ok(canonical_file)
+}
+
+fn resolve_existing_regular_file(path: &str) -> Result<PathBuf, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Path cannot be empty".to_string());
+    }
+
+    let candidate = PathBuf::from(trimmed);
+    if is_filesystem_root(&candidate) {
+        return Err("Refusing to open a filesystem root".to_string());
+    }
+
+    let metadata =
+        fs::symlink_metadata(&candidate).map_err(|e| format!("Failed to inspect path: {}", e))?;
+    if !metadata.is_file() {
+        return Err("Path must be an existing regular file".to_string());
+    }
+
+    fs::canonicalize(candidate).map_err(|e| format!("Failed to resolve file path: {}", e))
+}
+
+fn is_filesystem_root(path: &Path) -> bool {
+    path.parent().is_none()
+}
+
+fn open_configured_app_db(app: &tauri::AppHandle) -> Result<Connection, String> {
+    let db_path = resolve_db_path(app)?;
+    let conn = Connection::open(db_path).map_err(|e| e.to_string())?;
+    configure_connection(&conn).map_err(|e| e.to_string())?;
+    Ok(conn)
+}
+
+fn path_is_known_media_file(
+    conn: &Connection,
+    requested_path: &str,
+    canonical_path: &Path,
+) -> Result<bool, String> {
+    let requested = normalize_path_string(requested_path);
+    let canonical = normalize_path_for_frontend(canonical_path);
+
+    let is_known: i64 = conn
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM images
+                WHERE id IN (?1, ?2) OR path IN (?1, ?2)
+                UNION ALL
+                SELECT 1 FROM removed_images
+                WHERE id IN (?1, ?2) OR path IN (?1, ?2)
+            )",
+            params![requested, canonical],
+            |row| row.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+
+    Ok(is_known != 0)
+}
+
+fn resolve_backup_dir_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    let db_path = resolve_db_path(app)?;
+    let parent = db_path
+        .parent()
+        .ok_or_else(|| "Failed to get DB parent directory".to_string())?;
+
+    Ok(parent.join("backups"))
+}
+
+fn is_app_backup_file(path: &Path, backup_dir: &Path) -> Result<bool, String> {
+    if !path
+        .extension()
+        .is_some_and(|ext| ext.to_string_lossy().eq_ignore_ascii_case("db"))
+    {
+        return Ok(false);
+    }
+
+    let canonical_file =
+        fs::canonicalize(path).map_err(|e| format!("Failed to resolve backup path: {}", e))?;
+    let canonical_dir = match fs::canonicalize(backup_dir) {
+        Ok(dir) => dir,
+        Err(_) => return Ok(false),
+    };
+
+    Ok(canonical_file.parent() == Some(canonical_dir.as_path()))
+}
+
+fn resolve_existing_show_target(path: &str, backup_dir: &Path) -> Result<(PathBuf, bool), String> {
+    let canonical_file = resolve_existing_regular_file(path)?;
+    let is_backup_file = is_app_backup_file(&canonical_file, backup_dir)?;
+
+    Ok((canonical_file, is_backup_file))
+}
+
+fn resolve_known_media_show_target(
+    conn: &Connection,
+    path: &str,
+    canonical_file: PathBuf,
+) -> Result<PathBuf, String> {
+    if path_is_known_media_file(conn, path, &canonical_file)? {
+        return Ok(canonical_file);
+    }
+
+    Err("Refusing to reveal an untracked file".to_string())
+}
+
+#[cfg(test)]
+fn resolve_show_in_folder_target(
+    conn: &Connection,
+    path: &str,
+    backup_dir: &Path,
+) -> Result<PathBuf, String> {
+    let (canonical_file, is_backup_file) = resolve_existing_show_target(path, backup_dir)?;
+    if is_backup_file {
+        return Ok(canonical_file);
+    }
+
+    resolve_known_media_show_target(conn, path, canonical_file)
+}
+
+fn normalize_path_for_frontend(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn normalize_path_string(path: &str) -> String {
+    path.trim().replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_existing_regular_file, resolve_existing_show_target,
+        resolve_known_media_file_target, resolve_show_in_folder_target,
+    };
+    use rusqlite::Connection;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn os_open_media_targets_require_known_regular_files() {
+        let temp_root = temp_dir("media_targets");
+        fs::create_dir_all(&temp_root).unwrap();
+        let image = temp_root.join("image.png");
+        let removed = temp_root.join("removed.png");
+        let untracked = temp_root.join("untracked.png");
+        let directory = temp_root.join("directory");
+        fs::write(&image, b"image").unwrap();
+        fs::write(&removed, b"removed").unwrap();
+        fs::write(&untracked, b"untracked").unwrap();
+        fs::create_dir_all(&directory).unwrap();
+
+        let conn = media_db();
+        let image_path = normalize(&fs::canonicalize(&image).unwrap());
+        let removed_path = normalize(&fs::canonicalize(&removed).unwrap());
+        conn.execute(
+            "INSERT INTO images (id, path) VALUES (?1, ?1)",
+            [&image_path],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO removed_images (id, path) VALUES (?1, ?1)",
+            [&removed_path],
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_known_media_file_target(&conn, &image.to_string_lossy()).unwrap(),
+            fs::canonicalize(&image).unwrap()
+        );
+        assert_eq!(
+            resolve_known_media_file_target(&conn, &removed.to_string_lossy()).unwrap(),
+            fs::canonicalize(&removed).unwrap()
+        );
+        assert!(resolve_known_media_file_target(&conn, &untracked.to_string_lossy()).is_err());
+        assert!(resolve_known_media_file_target(&conn, &directory.to_string_lossy()).is_err());
+        assert!(resolve_known_media_file_target(&conn, "").is_err());
+        assert!(resolve_known_media_file_target(
+            &conn,
+            &temp_root.join("missing.png").to_string_lossy()
+        )
+        .is_err());
+
+        let filesystem_root = temp_root.ancestors().last().unwrap();
+        assert!(resolve_existing_regular_file(&filesystem_root.to_string_lossy()).is_err());
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn show_in_folder_allows_known_media_and_direct_app_backups() {
+        let temp_root = temp_dir("show_targets");
+        let backup_dir = temp_root.join("backups");
+        let external_dir = temp_root.join("external");
+        let nested_dir = backup_dir.join("nested");
+        fs::create_dir_all(&backup_dir).unwrap();
+        fs::create_dir_all(&external_dir).unwrap();
+        fs::create_dir_all(&nested_dir).unwrap();
+
+        let image = temp_root.join("image.png");
+        let removed = temp_root.join("removed.png");
+        let backup = backup_dir.join("images.db");
+        let external_backup = external_dir.join("images.db");
+        let nested_backup = nested_dir.join("images.db");
+        let wrong_ext_backup = backup_dir.join("images.sqlite");
+        fs::write(&image, b"image").unwrap();
+        fs::write(&removed, b"removed").unwrap();
+        fs::write(&backup, b"backup").unwrap();
+        fs::write(&external_backup, b"outside").unwrap();
+        fs::write(&nested_backup, b"nested").unwrap();
+        fs::write(&wrong_ext_backup, b"wrong ext").unwrap();
+
+        let conn = media_db();
+        let image_path = normalize(&fs::canonicalize(&image).unwrap());
+        let removed_path = normalize(&fs::canonicalize(&removed).unwrap());
+        conn.execute(
+            "INSERT INTO images (id, path) VALUES (?1, ?1)",
+            [&image_path],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO removed_images (id, path) VALUES (?1, ?1)",
+            [&removed_path],
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_show_in_folder_target(&conn, &image.to_string_lossy(), &backup_dir).unwrap(),
+            fs::canonicalize(&image).unwrap()
+        );
+        assert_eq!(
+            resolve_show_in_folder_target(&conn, &removed.to_string_lossy(), &backup_dir).unwrap(),
+            fs::canonicalize(&removed).unwrap()
+        );
+        assert_eq!(
+            resolve_show_in_folder_target(&conn, &backup.to_string_lossy(), &backup_dir).unwrap(),
+            fs::canonicalize(&backup).unwrap()
+        );
+        assert!(resolve_show_in_folder_target(
+            &conn,
+            &external_backup.to_string_lossy(),
+            &backup_dir
+        )
+        .is_err());
+        assert!(resolve_show_in_folder_target(
+            &conn,
+            &nested_backup.to_string_lossy(),
+            &backup_dir
+        )
+        .is_err());
+        assert!(resolve_show_in_folder_target(
+            &conn,
+            &wrong_ext_backup.to_string_lossy(),
+            &backup_dir
+        )
+        .is_err());
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    #[test]
+    fn direct_backup_show_target_resolves_without_media_db() {
+        let temp_root = temp_dir("backup_without_db");
+        let backup_dir = temp_root.join("backups");
+        fs::create_dir_all(&backup_dir).unwrap();
+        let backup = backup_dir.join("images.db");
+        fs::write(&backup, b"backup").unwrap();
+
+        let (target, is_backup_file) =
+            resolve_existing_show_target(&backup.to_string_lossy(), &backup_dir).unwrap();
+
+        assert_eq!(target, fs::canonicalize(&backup).unwrap());
+        assert!(is_backup_file);
+
+        let _ = fs::remove_dir_all(temp_root);
+    }
+
+    fn media_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute("CREATE TABLE images (id TEXT, path TEXT)", [])
+            .unwrap();
+        conn.execute("CREATE TABLE removed_images (id TEXT, path TEXT)", [])
+            .unwrap();
+        conn
+    }
+
+    fn normalize(path: &Path) -> String {
+        path.to_string_lossy().replace('\\', "/")
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ambit_scanner_utils_{}_{}_{}",
+            name,
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
 }

--- a/src/components/ui/AppContextMenu.tsx
+++ b/src/components/ui/AppContextMenu.tsx
@@ -8,6 +8,7 @@ import { useSearchStore } from '../../stores/searchStore';
 import { AIImage, ContextMenuState } from '../../types';
 import { useQueryClient } from '@tanstack/react-query';
 import { isBrowserMockMode } from '../../services/runtime';
+import { isOsOpenUnavailable, openFileInDefaultApp, showPathInFolder } from '../../services/osOpen';
 
 interface AppContextMenuProps {
     contextMenu: ContextMenuState | null;
@@ -167,26 +168,25 @@ export const AppContextMenu: React.FC<AppContextMenuProps> = ({
                 onClose();
             }}
             onShowInFolder={async () => {
-                if (browserMockMode) {
-                    addToast('Unavailable in browser mock mode.', 'info');
-                    onClose();
-                    return;
-                }
                 const id = contextMenu.imageId;
-                const { invoke } = await import('@tauri-apps/api/core');
-                await invoke('show_in_folder', { path: id });
-                addToast('Opening folder...', 'info');
+                if (id) {
+                    const result = await showPathInFolder(id);
+                    if (result.status === 'ok') {
+                        addToast('Opening folder...', 'info');
+                    } else {
+                        addToast(result.error, isOsOpenUnavailable(result.error) ? 'info' : 'error');
+                    }
+                }
                 onClose();
             }}
             onOpenInDefaultApp={async () => {
-                if (browserMockMode) {
-                    addToast('Unavailable in browser mock mode.', 'info');
-                    onClose();
-                    return;
-                }
                 const id = contextMenu.imageId;
-                const { invoke } = await import('@tauri-apps/api/core');
-                await invoke('open_file', { path: id });
+                if (id) {
+                    const result = await openFileInDefaultApp(id);
+                    if (result.status === 'error') {
+                        addToast(result.error, isOsOpenUnavailable(result.error) ? 'info' : 'error');
+                    }
+                }
                 onClose();
             }}
             onSetThumbnail={filters.collectionId && activeImage ? async () => {

--- a/src/features/settings/components/BackupSettings.tsx
+++ b/src/features/settings/components/BackupSettings.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Database, FolderOpen, RefreshCw, FileClock, AlertCircle } from 'lucide-react';
 import { commands, BackupInfo } from '../../../bindings';
 import { useToast } from '../../../hooks/useToast';
+import { isOsOpenUnavailable, showPathInFolder } from '../../../services/osOpen';
 
 export const BackupSettings: React.FC = () => {
     const [backups, setBackups] = React.useState<BackupInfo[]>([]);
@@ -40,7 +41,12 @@ export const BackupSettings: React.FC = () => {
 
     const handleOpenFolder = async () => {
         if (backups.length > 0) {
-            await commands.showInFolder(backups[0].path);
+            const result = await showPathInFolder(backups[0].path);
+            if (result.status === 'ok') {
+                addToast('Opening backup folder...', 'info');
+            } else {
+                addToast(result.error, isOsOpenUnavailable(result.error) ? 'info' : 'error');
+            }
         } else {
             addToast('No backups exist yet to show folder', 'info');
         }

--- a/src/features/viewer/components/ImageViewer.tsx
+++ b/src/features/viewer/components/ImageViewer.tsx
@@ -15,6 +15,7 @@ import { getFilename } from '../../../utils/pathUtils';
 import { getImageWithFullMetadata } from '../../../services/db/imageRepo';
 import { useToast } from '../../../hooks/useToast';
 import type { PromptHighlightSpec } from '../utils/searchHighlights';
+import { isOsOpenUnavailable, openFileInDefaultApp } from '../../../services/osOpen';
 
 interface ImageViewerProps {
     image: AIImage;
@@ -224,8 +225,10 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
     };
 
     const handleOpenExternal = async () => {
-        const { invoke } = await import('@tauri-apps/api/core');
-        await invoke('open_file', { path: displayImage.id });
+        const result = await openFileInDefaultApp(displayImage.id);
+        if (result.status === 'error') {
+            addToast(result.error, isOsOpenUnavailable(result.error) ? 'info' : 'error');
+        }
     };
 
     const handleShare = () => {

--- a/src/services/__tests__/osOpen.test.ts
+++ b/src/services/__tests__/osOpen.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    isBrowserMockMode: vi.fn(),
+    openFile: vi.fn(),
+    showInFolder: vi.fn(),
+}));
+
+vi.mock('../runtime', () => ({
+    isBrowserMockMode: mocks.isBrowserMockMode,
+}));
+
+vi.mock('../../bindings', () => ({
+    commands: {
+        openFile: mocks.openFile,
+        showInFolder: mocks.showInFolder,
+    },
+}));
+
+describe('osOpen helpers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.isBrowserMockMode.mockReturnValue(false);
+    });
+
+    it('opens files through generated commands outside browser mock mode', async () => {
+        mocks.openFile.mockResolvedValue({ status: 'ok', data: null });
+
+        const { openFileInDefaultApp } = await import('../osOpen');
+        await expect(openFileInDefaultApp('C:/library/image.png')).resolves.toEqual({
+            status: 'ok',
+            data: null,
+        });
+
+        expect(mocks.openFile).toHaveBeenCalledWith('C:/library/image.png');
+    });
+
+    it('shows paths in folders through generated commands outside browser mock mode', async () => {
+        mocks.showInFolder.mockResolvedValue({ status: 'ok', data: null });
+
+        const { showPathInFolder } = await import('../osOpen');
+        await expect(showPathInFolder('C:/library/image.png')).resolves.toEqual({
+            status: 'ok',
+            data: null,
+        });
+
+        expect(mocks.showInFolder).toHaveBeenCalledWith('C:/library/image.png');
+    });
+
+    it('does not call Tauri commands in browser mock mode', async () => {
+        mocks.isBrowserMockMode.mockReturnValue(true);
+
+        const { openFileInDefaultApp, showPathInFolder, OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE } = await import('../osOpen');
+        await expect(openFileInDefaultApp('C:/library/image.png')).resolves.toEqual({
+            status: 'error',
+            error: OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE,
+        });
+        await expect(showPathInFolder('C:/library/image.png')).resolves.toEqual({
+            status: 'error',
+            error: OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE,
+        });
+
+        expect(mocks.openFile).not.toHaveBeenCalled();
+        expect(mocks.showInFolder).not.toHaveBeenCalled();
+    });
+
+    it('returns backend rejection results without throwing', async () => {
+        mocks.openFile.mockResolvedValue({ status: 'error', error: 'Refusing to open an untracked file' });
+
+        const { openFileInDefaultApp } = await import('../osOpen');
+        await expect(openFileInDefaultApp('C:/library/untracked.png')).resolves.toEqual({
+            status: 'error',
+            error: 'Refusing to open an untracked file',
+        });
+    });
+
+    it('converts thrown command errors into error results', async () => {
+        mocks.showInFolder.mockRejectedValue(new Error('invoke failed'));
+
+        const { showPathInFolder } = await import('../osOpen');
+        await expect(showPathInFolder('C:/library/image.png')).resolves.toEqual({
+            status: 'error',
+            error: 'invoke failed',
+        });
+    });
+});

--- a/src/services/osOpen.ts
+++ b/src/services/osOpen.ts
@@ -1,0 +1,36 @@
+import { commands, type Result } from '../bindings';
+import { isBrowserMockMode } from './runtime';
+
+export const OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE = 'Unavailable in browser mock mode.';
+
+export const isOsOpenUnavailable = (error: string): boolean =>
+    error === OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE;
+
+export const openFileInDefaultApp = async (path: string): Promise<Result<null, string>> => {
+    if (isBrowserMockMode()) {
+        return { status: 'error', error: OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE };
+    }
+
+    return runOsOpenCommand(() => commands.openFile(path));
+};
+
+export const showPathInFolder = async (path: string): Promise<Result<null, string>> => {
+    if (isBrowserMockMode()) {
+        return { status: 'error', error: OS_OPEN_BROWSER_UNAVAILABLE_MESSAGE };
+    }
+
+    return runOsOpenCommand(() => commands.showInFolder(path));
+};
+
+const runOsOpenCommand = async (
+    command: () => Promise<Result<null, string>>
+): Promise<Result<null, string>> => {
+    try {
+        return await command();
+    } catch (error) {
+        return {
+            status: 'error',
+            error: error instanceof Error ? error.message : String(error),
+        };
+    }
+};


### PR DESCRIPTION
## Summary
- harden `open_file` and `show_in_folder` with Rust-side path provenance checks
- centralize frontend OS-open calls behind generated command helpers with browser mock fallback
- restrict Tauri shell-open permission to the existing external-link allowlist

## Details
- `open_file` now only opens existing regular files known through `images` or `removed_images`.
- `show_in_folder` now reveals known image files or direct app-local backup `.db` files inside the resolved backup directory.
- Backup reveal short-circuits before opening the active SQLite DB so the Settings recovery path still works if `images.db` is corrupt or unreadable.
- Browser mock mode returns an unavailable result and avoids invoking Tauri.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml --lib scanner::utils`
- `pnpm run typecheck`
- `pnpm run test:run`
- `pnpm run verify:release`
- Rendered mock-mode smoke: app load -> mock image viewer -> Open in Default App -> unavailable toast, no overlay, no new console warnings/errors