### PR TITLE
chore: sync cargo lock version

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.21.7",
  "chrono",


### PR DESCRIPTION
## Summary
- Sync the local `app` package version in `src-tauri/Cargo.lock` from `0.4.0` to `0.5.0` after the release-please version bump.
- Keeps the committed lockfile aligned with `package.json`, `src-tauri/Cargo.toml`, and Tauri config.

## Validation
- `pnpm run check:versions`
- `cargo metadata --manifest-path src-tauri/Cargo.toml --locked --format-version 1`