### PR TITLE
Fix packaged startup after app identifier migration

### DIFF
--- a/src-tauri/src/app_data_migration.rs
+++ b/src-tauri/src/app_data_migration.rs
@@ -1,6 +1,8 @@
 const PRODUCTION_IDENTIFIER: &str = "io.github.asuraace.ambit";
 const LEGACY_PRODUCTION_IDENTIFIER: &str = "com.ambit.app";
 #[cfg(not(test))]
+const THUMBNAIL_PATH_REPAIR_MARKER: &str = ".thumbnail-path-repair-v1";
+#[cfg(not(test))]
 const APP_IDENTIFIER_PATHS: [&str; 5] = [
     PRODUCTION_IDENTIFIER,
     LEGACY_PRODUCTION_IDENTIFIER,
@@ -20,7 +22,10 @@ enum IdentifierMigrationOutcome {
 
 #[cfg(not(test))]
 pub(crate) fn migrate_legacy_identifier_data() {
-    if let Some(config_dir) = dirs::config_dir() {
+    let config_dir = dirs::config_dir();
+    let data_local_dir = dirs::data_local_dir();
+
+    if let Some(config_dir) = &config_dir {
         let legacy_dir = config_dir.join(LEGACY_PRODUCTION_IDENTIFIER);
         let current_dir = config_dir.join(PRODUCTION_IDENTIFIER);
         let _ =
@@ -29,7 +34,7 @@ pub(crate) fn migrate_legacy_identifier_data() {
         eprintln!("[IdentifierMigration] Failed to resolve Roaming AppData config directory");
     }
 
-    if let Some(data_local_dir) = dirs::data_local_dir() {
+    if let Some(data_local_dir) = &data_local_dir {
         let legacy_dir = data_local_dir.join(LEGACY_PRODUCTION_IDENTIFIER);
         let current_dir = data_local_dir.join(PRODUCTION_IDENTIFIER);
         let _ = migrate_identifier_dir(
@@ -40,6 +45,180 @@ pub(crate) fn migrate_legacy_identifier_data() {
         );
     } else {
         eprintln!("[IdentifierMigration] Failed to resolve Local AppData directory");
+    }
+
+    if let (Some(config_dir), Some(data_local_dir)) = (&config_dir, &data_local_dir) {
+        repair_legacy_production_thumbnail_paths(config_dir, data_local_dir);
+    }
+}
+
+#[cfg(not(test))]
+fn repair_legacy_production_thumbnail_paths(
+    config_dir: &std::path::Path,
+    data_local_dir: &std::path::Path,
+) {
+    let db_path = config_dir.join(PRODUCTION_IDENTIFIER).join("images.db");
+    let legacy_thumbnail_dir = data_local_dir
+        .join(LEGACY_PRODUCTION_IDENTIFIER)
+        .join(".thumbnails");
+    let current_thumbnail_dir = data_local_dir
+        .join(PRODUCTION_IDENTIFIER)
+        .join(".thumbnails");
+    let repair_marker = data_local_dir
+        .join(PRODUCTION_IDENTIFIER)
+        .join(THUMBNAIL_PATH_REPAIR_MARKER);
+
+    if !db_path.exists() {
+        return;
+    }
+
+    if repair_marker.exists() && !legacy_thumbnail_dir.exists() {
+        return;
+    }
+
+    match repair_legacy_thumbnail_cache_and_paths(
+        &db_path,
+        &legacy_thumbnail_dir,
+        &current_thumbnail_dir,
+    ) {
+        Ok(None) => {}
+        Ok(Some(updated)) => {
+            write_thumbnail_path_repair_marker(&repair_marker);
+            if updated > 0 {
+                println!(
+                    "[IdentifierMigration] Repaired {updated} legacy thumbnail path references in {}",
+                    db_path.display()
+                );
+            }
+        }
+        Err(error) => {
+            eprintln!(
+                "[IdentifierMigration] Failed to repair legacy thumbnail path references in {}: {error}",
+                db_path.display()
+            );
+        }
+    }
+}
+
+#[cfg(not(test))]
+fn write_thumbnail_path_repair_marker(repair_marker: &std::path::Path) {
+    if let Some(parent) = repair_marker.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "[IdentifierMigration] Failed to create thumbnail path repair marker parent {}: {error}",
+                parent.display()
+            );
+            return;
+        }
+    }
+
+    if let Err(error) = std::fs::write(repair_marker, "1") {
+        eprintln!(
+            "[IdentifierMigration] Failed to write thumbnail path repair marker {}: {error}",
+            repair_marker.display()
+        );
+    }
+}
+
+fn repair_legacy_thumbnail_cache_and_paths(
+    db_path: &std::path::Path,
+    legacy_thumbnail_dir: &std::path::Path,
+    current_thumbnail_dir: &std::path::Path,
+) -> rusqlite::Result<Option<usize>> {
+    if !prepare_current_thumbnail_cache(legacy_thumbnail_dir, current_thumbnail_dir) {
+        return Ok(None);
+    }
+
+    repair_legacy_thumbnail_paths_in_database(db_path, legacy_thumbnail_dir, current_thumbnail_dir)
+        .map(Some)
+}
+
+fn prepare_current_thumbnail_cache(
+    legacy_thumbnail_dir: &std::path::Path,
+    current_thumbnail_dir: &std::path::Path,
+) -> bool {
+    if current_thumbnail_dir.exists() {
+        if !current_thumbnail_dir.is_dir() {
+            eprintln!(
+                "[IdentifierMigration] Failed thumbnail cache repair; current thumbnail path is not a directory: {}",
+                current_thumbnail_dir.display()
+            );
+            return false;
+        }
+
+        if !legacy_thumbnail_dir.exists() {
+            return true;
+        }
+
+        if !legacy_thumbnail_dir.is_dir() {
+            eprintln!(
+                "[IdentifierMigration] Failed thumbnail cache repair; legacy thumbnail path is not a directory: {}",
+                legacy_thumbnail_dir.display()
+            );
+            return true;
+        }
+
+        return match move_path_without_overwrite(
+            legacy_thumbnail_dir,
+            current_thumbnail_dir,
+            "Local thumbnail cache",
+        ) {
+            Ok((moved, skipped)) => {
+                println!(
+                    "[IdentifierMigration] Merged Local thumbnail cache from {} to {}; moved {moved} entries, skipped {skipped}",
+                    legacy_thumbnail_dir.display(),
+                    current_thumbnail_dir.display()
+                );
+                true
+            }
+            Err(()) => false,
+        };
+    }
+
+    if !legacy_thumbnail_dir.exists() {
+        println!(
+            "[IdentifierMigration] Skipped thumbnail path repair; no thumbnail cache at {} or {}",
+            legacy_thumbnail_dir.display(),
+            current_thumbnail_dir.display()
+        );
+        return false;
+    }
+
+    if !legacy_thumbnail_dir.is_dir() {
+        eprintln!(
+            "[IdentifierMigration] Failed thumbnail cache repair; legacy thumbnail path is not a directory: {}",
+            legacy_thumbnail_dir.display()
+        );
+        return false;
+    }
+
+    if let Some(parent) = current_thumbnail_dir.parent() {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "[IdentifierMigration] Failed thumbnail cache repair; could not create parent {}: {error}",
+                parent.display()
+            );
+            return false;
+        }
+    }
+
+    match std::fs::rename(legacy_thumbnail_dir, current_thumbnail_dir) {
+        Ok(()) => {
+            println!(
+                "[IdentifierMigration] Moved Local thumbnail cache from {} to {}",
+                legacy_thumbnail_dir.display(),
+                current_thumbnail_dir.display()
+            );
+            true
+        }
+        Err(error) => {
+            eprintln!(
+                "[IdentifierMigration] Failed thumbnail cache repair; could not move {} to {}: {error}",
+                legacy_thumbnail_dir.display(),
+                current_thumbnail_dir.display()
+            );
+            false
+        }
     }
 }
 
@@ -259,6 +438,91 @@ fn move_path_without_overwrite(
     }
 }
 
