### PR TITLE
ci: harden release supply chain gates

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -6,6 +6,13 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   frontend-checks:
     name: frontend-checks
@@ -30,6 +37,9 @@ jobs:
 
       - name: install frontend dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: run production dependency audit
+        run: pnpm run audit:prod
 
       - name: typecheck
         run: pnpm exec tsc --noEmit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,9 +10,14 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: release-please-main
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Verify release automation prerequisites
         env:
@@ -34,4 +39,3 @@ jobs:
           # Using GITHUB_TOKEN for now. If user wants to trigger other workflows, 
           # they should provide a PAT as RELEASE_PLEASE_TOKEN or use a GitHub App token.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - "v*"
       - "ambit-v*"
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish-tauri:
     permissions:
@@ -16,6 +20,7 @@ jobs:
         platform: [windows-latest]
 
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -35,7 +40,10 @@ jobs:
           targets: ${{ matrix.platform == 'windows-latest' && 'x86_64-pc-windows-msvc' || '' }}
 
       - name: install frontend dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: run production dependency audit
+        run: pnpm run audit:prod
 
       - name: install cargo-audit
         run: cargo install cargo-audit --version 0.22.1 --locked
@@ -45,8 +53,8 @@ jobs:
       - name: run rust dependency advisory audit
         run: pnpm run audit:rust
 
-      - name: verify version consistency
-        run: pnpm check:versions
+      - name: verify release gate
+        run: pnpm run verify:release
 
       - name: verify updater signing configuration
         shell: bash

--- a/.github/workflows/updater-signing-preflight.yml
+++ b/.github/workflows/updater-signing-preflight.yml
@@ -6,10 +6,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: updater-signing-preflight
+  cancel-in-progress: false
+
 jobs:
   verify-updater-signing:
     name: Verify updater signing secret
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v4
@@ -25,7 +30,7 @@ jobs:
           version: 9
 
       - name: install frontend dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: verify updater signing secret
         shell: bash

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:versions": "node ./scripts/check-version-consistency.mjs",
     "typecheck": "tsc --noEmit",
     "verify:release": "pnpm run check:versions && pnpm run bindings:check && pnpm run typecheck && pnpm run test:run && pnpm run test:rust",
+    "audit:prod": "pnpm audit --prod",
     "audit:rust": "node ./scripts/audit-rust.mjs",
     "test": "vitest",
     "test:run": "vitest run",


### PR DESCRIPTION
## Summary
- Add `audit:prod` as the production dependency audit script.
- Run production dependency audits in PR CI and release packaging before build/signing.
- Use frozen pnpm installs in release and updater-signing preflight workflows.
- Add read-only default PR CI permissions plus workflow concurrency and job timeouts.
- Run `pnpm run verify:release` in the release workflow before Tauri artifacts are published.

## Validation
- `pnpm run audit:prod`
- `pnpm run audit:rust` (`0` unignored vulnerabilities; `RUSTSEC-2023-0071` remains ignored for the optional sqlx MySQL path; 23 warnings remain tracked as non-blocking issue #51 debt)
- `pnpm run verify:release`
- `pnpm run app:build:no-bundle`
- Static workflow review: PR CI remains split across Ubuntu frontend checks and Windows Rust checks; release keeps `contents: write` only on the publishing job; updater-signing preflight remains read-only.
- Package inspection: generated `dist` and no-bundle app output did not include `.env`, `.db`, report, agent/worktree, or credential-like shipped files. Cargo `.fingerprint` matches for the upstream `match_token` crate were build metadata only.

## Manual repository checks
- Confirm branch protection requires the PR CI workflow before merge.
- Confirm repository Actions settings allow release-please to create pull requests when `RELEASE_PLEASE_TOKEN` is configured.
- Confirm `TAURI_SIGNING_PRIVATE_KEY` and optional password are configured only as GitHub secrets.
- Follow-up: consider SHA-pinning GitHub Actions in a separate hardening PR if the release policy wants maximum supply-chain immutability.