### PR TITLE
ci: update github actions runtime refs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 9
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: pnpm
@@ -55,15 +55,15 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 9
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create release PR or GitHub Release
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v5.0.0
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
 
       - name: install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 9
 
@@ -82,7 +82,7 @@ jobs:
           fi
           rm -f .tmp/updater-signing-smoke-test.txt .tmp/updater-signing-smoke-test.txt.sig
 
-      - uses: tauri-apps/tauri-action@v0.6.0
+      - uses: tauri-apps/tauri-action@action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/updater-signing-preflight.yml
+++ b/.github/workflows/updater-signing-preflight.yml
@@ -17,15 +17,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 20
 
       - name: install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6.0.8
         with:
           version: 9
 

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -4,6 +4,8 @@ This document outlines the required configuration for the automated release work
 
 ## Automated Release (release-please)
 The `release-please` workflow automates application versioning and `CHANGELOG.md` generation.
+It remains the release automation source of truth for version bumps, changelog updates, release PRs, tags, and GitHub Releases.
+Codex can assist by reviewing release PRs, rerunning workflows, and verifying published assets, but it should not replace this auditable release flow.
 
 ### Required Secrets
 *   **RELEASE_PLEASE_TOKEN (Optional but Recommended):**
@@ -69,6 +71,7 @@ Ambit now uses Tauri's updater plugin with GitHub Releases as the public update 
 ## Repository Settings To Verify
 *   **Branch protection:** `main` should require pull requests and the `frontend-checks` plus `rust-tests` status checks.
 *   **Actions permissions:** Under **Settings > Actions > General**, enable **Allow GitHub Actions to create and approve pull requests**.
+*   **Actions policy:** Keep external Actions restricted to the selected-action allowlist used by the workflows. Do not switch back to local-only, which prevents workflow startup, or unrestricted marketplace actions, which broadens supply-chain exposure.
 *   **Release token:** If `RELEASE_PLEASE_TOKEN` is missing, `release-please` still works with `GITHUB_TOKEN`, but downstream workflows triggered from release PRs or release tags will not run automatically.
 *   **Updater signing:** `TAURI_SIGNING_PRIVATE_KEY` must be present before any release tag is built. If the key has a non-empty passphrase, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` must also be present.
 


### PR DESCRIPTION
## Summary
- Update GitHub Actions references to maintained Node 24-compatible versions.
- Replace the deprecated `google-github-actions/release-please-action` with `googleapis/release-please-action`.
- Document that release-please remains the release source of truth while Codex assists with review, reruns, and asset verification.
- Document that repository Actions should stay on the selected-action allowlist.

## Validation
- Confirmed `v0.5.0` release workflow completed successfully before starting this branch.
- `npx --yes github-actionlint`
- `pnpm run audit:prod`
- `pnpm run audit:rust`

## Notes
- The repository selected-actions allowlist was temporarily expanded to include both old and new action refs so this PR's CI can start. After this PR lands, narrow the allowlist to the new exact refs only:
  - `actions/checkout@v6.0.2`
  - `actions/setup-node@v6.4.0`
  - `pnpm/action-setup@v6.0.8`
  - `dtolnay/rust-toolchain@stable`
  - `tauri-apps/tauri-action@action-v0.6.2`
  - `googleapis/release-please-action@v5.0.0`