### PR TITLE
[codex] upgrade lucide-react to 1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clsx": "^2.1.0",
     "framer-motion": "^12.25.0",
     "jszip": "^3.10.1",
-    "lucide-react": "^0.554.0",
+    "lucide-react": "^1.16.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^3.10.1
         version: 3.10.1
       lucide-react:
-        specifier: ^0.554.0
-        version: 0.554.0(react@19.2.6)
+        specifier: ^1.16.0
+        version: 1.16.0(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -1331,8 +1331,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@0.554.0:
-    resolution: {integrity: sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==}
+  lucide-react@1.16.0:
+    resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -3190,7 +3190,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@0.554.0(react@19.2.6):
+  lucide-react@1.16.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 

--- a/src/components/ui/DonationModal.tsx
+++ b/src/components/ui/DonationModal.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Coffee, Github, Heart, X } from 'lucide-react';
+import { Coffee, Heart, X } from 'lucide-react';
 import { APP_NAME } from '../../constants/app';
 import { ENABLED_DONATION_PROVIDERS, SUPPORT_CHANNELS } from '../../constants/support';
 import { openExternalUrl } from '../../utils/externalLinks';
@@ -60,7 +60,7 @@ export const DonationModal: React.FC<DonationModalProps> = ({ isOpen, onClose })
                             {ENABLED_DONATION_PROVIDERS.length > 0 ? (
                                 <div className="flex flex-col gap-3 w-full">
                                     {ENABLED_DONATION_PROVIDERS.map((provider) => {
-                                        const ProviderIcon = provider.id === 'github-sponsors' ? Github : Coffee;
+                                        const ProviderIcon = provider.id === 'github-sponsors' ? Heart : Coffee;
                                         const isKoFi = provider.id === 'ko-fi';
 
                                         return (

--- a/src/features/filters/components/FilterPanel.tsx
+++ b/src/features/filters/components/FilterPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Check, Filter, Github, FolderOpen, Sliders, Puzzle, Save, FolderSearch, Images, HardDrive, Layers3, type LucideIcon } from 'lucide-react';
+import { Check, Filter, ExternalLink, FolderOpen, Sliders, Puzzle, Save, FolderSearch, Images, HardDrive, Layers3, type LucideIcon } from 'lucide-react';
 import { AIImage, FilterState } from '../../../types';
 import { useSearch } from '../../../contexts/SearchContext';
 import { useCollections } from '../../../contexts/CollectionContext';
@@ -530,7 +530,7 @@ export const FilterPanel: React.FC<FilterPanelProps> = ({
                         className="hover:text-gray-900 dark:hover:text-zinc-200 transition-colors opacity-80 hover:opacity-100"
                         title="Open Ambit on GitHub"
                     >
-                        <Github className="w-3 h-3" />
+                        <ExternalLink className="w-3 h-3" />
                     </button>
                     <span className="hover:text-gray-900 dark:hover:text-zinc-200 transition-colors cursor-default">v{appVersion ?? '...'}</span>
                 </div>


### PR DESCRIPTION
﻿## Summary
- Upgrade `lucide-react` from `^0.554.0` to `^1.16.0`.
- Replace the removed `Github` icon export with supported lucide 1.x icons.
- Keep the UI behavior unchanged: repo footer link still opens GitHub, donation modal still shows Ko-fi and GitHub Sponsors actions.

## Validation
- `pnpm run typecheck`
- `pnpm run test:run`
- `pnpm run build`
- Browser smoke test: app loaded at `http://localhost:1421/`, filter footer repo button rendered, Support modal opened, and no browser warnings/errors were reported.

## Notes
- Frontend-only dependency update.
- Do not merge until GitHub `pr-ci` passes.
