### PR TITLE
[codex] Simplify support modal copy

### DIFF
--- a/src/components/ui/DonationModal.tsx
+++ b/src/components/ui/DonationModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Coffee, Heart, X } from 'lucide-react';
 import { APP_NAME } from '../../constants/app';
-import { ENABLED_DONATION_PROVIDERS, SUPPORT_CHANNELS } from '../../constants/support';
+import { ENABLED_DONATION_PROVIDERS } from '../../constants/support';
 import { openExternalUrl } from '../../utils/externalLinks';
 
 interface DonationModalProps {
@@ -73,7 +73,7 @@ export const DonationModal: React.FC<DonationModalProps> = ({ isOpen, onClose })
                                                     : 'bg-gray-800 hover:bg-gray-700 dark:bg-white dark:hover:bg-gray-200 text-white dark:text-gray-900'
                                                     }`}
                                             >
-                                                <ProviderIcon className="w-5 h-5" /> Support via {provider.label}
+                                                <ProviderIcon className="w-5 h-5" /> {provider.ctaLabel}
                                             </button>
                                         );
                                     })}
@@ -86,23 +86,6 @@ export const DonationModal: React.FC<DonationModalProps> = ({ isOpen, onClose })
                                     </div>
                                 </div>
                             )}
-
-                            <p className="mt-5 text-xs text-gray-500 dark:text-gray-400 leading-relaxed max-w-xs">
-                                Ambit remains free and open source. There are no paid-only features or priority-support tiers.
-                            </p>
-
-                            <div className="mt-5 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-xs text-gray-400">
-                                {SUPPORT_CHANNELS.map((channel) => (
-                                    <button
-                                        key={channel.id}
-                                        type="button"
-                                        onClick={() => handleOpenLink(channel.url)}
-                                        className="hover:text-sage-600 dark:hover:text-sage-300 hover:underline transition-colors"
-                                    >
-                                        {channel.label}
-                                    </button>
-                                ))}
-                            </div>
 
                             <div className="mt-8 text-xs text-gray-400">
                                 Thank you for being part of the journey.

--- a/src/components/ui/__tests__/DonationModal.test.tsx
+++ b/src/components/ui/__tests__/DonationModal.test.tsx
@@ -7,25 +7,20 @@ describe('DonationModal', () => {
     it('shows support routes and live donation providers', async () => {
         render(<DonationModal isOpen={true} onClose={vi.fn()} />);
 
-        expect(screen.getByText('Report a bug')).toBeTruthy();
-        expect(screen.getByText('Follow releases')).toBeTruthy();
-        expect(screen.getByText(/Ko-fi/)).toBeTruthy();
-        expect(screen.getByText(/GitHub Sponsors/)).toBeTruthy();
+        expect(screen.getByText('Buy me a coffee')).toBeTruthy();
+        expect(screen.getByText('Sponsor on GitHub')).toBeTruthy();
+        expect(screen.getByText('Thank you for being part of the journey.')).toBeTruthy();
+        expect(screen.queryByText('Report a bug')).toBeNull();
+        expect(screen.queryByText('Follow releases')).toBeNull();
         expect(screen.queryByText('Donations are not configured yet')).toBeNull();
 
-        fireEvent.click(screen.getByText('Report a bug'));
-
-        await waitFor(() => {
-            expect(open).toHaveBeenCalledWith('https://github.com/AsuraAce/ambit/issues');
-        });
-
-        fireEvent.click(screen.getByText(/GitHub Sponsors/));
+        fireEvent.click(screen.getByText('Sponsor on GitHub'));
 
         await waitFor(() => {
             expect(open).toHaveBeenCalledWith('https://github.com/sponsors/AsuraAce');
         });
 
-        fireEvent.click(screen.getByText(/Ko-fi/));
+        fireEvent.click(screen.getByText('Buy me a coffee'));
 
         await waitFor(() => {
             expect(open).toHaveBeenCalledWith('https://ko-fi.com/astraoriondev');

--- a/src/constants/support.ts
+++ b/src/constants/support.ts
@@ -14,6 +14,7 @@ export interface SupportChannel {
 export interface DonationProvider {
     id: 'ko-fi' | 'github-sponsors' | 'patreon';
     label: string;
+    ctaLabel: string;
     url: string | null;
 }
 
@@ -36,16 +37,19 @@ export const DONATION_PROVIDERS: DonationProvider[] = [
     {
         id: 'ko-fi',
         label: 'Ko-fi',
+        ctaLabel: 'Buy me a coffee',
         url: KO_FI_URL
     },
     {
         id: 'github-sponsors',
         label: 'GitHub Sponsors',
+        ctaLabel: 'Sponsor on GitHub',
         url: GITHUB_SPONSORS_URL
     },
     {
         id: 'patreon',
         label: 'Patreon',
+        ctaLabel: 'Become a patron',
         url: null
     }
 ];


### PR DESCRIPTION
## Summary
- simplify the Support Modal copy by removing the post-button support text and links
- standardize the visible support CTAs to provider-specific labels
- store CTA labels in the donation provider config so future providers do not inherit GitHub wording

## Why
This keeps the modal tighter and aligns the support buttons with clearer, more conventional CTA text.

## Impact
Users now see a shorter Support Modal with `Buy me a coffee` and `Sponsor on GitHub` buttons, while the thank-you message remains in place.

## Validation
- `pnpm run test:run -- DonationModal`
