### PR TITLE
[codex] tune Dependabot and unblock PR checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,28 +1,78 @@
 version: 2
+
 updates:
-  - package-ecosystem: npm
-    directory: /
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "weekly"
+      day: "monday"
       time: "09:00"
-      timezone: Europe/Berlin
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm-safe-patch-minor:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@tauri-apps/*"
+          - "typescript"
+        update-types:
+          - "minor"
+          - "patch"
 
-  - package-ecosystem: cargo
-    directory: /src-tauri
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "weekly"
+      day: "monday"
       time: "09:15"
-      timezone: Europe/Berlin
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      cargo-safe-patch-minor:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "tauri"
+          - "tauri-*"
+          - "tauri-plugin-*"
+          - "image"
+          - "webp"
+          - "sha2"
+          - "keyring"
+          - "rusqlite"
+          - "dirs"
+          - "notify"
+          - "reqwest"
+          - "specta"
+          - "specta-*"
+        update-types:
+          - "minor"
+          - "patch"
 
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
-      day: monday
+      interval: "weekly"
+      day: "monday"
       time: "09:30"
-      timezone: Europe/Berlin
-    open-pull-requests-limit: 5
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github_actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -74,11 +74,6 @@ jobs:
       - name: install rust stable
         uses: dtolnay/rust-toolchain@stable
 
-      - name: cache rust dependencies
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: src-tauri
-
       - name: verify generated bindings
         run: pnpm run bindings:check
 


### PR DESCRIPTION
## Summary

- Tightens Dependabot scheduling by capping open PRs at 3 per ecosystem.
- Groups low-risk npm and Cargo patch/minor updates while keeping major/core-runtime/security-sensitive packages separate for review.
- Adds explicit labels and commit-message settings for dependency PRs.
- Removes the `swatinem/rust-cache@v2` step from `pr-ci`, because the repository currently uses selected GitHub Actions and that action is not allowlisted, causing startup failures before CI jobs are created.

## Validation

- `python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/dependabot.yml', '.github/workflows/pr-ci.yml']]; print('yaml: ok')"`
- `git diff --check`

## Notes

This does not enable unattended auto-merge. Current Dependabot PRs remain labeled for assisted/manual triage, and no dependency PRs were merged.