+fn repair_legacy_thumbnail_paths_in_database(
+    db_path: &std::path::Path,
+    legacy_thumbnail_dir: &std::path::Path,
+    current_thumbnail_dir: &std::path::Path,
+) -> rusqlite::Result<usize> {
+    let conn = rusqlite::Connection::open(db_path)?;
+    let replacements = path_replacement_pairs(legacy_thumbnail_dir, current_thumbnail_dir);
+    let mut updated = 0usize;
+
+    for (table, column) in [
+        ("images", "thumbnail_path"),
+        ("removed_images", "thumbnail_path"),
+        ("models", "thumbnail_path"),
+        ("models", "sidecar_thumbnail_path"),
+        ("facet_cache", "thumbnail_path"),
+        ("facet_cache", "safe_thumbnail_path"),
+        ("collections", "custom_thumbnail"),
+    ] {
+        if !column_exists(&conn, table, column)? {
+            continue;
+        }
+
+        for (legacy_prefix, current_prefix) in &replacements {
+            updated += update_path_prefix(&conn, table, column, legacy_prefix, current_prefix)?;
+        }
+    }
+
+    Ok(updated)
+}
+
+fn path_replacement_pairs(
+    legacy_thumbnail_dir: &std::path::Path,
+    current_thumbnail_dir: &std::path::Path,
+) -> Vec<(String, String)> {
+    let native_legacy = legacy_thumbnail_dir.to_string_lossy().to_string();
+    let native_current = current_thumbnail_dir.to_string_lossy().to_string();
+    let forward_legacy = native_legacy.replace('\\', "/");
+    let forward_current = native_current.replace('\\', "/");
+
+    let mut pairs = vec![(native_legacy, native_current)];
+    if pairs[0].0 != forward_legacy {
+        pairs.push((forward_legacy, forward_current));
+    }
+    pairs
+}
+
+fn column_exists(conn: &rusqlite::Connection, table: &str, column: &str) -> rusqlite::Result<bool> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info(\"{table}\")"))?;
+    let mut rows = stmt.query([])?;
+
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?;
+        if name == column {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn update_path_prefix(
+    conn: &rusqlite::Connection,
+    table: &str,
+    column: &str,
+    legacy_prefix: &str,
+    current_prefix: &str,
+) -> rusqlite::Result<usize> {
+    let pattern = format!("{}%", escape_sql_like(legacy_prefix));
+    conn.execute(
+        &format!(
+            "UPDATE \"{table}\"
+             SET \"{column}\" = replace(\"{column}\", ?1, ?2)
+             WHERE \"{column}\" LIKE ?3 ESCAPE '\\'"
+        ),
+        rusqlite::params![legacy_prefix, current_prefix, pattern],
+    )
+}
+
+fn escape_sql_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 #[cfg(not(test))]
 pub(crate) fn app_identifier_dirs_to_check() -> Vec<std::path::PathBuf> {
     let mut paths_to_check = Vec::new();
@@ -307,6 +571,51 @@ mod identifier_migration_tests {
 
     fn cleanup(root: &Path) {
         let _ = fs::remove_dir_all(root);
+    }
+
+    fn create_test_db(path: &Path) -> rusqlite::Connection {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("test db parent should be created");
+        }
+        let conn = rusqlite::Connection::open(path).expect("test db should open");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE images (id TEXT PRIMARY KEY, thumbnail_path TEXT);
+            CREATE TABLE removed_images (id TEXT PRIMARY KEY, thumbnail_path TEXT);
+            CREATE TABLE models (
+                hash TEXT PRIMARY KEY,
+                thumbnail_path TEXT,
+                sidecar_thumbnail_path TEXT
+            );
+            CREATE TABLE facet_cache (
+                facet_type TEXT NOT NULL,
+                resource_name TEXT NOT NULL,
+                thumbnail_path TEXT,
+                safe_thumbnail_path TEXT,
+                PRIMARY KEY (facet_type, resource_name)
+            );
+            CREATE TABLE collections (id TEXT PRIMARY KEY, custom_thumbnail TEXT);
+            "#,
+        )
+        .expect("test schema should be created");
+        conn
+    }
+
+    fn insert_image_thumbnail(conn: &rusqlite::Connection, id: &str, thumbnail_path: &str) {
+        conn.execute(
+            "INSERT INTO images (id, thumbnail_path) VALUES (?1, ?2)",
+            rusqlite::params![id, thumbnail_path],
+        )
+        .expect("image thumbnail row should be inserted");
+    }
+
+    fn image_thumbnail_path(conn: &rusqlite::Connection, id: &str) -> String {
+        conn.query_row(
+            "SELECT thumbnail_path FROM images WHERE id = ?1",
+            [id],
+            |row| row.get(0),
+        )
+        .expect("image thumbnail path should be returned")
     }
 
     #[test]
@@ -418,6 +727,218 @@ mod identifier_migration_tests {
                 .expect("current thumbnail should remain"),
             "current"
         );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn repairs_legacy_thumbnail_paths_in_database() {
+        let root = unique_temp_root("repair-db");
+        let db_path = root.join("images.db");
+        let legacy_thumb = root
+            .join("Local")
+            .join(LEGACY_PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        let current_thumb = root
+            .join("Local")
+            .join(PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        let legacy_native = legacy_thumb.to_string_lossy().to_string();
+        let current_native = current_thumb.to_string_lossy().to_string();
+        let legacy_forward = legacy_native.replace('\\', "/");
+        let current_forward = current_native.replace('\\', "/");
+        let conn = create_test_db(&db_path);
+
+        conn.execute(
+            "INSERT INTO images (id, thumbnail_path) VALUES ('img1', ?1)",
+            [format!("{legacy_native}\\one.webp")],
+        )
+        .expect("image row should be inserted");
+        conn.execute(
+            "INSERT INTO removed_images (id, thumbnail_path) VALUES ('old1', ?1)",
+            [format!("{legacy_forward}/two.webp")],
+        )
+        .expect("removed image row should be inserted");
+        conn.execute(
+            "INSERT INTO models (hash, thumbnail_path, sidecar_thumbnail_path) VALUES ('m1', ?1, ?2)",
+            [
+                format!("{legacy_native}\\model.webp"),
+                format!("{legacy_forward}/sidecar.webp"),
+            ],
+        )
+        .expect("model row should be inserted");
+        conn.execute(
+            "INSERT INTO facet_cache (facet_type, resource_name, thumbnail_path, safe_thumbnail_path) VALUES ('checkpoints', 'm1', ?1, ?2)",
+            [
+                format!("{legacy_native}\\facet.webp"),
+                format!("{legacy_forward}/safe.webp"),
+            ],
+        )
+        .expect("facet row should be inserted");
+        conn.execute(
+            "INSERT INTO collections (id, custom_thumbnail) VALUES ('c1', ?1)",
+            [format!("{legacy_native}\\collection.webp")],
+        )
+        .expect("collection row should be inserted");
+        drop(conn);
+
+        let updated =
+            repair_legacy_thumbnail_paths_in_database(&db_path, &legacy_thumb, &current_thumb)
+                .expect("thumbnail path repair should succeed");
+
+        assert_eq!(updated, 7);
+        let conn = rusqlite::Connection::open(&db_path).expect("test db should reopen");
+        let image_path: String = conn
+            .query_row(
+                "SELECT thumbnail_path FROM images WHERE id = 'img1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("image path should be returned");
+        let removed_path: String = conn
+            .query_row(
+                "SELECT thumbnail_path FROM removed_images WHERE id = 'old1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("removed image path should be returned");
+        let sidecar_path: String = conn
+            .query_row(
+                "SELECT sidecar_thumbnail_path FROM models WHERE hash = 'm1'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("model sidecar path should be returned");
+
+        assert_eq!(image_path, format!("{current_native}\\one.webp"));
+        assert_eq!(removed_path, format!("{current_forward}/two.webp"));
+        assert_eq!(sidecar_path, format!("{current_forward}/sidecar.webp"));
+        cleanup(&root);
+    }
+
+    #[test]
+    fn moves_legacy_thumbnail_cache_before_repair_when_current_cache_is_missing() {
+        let root = unique_temp_root("repair-missing-current-cache");
+        let db_path = root.join("images.db");
+        let legacy_thumb = root
+            .join("Local")
+            .join(LEGACY_PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        let current_profile = root.join("Local").join(PRODUCTION_IDENTIFIER);
+        let current_thumb = current_profile.join(".thumbnails");
+        write_file(&current_profile.join("library.json"), "{}");
+        write_file(&legacy_thumb.join("sample.webp"), "legacy-thumb");
+
+        let legacy_path = legacy_thumb
+            .join("sample.webp")
+            .to_string_lossy()
+            .to_string();
+        let current_path = current_thumb
+            .join("sample.webp")
+            .to_string_lossy()
+            .to_string();
+        let conn = create_test_db(&db_path);
+        insert_image_thumbnail(&conn, "img1", &legacy_path);
+        drop(conn);
+
+        let updated =
+            repair_legacy_thumbnail_cache_and_paths(&db_path, &legacy_thumb, &current_thumb)
+                .expect("thumbnail cache and DB repair should succeed")
+                .expect("thumbnail path repair should run");
+
+        assert_eq!(updated, 1);
+        assert!(!legacy_thumb.exists());
+        assert_eq!(
+            fs::read_to_string(current_thumb.join("sample.webp"))
+                .expect("moved thumbnail should exist"),
+            "legacy-thumb"
+        );
+        let conn = rusqlite::Connection::open(&db_path).expect("test db should reopen");
+        assert_eq!(image_thumbnail_path(&conn, "img1"), current_path);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn merges_legacy_thumbnail_cache_without_overwriting_current_files_before_repair() {
+        let root = unique_temp_root("repair-merge-current-cache");
+        let db_path = root.join("images.db");
+        let legacy_thumb = root
+            .join("Local")
+            .join(LEGACY_PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        let current_thumb = root
+            .join("Local")
+            .join(PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        write_file(&legacy_thumb.join("unique.webp"), "legacy-unique");
+        write_file(&legacy_thumb.join("duplicate.webp"), "legacy-duplicate");
+        write_file(&current_thumb.join("duplicate.webp"), "current-duplicate");
+
+        let legacy_path = legacy_thumb
+            .join("unique.webp")
+            .to_string_lossy()
+            .to_string();
+        let current_path = current_thumb
+            .join("unique.webp")
+            .to_string_lossy()
+            .to_string();
+        let conn = create_test_db(&db_path);
+        insert_image_thumbnail(&conn, "img1", &legacy_path);
+        drop(conn);
+
+        let updated =
+            repair_legacy_thumbnail_cache_and_paths(&db_path, &legacy_thumb, &current_thumb)
+                .expect("thumbnail cache and DB repair should succeed")
+                .expect("thumbnail path repair should run");
+
+        assert_eq!(updated, 1);
+        assert_eq!(
+            fs::read_to_string(current_thumb.join("unique.webp"))
+                .expect("unique legacy thumbnail should be moved"),
+            "legacy-unique"
+        );
+        assert_eq!(
+            fs::read_to_string(current_thumb.join("duplicate.webp"))
+                .expect("current duplicate thumbnail should remain"),
+            "current-duplicate"
+        );
+        assert_eq!(
+            fs::read_to_string(legacy_thumb.join("duplicate.webp"))
+                .expect("skipped legacy duplicate should remain"),
+            "legacy-duplicate"
+        );
+        let conn = rusqlite::Connection::open(&db_path).expect("test db should reopen");
+        assert_eq!(image_thumbnail_path(&conn, "img1"), current_path);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn skips_path_repair_when_no_thumbnail_cache_exists() {
+        let root = unique_temp_root("repair-missing-caches");
+        let db_path = root.join("images.db");
+        let legacy_thumb = root
+            .join("Local")
+            .join(LEGACY_PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        let current_thumb = root
+            .join("Local")
+            .join(PRODUCTION_IDENTIFIER)
+            .join(".thumbnails");
+        let legacy_path = legacy_thumb
+            .join("missing.webp")
+            .to_string_lossy()
+            .to_string();
+        let conn = create_test_db(&db_path);
+        insert_image_thumbnail(&conn, "img1", &legacy_path);
+        drop(conn);
+
+        let updated =
+            repair_legacy_thumbnail_cache_and_paths(&db_path, &legacy_thumb, &current_thumb)
+                .expect("missing thumbnail caches should skip path repair cleanly");
+
+        assert_eq!(updated, None);
+        assert!(!current_thumb.exists());
+        let conn = rusqlite::Connection::open(&db_path).expect("test db should reopen");
+        assert_eq!(image_thumbnail_path(&conn, "img1"), legacy_path);
         cleanup(&root);
     }
 }

--- a/src/components/ui/Charts.tsx
+++ b/src/components/ui/Charts.tsx
@@ -1,7 +1,6 @@
 
 import * as React from 'react';
 import { useState } from 'react';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { Lightbulb, X, BarChart3 } from 'lucide-react';
 import { AIImage } from '../../types';
 // Note: useLibraryStats hook is deprecated for large library performance. Using DB stats.
@@ -34,6 +33,7 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
     const { stats, setFilters, isFiltering } = useLibraryContext();
     const { totalGenerations, avgSteps, estSizeMB, modelStats, keywordStats } = stats;
     const modelChartStats: ModelChartStat[] = modelStats ?? [];
+    const maxModelCount = Math.max(1, ...modelChartStats.map(stat => stat.count));
 
     const [showTip, setShowTip] = useState(true);
 
@@ -85,42 +85,49 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
                         {/* Bar Chart */}
                         <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-white/10 rounded-xl p-6 h-80 shadow-sm flex flex-col">
                             <h3 className="text-sm font-bold text-gray-400 mb-6 uppercase tracking-wider flex-shrink-0">Generations per Model (Click to Filter)</h3>
-                            <div className="flex-1 min-h-0 w-full">
-                                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={0}>
-                                    <BarChart data={modelChartStats} style={{ outline: 'none' }}>
-                                        <XAxis dataKey="name" stroke="#52525b" tick={{ fill: '#71717a', fontSize: 12 }} />
-                                        <YAxis stroke="#52525b" tick={{ fill: '#71717a', fontSize: 12 }} />
-                                        <Tooltip
-                                            contentStyle={{ backgroundColor: '#18181b', borderColor: 'rgba(255,255,255,0.1)', color: '#fff', borderRadius: '0.5rem' }}
-                                            cursor={{ fill: '#27272a', opacity: 0.2 }}
-                                        />
-                                        <Bar
-                                            dataKey="count"
-                                            radius={[6, 6, 0, 0]}
-                                            onClick={(data: unknown) => {
-                                                const datum = data as Partial<ModelChartStat> | null;
-                                                if (typeof datum?.fullName === 'string') {
-                                                    onFilter('model', datum.fullName);
+                            <div className="flex-1 min-h-0 w-full overflow-y-auto custom-scrollbar pr-1 space-y-3">
+                                {modelChartStats.length === 0 ? (
+                                    <div className="h-full flex items-center justify-center text-xs uppercase tracking-wider text-gray-400">
+                                        No model stats found
+                                    </div>
+                                ) : modelChartStats.map((stat, index) => {
+                                    const widthPercent = Math.max(6, Math.round((stat.count / maxModelCount) * 100));
+                                    const colorClass = [
+                                        'bg-indigo-500',
+                                        'bg-violet-500',
+                                        'bg-rose-500',
+                                        'bg-teal-500'
+                                    ][index % 4];
+
+                                    return (
+                                        <button
+                                            key={`${stat.fullName ?? stat.name}-${index}`}
+                                            type="button"
+                                            className="group w-full text-left rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors focus:outline-none focus:ring-2 focus:ring-sage-500/60"
+                                            title={stat.fullName ?? stat.name}
+                                            onClick={() => {
+                                                if (typeof stat.fullName === 'string') {
+                                                    onFilter('model', stat.fullName);
                                                 }
                                             }}
-                                            cursor="pointer"
-                                            activeBar={{
-                                                fillOpacity: 0.9,
-                                                stroke: '#ffffff',
-                                                strokeWidth: 1.5,
-                                                strokeOpacity: 0.5
-                                            }}
                                         >
-                                            {modelChartStats.map((entry, index) => (
-                                                <Cell
-                                                    key={`cell-${index}`}
-                                                    fill={['#6366f1', '#8b5cf6', '#ec4899', '#14b8a6'][index % 4]}
-                                                    style={{ outline: 'none' }}
+                                            <div className="flex items-center justify-between gap-3 mb-1">
+                                                <span className="text-xs font-medium text-gray-700 dark:text-gray-200 truncate">
+                                                    {stat.name}
+                                                </span>
+                                                <span className="text-xs font-mono text-gray-500 dark:text-gray-400 shrink-0">
+                                                    {stat.count.toLocaleString()}
+                                                </span>
+                                            </div>
+                                            <div className="h-2.5 rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden">
+                                                <div
+                                                    className={`h-full rounded-full ${colorClass} group-hover:opacity-90 transition-all`}
+                                                    style={{ width: `${widthPercent}%` }}
                                                 />
-                                            ))}
-                                        </Bar>
-                                    </BarChart>
-                                </ResponsiveContainer>
+                                            </div>
+                                        </button>
+                                    );
+                                })}
                             </div>
                         </div>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,30 @@ export default defineConfig(({ mode }) => {
     plugins: [react()],
     build: {
       modulePreload: false,
+      rolldownOptions: {
+        output: {
+          codeSplitting: {
+            minSize: 20_000,
+            groups: [
+              {
+                name: 'react-runtime',
+                test: /node_modules[\\/]\.pnpm[\\/](react|react-dom|scheduler)@/,
+                priority: 30,
+              },
+              {
+                name: 'app-runtime',
+                test: /node_modules[\\/]\.pnpm[\\/](@tanstack[+]react-query|zustand|framer-motion)@/,
+                priority: 20,
+              },
+              {
+                name: 'ui-icons',
+                test: /node_modules[\\/]\.pnpm[\\/]lucide-react@/,
+                priority: 10,
+              },
+            ],
+          },
+        },
+      },
     },
     define: {
       'process.env.API_KEY': mode === 'development' ? JSON.stringify(env.GEMINI_API_KEY) : undefined,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,48 +14,7 @@ export default defineConfig(({ mode }) => {
     },
     plugins: [react()],
     build: {
-      rolldownOptions: {
-        output: {
-          codeSplitting: {
-            minSize: 20_000,
-            groups: [
-              {
-                name: 'react-vendor',
-                test: /node_modules[\\/]\.pnpm[\\/](react|react-dom|scheduler)@/,
-                priority: 30,
-              },
-              {
-                name: 'state-vendor',
-                test: /node_modules[\\/]\.pnpm[\\/](@tanstack[+]react-query|zustand)@/,
-                priority: 25,
-              },
-              {
-                name: 'ui-vendor',
-                test: /node_modules[\\/]\.pnpm[\\/](framer-motion|lucide-react)@/,
-                priority: 20,
-                maxSize: 250_000,
-              },
-              {
-                name: 'tauri-vendor',
-                test: /node_modules[\\/]\.pnpm[\\/]@tauri-apps[+\\/]/,
-                priority: 20,
-              },
-              {
-                name: 'app-data-core',
-                test: /[\\/]src[\\/](bindings\.ts|services[\\/]db[\\/]|utils[\\/]sqlHelpers\.ts)/,
-                priority: 10,
-                maxSize: 250_000,
-              },
-              {
-                name: 'vendor',
-                test: /node_modules[\\/]/,
-                priority: 1,
-                maxSize: 250_000,
-              },
-            ],
-          },
-        },
-      },
+      modulePreload: false,
     },
     define: {
       'process.env.API_KEY': mode === 'development' ? JSON.stringify(env.GEMINI_API_KEY) : undefined,


### PR DESCRIPTION
## Summary
- remove the previous broad Rolldown vendor/modulepreload startup path that left the packaged WebView stuck on the static loading screen
- keep module preload disabled and add only targeted startup chunks for React runtime, app runtime, and Lucide icons so the entry bundle stays under the production guard
- replace the Recharts-backed model chart with native React/CSS bars to avoid the startup vendor crash path
- repair legacy `com.ambit.app` thumbnail-cache data for the new `io.github.asuraace.ambit` identifier, including move/merge handling and a one-time repair marker

## Verification
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml identifier_migration_tests --lib`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build:guard` (startup entry: 454 kB)
- `pnpm run coverage`
- `pnpm exec tauri build --ci --no-bundle`
- release executable smoke-launched; first run wrote `.thumbnail-path-repair-v1`, subsequent startup exposed the Ambit window in ~10.8s