### PR TITLE
[codex] Persist dynamic collection thumbnails

### DIFF
--- a/src-tauri/src/db/migrations/m57_collection_thumbnail_cache.rs
+++ b/src-tauri/src/db/migrations/m57_collection_thumbnail_cache.rs
@@ -1,0 +1,68 @@
+use tauri_plugin_sql::Migration;
+
+pub fn migration57() -> Migration {
+    Migration {
+        version: 57,
+        description: "add_collection_dynamic_thumbnail_cache",
+        sql: r#"
+            ALTER TABLE collections ADD COLUMN dynamic_thumbnail_path TEXT;
+            ALTER TABLE collections ADD COLUMN dynamic_safe_thumbnail_path TEXT;
+            ALTER TABLE collections ADD COLUMN dynamic_thumbnail_is_sensitive INTEGER;
+            ALTER TABLE collections ADD COLUMN dynamic_thumbnail_cached_at INTEGER;
+        "#,
+        kind: tauri_plugin_sql::MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration57;
+
+    #[test]
+    fn migration_adds_nullable_dynamic_thumbnail_cache_columns() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                color TEXT,
+                is_archived INTEGER NOT NULL DEFAULT 0,
+                is_pinned INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL,
+                filter_state TEXT,
+                manual_exclusions TEXT,
+                custom_thumbnail TEXT,
+                source TEXT NOT NULL DEFAULT 'ambit',
+                updated_at INTEGER
+            );
+            ",
+        )
+        .expect("setup schema");
+
+        conn.execute_batch(migration57().sql)
+            .expect("apply migration");
+
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(collections)")
+            .expect("prepare table info");
+        let columns: Vec<(String, i64)> = stmt
+            .query_map([], |row| Ok((row.get(1)?, row.get(3)?)))
+            .expect("query columns")
+            .collect::<Result<_, _>>()
+            .expect("collect columns");
+
+        for column_name in [
+            "dynamic_thumbnail_path",
+            "dynamic_safe_thumbnail_path",
+            "dynamic_thumbnail_is_sensitive",
+            "dynamic_thumbnail_cached_at",
+        ] {
+            let (_, not_null) = columns
+                .iter()
+                .find(|(name, _)| name == column_name)
+                .unwrap_or_else(|| panic!("missing column {column_name}"));
+            assert_eq!(*not_null, 0, "{column_name} should be nullable");
+        }
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -23,6 +23,7 @@ pub mod m53_live_facet_indexes;
 pub mod m54_resource_junction_covering_indexes;
 pub mod m55_manual_thumbnail_lookup_index;
 pub mod m56_thumbnail_optimization;
+pub mod m57_collection_thumbnail_cache;
 
 pub fn init_db() -> Vec<Migration> {
     get_migrations()
@@ -55,6 +56,7 @@ pub fn get_migrations() -> Vec<Migration> {
     migrations.push(m54_resource_junction_covering_indexes::migration54());
     migrations.push(m55_manual_thumbnail_lookup_index::migration55());
     migrations.push(m56_thumbnail_optimization::migration56());
+    migrations.push(m57_collection_thumbnail_cache::migration57());
 
     migrations.sort_by_key(|m| m.version);
 
@@ -66,7 +68,7 @@ mod tests {
     use super::get_migrations;
 
     #[test]
-    fn migrations_include_mainline_49_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_resource_indexes_54_manual_thumbnail_55_and_thumbnail_optimization_56(
+    fn migrations_include_mainline_49_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_resource_indexes_54_manual_thumbnail_55_thumbnail_optimization_56_and_collection_thumbnail_cache_57(
     ) {
         let versions: Vec<i64> = get_migrations()
             .iter()
@@ -81,6 +83,7 @@ mod tests {
         assert!(versions.contains(&54));
         assert!(versions.contains(&55));
         assert!(versions.contains(&56));
+        assert!(versions.contains(&57));
     }
 
     #[test]
@@ -106,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn database_at_mainline_49_has_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_resource_indexes_54_manual_thumbnail_55_and_thumbnail_optimization_56_pending(
+    fn database_at_mainline_49_has_privacy_50_file_hash_51_thumbnail_privacy_52_live_facet_indexes_53_resource_indexes_54_manual_thumbnail_55_thumbnail_optimization_56_and_collection_thumbnail_cache_57_pending(
     ) {
         let migrations = get_migrations();
         let has_49 = migrations.iter().any(|migration| migration.version == 49);
@@ -117,6 +120,6 @@ mod tests {
             .collect();
 
         assert!(has_49);
-        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54, 55, 56]);
+        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54, 55, 56, 57]);
     }
 }

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -125,6 +125,8 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
     const { addToast } = useToast();
     const queryClient = useQueryClient();
     const setCollections = useCollectionStore(s => s.setCollections);
+    const refreshCollections = useCollectionStore(s => s.refreshCollections);
+    const refreshCollectionThumbnails = useCollectionStore(s => s.refreshCollectionThumbnails);
 
     // Zustand State
     const syncStatus = useLibraryStore(s => s.syncStatus);
@@ -356,6 +358,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     return changed ? next : prev;
                 });
             }
+            const shouldRefreshBoardCollectionThumbnails = !!boardMapping && boardMapping.size > 0;
 
             // Orphan scanning
             let orphansImported = 0;
@@ -415,6 +418,14 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         cycleId: livePerfContext?.cycleId,
                         changedImageCount: totalProcessed
                     }, touchedFacetResources);
+
+                    if (shouldRefreshBoardCollectionThumbnails) {
+                        void refreshCollections()
+                            .then(() => refreshCollectionThumbnails(true))
+                            .catch((error) => {
+                                console.error('[Sync] Failed to refresh collection thumbnails after live Invoke sync', error);
+                            });
+                    }
                 } else {
                     // MANUAL HEAVY REBUILD
                     setSyncProgress({ current: totalProcessed, total: totalProcessed, message: 'Updating gallery...' });
@@ -463,7 +474,14 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     if (options.mode !== 'startup') {
                         await onSyncComplete?.('full');
                     } else {
+                        if (shouldRefreshBoardCollectionThumbnails) {
+                            await refreshCollections();
+                        }
                         setSyncStatus('complete');
+                    }
+
+                    if (shouldRefreshBoardCollectionThumbnails) {
+                        await refreshCollectionThumbnails(true);
                     }
 
                     await persistInvokeSnapshot(snapshotCursor);
@@ -552,7 +570,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 }
             }
         }
-    }, [syncStatus, addToast, onSyncComplete, queryClient, queueLiveFacetRefresh, setSettings, setCollections, setSyncStatus, setSyncProgress, setIsLiveSyncing, startLiveWatchSession, updateLiveWatchSession, reportLiveImagesReceived]);
+    }, [syncStatus, addToast, onSyncComplete, queryClient, queueLiveFacetRefresh, setSettings, setCollections, refreshCollections, refreshCollectionThumbnails, setSyncStatus, setSyncProgress, setIsLiveSyncing, startLiveWatchSession, updateLiveWatchSession, reportLiveImagesReceived]);
 
     const startTargetedLiveSync = useCallback(async (paths: string[], perfContext?: TargetedLiveSyncPerfContext) => {
         if (isBrowserMockMode()) {

--- a/src/features/collections/components/AddToCollectionModal.tsx
+++ b/src/features/collections/components/AddToCollectionModal.tsx
@@ -48,6 +48,7 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
     const [showSortMenu, setShowSortMenu] = useState(false);
     const [showArchived, setShowArchived] = useState(false);
     const thumbnailHydrationPendingIds = useCollectionStore(s => s.thumbnailHydrationPendingIds);
+    const smartSummaryPendingIds = useCollectionStore(s => s.smartSummaryPendingIds);
 
     const allCollections = [...collections, ...smartCollections];
 
@@ -171,7 +172,7 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
                     {filtered.length > 0 ? (
                         <div className="grid grid-cols-1 gap-1">
                             {filtered.map(col => {
-                                const showThumbnailSkeleton = !!thumbnailHydrationPendingIds[col.id] && !col.thumbnail;
+                                const showThumbnailSkeleton = (!!thumbnailHydrationPendingIds[col.id] || !!smartSummaryPendingIds[col.id]) && !col.thumbnail;
 
                                 return (
                                     <button

--- a/src/features/collections/components/__tests__/AddToCollectionModal.test.tsx
+++ b/src/features/collections/components/__tests__/AddToCollectionModal.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Collection } from '../../../../types';
 import { useCollectionStore } from '../../../../stores/collectionStore';
 import { AddToCollectionModal } from '../AddToCollectionModal';
+import { createDefaultFilters } from '../../../../utils/filterState';
 
 vi.mock('framer-motion', () => {
     type MotionDivProps = React.HTMLAttributes<HTMLDivElement> & {
@@ -67,6 +68,25 @@ describe('AddToCollectionModal thumbnail hydration states', () => {
         });
 
         renderModal([baseCollection]);
+
+        expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
+        expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();
+        expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
+    });
+
+    it('renders a skeleton for smart collections with pending summary hydration', () => {
+        useCollectionStore.setState({
+            smartSummaryPendingIds: {
+                'smart-collection-1': true
+            }
+        });
+
+        renderModal([{
+            ...baseCollection,
+            id: 'smart-collection-1',
+            name: 'Smart Collection One',
+            filters: createDefaultFilters({ dateRange: 'today' })
+        }]);
 
         expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
         expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();

--- a/src/features/filters/components/CollectionList.tsx
+++ b/src/features/filters/components/CollectionList.tsx
@@ -68,6 +68,7 @@ export function CollectionList<T extends Collection>({
     const { settings, setSettings } = useSettings();
     const refreshSmartCounts = useCollectionStore(s => s.refreshSmartCounts);
     const thumbnailHydrationPendingIds = useCollectionStore(s => s.thumbnailHydrationPendingIds);
+    const smartSummaryPendingIds = useCollectionStore(s => s.smartSummaryPendingIds);
     const persistedSort = settings.resourceSortOptions?.collections;
     const sort: CollectionSortOption = isCollectionSort(persistedSort) ? persistedSort : 'recent_desc';
 
@@ -98,7 +99,7 @@ export function CollectionList<T extends Collection>({
 
     React.useEffect(() => {
         if (showArchived) {
-            void refreshSmartCounts({ includeArchived: true });
+            void refreshSmartCounts({ includeArchived: true, markPending: true });
         }
     }, [showArchived, refreshSmartCounts]);
 
@@ -113,7 +114,8 @@ export function CollectionList<T extends Collection>({
         void refreshSmartCounts({
             collectionIds: [selectedSmartCollection.id],
             includeArchived: true,
-            includePromptSearch: true
+            includePromptSearch: true,
+            markPending: true
         });
     }, [collections, filters.collectionId, refreshSmartCounts]);
 
@@ -306,7 +308,7 @@ export function CollectionList<T extends Collection>({
                                             onResetThumbnail={onResetCollectionThumbnail}
                                             onDelete={onDeleteCollection}
                                             viewMode={viewMode}
-                                            isThumbnailPending={!!thumbnailHydrationPendingIds[col.id]}
+                                            isThumbnailPending={!!thumbnailHydrationPendingIds[col.id] || !!smartSummaryPendingIds[col.id]}
                                         />
                                     </motion.div>
                                 ))}
@@ -355,7 +357,7 @@ export function CollectionList<T extends Collection>({
                                     onResetThumbnail={onResetCollectionThumbnail}
                                     onDelete={onDeleteCollection}
                                     viewMode={viewMode}
-                                    isThumbnailPending={!!thumbnailHydrationPendingIds[col.id]}
+                                    isThumbnailPending={!!thumbnailHydrationPendingIds[col.id] || !!smartSummaryPendingIds[col.id]}
                                 />
                             </motion.div>
                         ))}

--- a/src/features/filters/components/__tests__/CollectionItem.test.tsx
+++ b/src/features/filters/components/__tests__/CollectionItem.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '../../../../test/testUtils';
 import { describe, expect, it, vi } from 'vitest';
 import type { Collection, FilterState } from '../../../../types';
 import { CollectionItem } from '../CollectionItem';
+import { createDefaultFilters } from '../../../../utils/filterState';
 
 vi.mock('../../../../components/ui/PrivacyAwareThumbnail', () => ({
     PrivacyAwareThumbnail: ({ src }: { src?: string | null }) => (
@@ -34,6 +35,13 @@ const baseCollection: Collection = {
     createdAt: 1,
     updatedAt: 1,
     source: 'ambit'
+};
+
+const smartCollection: Collection = {
+    ...baseCollection,
+    id: 'smart-collection-1',
+    name: 'Smart Collection One',
+    filters: createDefaultFilters({ dateRange: 'today' })
 };
 
 const noopDrag = (_event: React.DragEvent, _collectionId: string) => { };
@@ -105,5 +113,33 @@ describe('CollectionItem thumbnail hydration states', () => {
         });
 
         expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
+    });
+
+    it('renders a skeleton while a smart collection thumbnail is pending', () => {
+        renderCollectionItem(smartCollection, { isThumbnailPending: true });
+
+        expect(screen.getByTestId('collection-thumbnail-skeleton')).toBeTruthy();
+        expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();
+        expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
+    });
+
+    it('renders a cached smart collection thumbnail instead of the pending skeleton', () => {
+        renderCollectionItem({
+            ...smartCollection,
+            thumbnail: 'asset://cached-smart-thumb.webp',
+            thumbnailSourceKind: 'dynamic'
+        }, { isThumbnailPending: true });
+
+        expect(screen.getByTestId('privacy-aware-thumbnail').getAttribute('data-src')).toBe('asset://cached-smart-thumb.webp');
+        expect(screen.queryByTestId('collection-thumbnail-skeleton')).toBeNull();
+        expect(screen.queryByTestId('collection-thumbnail-fallback')).toBeNull();
+    });
+
+    it('renders the smart collection fallback after pending clears with no thumbnail', () => {
+        renderCollectionItem(smartCollection);
+
+        expect(screen.getByTestId('collection-thumbnail-fallback')).toBeTruthy();
+        expect(screen.queryByTestId('collection-thumbnail-skeleton')).toBeNull();
+        expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
     });
 });

--- a/src/hooks/__tests__/useCollectionOperations.test.tsx
+++ b/src/hooks/__tests__/useCollectionOperations.test.tsx
@@ -2,15 +2,28 @@
 import { renderHook, act } from '../../test/testUtils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useCollectionOperations } from '../useCollectionOperations';
-import { AIImage, Collection } from '../../types';
+import { AIImage, Collection, FilterState, SmartCollection } from '../../types';
+import { createDefaultFilters } from '../../utils/filterState';
 
 // --- Mocks ---
 
 const mockAddToast = vi.fn();
+const mockRefreshCollectionThumbnails = vi.fn();
+const mockRefreshSmartCounts = vi.fn();
 vi.mock('../useToast', () => ({
     useToast: () => ({
         addToast: mockAddToast,
     }),
+}));
+
+vi.mock('../../stores/collectionStore', () => ({
+    useCollectionStore: (selector: (state: {
+        refreshCollectionThumbnails: typeof mockRefreshCollectionThumbnails;
+        refreshSmartCounts: typeof mockRefreshSmartCounts;
+    }) => unknown) => selector({
+        refreshCollectionThumbnails: mockRefreshCollectionThumbnails,
+        refreshSmartCounts: mockRefreshSmartCounts
+    })
 }));
 
 vi.mock('../../services/db/collectionRepo', () => ({
@@ -30,6 +43,7 @@ describe('useCollectionOperations', () => {
     const mockCollections: Collection[] = [
         { id: 'col1', name: 'Collection 1', createdAt: 100, source: 'ambit', count: 5, imageIds: ['img1'] },
     ];
+    const smartFilters: FilterState = createDefaultFilters({ searchQuery: 'portrait' });
 
     const makeImage = (overrides: Partial<AIImage> = {}): AIImage => ({
         id: 'img2',
@@ -72,6 +86,8 @@ describe('useCollectionOperations', () => {
         (collectionRepo.removeImagesFromCollection as any).mockResolvedValue(undefined);
         (collectionRepo.setCollectionCustomThumbnail as any).mockResolvedValue(undefined);
         mockRefreshCollections.mockResolvedValue(undefined);
+        mockRefreshCollectionThumbnails.mockResolvedValue(undefined);
+        mockRefreshSmartCounts.mockResolvedValue(undefined);
     });
 
     describe('createCollection', () => {
@@ -141,6 +157,80 @@ describe('useCollectionOperations', () => {
             expect(nextState[0].count).toBe(6); // 5 + 1
             expect(addImgs).toHaveBeenCalledWith('col1', ['img2']);
         });
+
+        it('refreshes static collection thumbnails after adding images', async () => {
+            const { result } = renderHook(() => useCollectionOperations(props));
+
+            await act(async () => {
+                await result.current.addImagesToCollection(['img2'], 'col1');
+            });
+
+            expect(mockRefreshCollectionThumbnails).toHaveBeenCalledTimes(1);
+            expect(mockRefreshCollectionThumbnails).toHaveBeenCalledWith(true);
+            expect(mockRefreshSmartCounts).not.toHaveBeenCalled();
+        });
+
+        it('refreshes targeted smart summaries after adding images to a smart collection', async () => {
+            const smartCollection: SmartCollection = {
+                id: 'smart1',
+                name: 'Smart Collection',
+                createdAt: 300,
+                source: 'ambit',
+                count: 1,
+                imageIds: [],
+                filters: smartFilters
+            };
+            const { result } = renderHook(() => useCollectionOperations({
+                ...props,
+                collections: [],
+                smartCollections: [smartCollection]
+            }));
+
+            await act(async () => {
+                await result.current.addImagesToCollection(['img2'], 'smart1');
+            });
+
+            expect(mockRefreshCollectionThumbnails).not.toHaveBeenCalled();
+            expect(mockRefreshSmartCounts).toHaveBeenCalledTimes(1);
+            expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
+                collectionIds: ['smart1'],
+                includeArchived: true,
+                includePromptSearch: true,
+                markPending: true
+            });
+        });
+    });
+
+    describe('removeImagesFromCollection', () => {
+        it('refreshes targeted smart summaries after removing images from a smart collection', async () => {
+            const smartCollection: SmartCollection = {
+                id: 'smart1',
+                name: 'Smart Collection',
+                createdAt: 300,
+                source: 'ambit',
+                count: 3,
+                imageIds: [],
+                filters: smartFilters
+            };
+            const { result } = renderHook(() => useCollectionOperations({
+                ...props,
+                collections: [],
+                smartCollections: [smartCollection]
+            }));
+
+            await act(async () => {
+                await result.current.removeImagesFromCollection(['img1'], 'smart1');
+            });
+
+            expect(mockRefreshCollectionThumbnails).not.toHaveBeenCalled();
+            expect(mockRefreshSmartCounts).toHaveBeenCalledTimes(1);
+            expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
+                collectionIds: ['smart1'],
+                includeArchived: true,
+                includePromptSearch: true,
+                markPending: true
+            });
+        });
     });
 
     describe('moveImagesBetweenCollections', () => {
@@ -166,6 +256,94 @@ describe('useCollectionOperations', () => {
 
             expect(source.count).toBe(4);
             expect(target.count).toBe(1);
+        });
+
+        it('refreshes static collection thumbnails once when moving between static collections', async () => {
+            const multiProps = {
+                ...props,
+                collections: [
+                    ...mockCollections,
+                    { id: 'col2', name: 'Target', createdAt: 200, source: 'ambit' as const, count: 0, imageIds: [] as string[] }
+                ]
+            };
+            const { result } = renderHook(() => useCollectionOperations(multiProps));
+
+            await act(async () => {
+                await result.current.moveImagesBetweenCollections(['img1'], 'col1', 'col2');
+            });
+
+            expect(mockRefreshCollectionThumbnails).toHaveBeenCalledTimes(1);
+            expect(mockRefreshCollectionThumbnails).toHaveBeenCalledWith(true);
+            expect(mockRefreshSmartCounts).not.toHaveBeenCalled();
+        });
+
+        it('refreshes both static and smart summaries when moving between mixed collection types', async () => {
+            const smartCollection: SmartCollection = {
+                id: 'smart1',
+                name: 'Smart Collection',
+                createdAt: 300,
+                source: 'ambit',
+                count: 0,
+                imageIds: [],
+                filters: smartFilters
+            };
+            const { result } = renderHook(() => useCollectionOperations({
+                ...props,
+                smartCollections: [smartCollection]
+            }));
+
+            await act(async () => {
+                await result.current.moveImagesBetweenCollections(['img1'], 'col1', 'smart1');
+            });
+
+            expect(mockRefreshCollectionThumbnails).toHaveBeenCalledTimes(1);
+            expect(mockRefreshCollectionThumbnails).toHaveBeenCalledWith(true);
+            expect(mockRefreshSmartCounts).toHaveBeenCalledTimes(1);
+            expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
+                collectionIds: ['smart1'],
+                includeArchived: true,
+                includePromptSearch: true,
+                markPending: true
+            });
+        });
+
+        it('refreshes both smart summaries in one targeted call when moving between smart collections', async () => {
+            const sourceSmart: SmartCollection = {
+                id: 'smart-source',
+                name: 'Smart Source',
+                createdAt: 300,
+                source: 'ambit',
+                count: 3,
+                imageIds: [],
+                filters: smartFilters
+            };
+            const targetSmart: SmartCollection = {
+                id: 'smart-target',
+                name: 'Smart Target',
+                createdAt: 400,
+                source: 'ambit',
+                count: 0,
+                imageIds: [],
+                filters: createDefaultFilters({ dateRange: 'today' })
+            };
+            const { result } = renderHook(() => useCollectionOperations({
+                ...props,
+                collections: [],
+                smartCollections: [sourceSmart, targetSmart]
+            }));
+
+            await act(async () => {
+                await result.current.moveImagesBetweenCollections(['img1'], 'smart-source', 'smart-target');
+            });
+
+            expect(mockRefreshCollectionThumbnails).not.toHaveBeenCalled();
+            expect(mockRefreshSmartCounts).toHaveBeenCalledTimes(1);
+            expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
+                collectionIds: ['smart-source', 'smart-target'],
+                includeArchived: true,
+                includePromptSearch: true,
+                markPending: true
+            });
         });
     });
 

--- a/src/hooks/useCollectionOperations.ts
+++ b/src/hooks/useCollectionOperations.ts
@@ -36,6 +36,30 @@ export const useCollectionOperations = ({
   const { addToast } = useToast();
   const queryClient = useQueryClient();
   const maskedKeywords = useSettingsStore(s => s.settings.maskedKeywords);
+  const refreshCollectionThumbnails = useCollectionStore(s => s.refreshCollectionThumbnails);
+  const refreshSmartCounts = useCollectionStore(s => s.refreshSmartCounts);
+
+  const refreshAffectedCollectionThumbnails = useCallback((affectedCollections: Collection[]) => {
+    const hasStaticCollection = affectedCollections.some(collection => !collection.filters);
+    const smartCollectionIds = [...new Set(
+      affectedCollections
+        .filter(collection => !!collection.filters)
+        .map(collection => collection.id)
+    )];
+
+    if (hasStaticCollection) {
+      void refreshCollectionThumbnails(true);
+    }
+
+    if (smartCollectionIds.length > 0) {
+      void refreshSmartCounts({
+        collectionIds: smartCollectionIds,
+        includeArchived: true,
+        includePromptSearch: true,
+        markPending: true
+      });
+    }
+  }, [refreshCollectionThumbnails, refreshSmartCounts]);
 
   const createCollection = useCallback(async (name: string, filters?: FilterState) => {
     const id = `c_${Date.now()}`;
@@ -215,12 +239,13 @@ export const useCollectionOperations = ({
         refreshCollections(),
         queryClient.invalidateQueries({ queryKey: ['images'] })
       ]);
+      refreshAffectedCollectionThumbnails([col]);
     } catch (e) {
       // Rollback
       setAllCollections(prev => prev.map(c => c.id === collectionId ? col : c));
       addToast("Failed to add to collection", "error");
     }
-  }, [collections, smartCollections, setAllCollections, refreshCollections, addToast]);
+  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast]);
 
   const removeImagesFromCollection = useCallback(async (imageIds: string[], collectionId: string) => {
     const col = [...collections, ...smartCollections].find(c => c.id === collectionId);
@@ -251,12 +276,13 @@ export const useCollectionOperations = ({
         refreshCollections(),
         queryClient.invalidateQueries({ queryKey: ['images'] })
       ]);
+      refreshAffectedCollectionThumbnails([col]);
     } catch (e) {
       // Rollback
       setAllCollections(prev => prev.map(c => c.id === collectionId ? col : c));
       addToast("Failed to remove from collection", "error");
     }
-  }, [collections, smartCollections, setAllCollections, refreshCollections, addToast]);
+  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast]);
 
   // Deprecated/Aliased for backward compat
   const saveSmartCollection = useCallback(async (name: string, filters: FilterState) => {
@@ -297,6 +323,7 @@ export const useCollectionOperations = ({
         refreshCollections(),
         queryClient.invalidateQueries({ queryKey: ['images'] })
       ]);
+      refreshAffectedCollectionThumbnails([sourceCol, targetCol]);
     } catch (e) {
       // Rollback both
       setAllCollections(prev => prev.map(c => {
@@ -306,7 +333,7 @@ export const useCollectionOperations = ({
       }));
       addToast("Failed to move images", "error");
     }
-  }, [collections, smartCollections, setAllCollections, refreshCollections, addToast]);
+  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast]);
 
   const setCollectionThumbnail = useCallback(async (collectionId: string, image: AIImage) => {
     const col = [...collections, ...smartCollections].find(c => c.id === collectionId);

--- a/src/services/db/__tests__/collectionRepo.test.ts
+++ b/src/services/db/__tests__/collectionRepo.test.ts
@@ -32,6 +32,10 @@ const makeCollectionRow = (overrides: Record<string, unknown> = {}) => ({
     created_at: 1,
     updated_at: 1,
     custom_thumbnail: null,
+    dynamic_thumbnail_path: null,
+    dynamic_safe_thumbnail_path: null,
+    dynamic_thumbnail_is_sensitive: null,
+    dynamic_thumbnail_cached_at: null,
     filter_state: null,
     manual_exclusions: null,
     source: 'ambit',
@@ -84,6 +88,18 @@ describe('collectionRepo filter normalization', () => {
         expect(filters?.controlNets).toEqual([]);
         expect(filters?.ipAdapters).toEqual([]);
         expect(filters?.pinnedOnly).toBe(false);
+    });
+
+    it('backfills missing dynamic thumbnail cache columns from the TypeScript schema guard', async () => {
+        dbMocks.select.mockResolvedValue([{ name: 'id' }, { name: 'created_at' }, { name: 'updated_at' }]);
+
+        const { ensureCollectionSchema } = await import('../collectionRepo');
+        await ensureCollectionSchema();
+
+        expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_path TEXT');
+        expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_safe_thumbnail_path TEXT');
+        expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_is_sensitive INTEGER');
+        expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_cached_at INTEGER');
     });
 });
 
@@ -159,6 +175,91 @@ describe('collectionRepo thumbnail hydration', () => {
         expect(queries.join('\n')).not.toContain('c.id as collection_id');
         expect(queries.join('\n')).not.toContain('WHERE id IN');
         expect(queries.join('\n')).not.toContain('WHERE path IN');
+    });
+
+    it('maps cached dynamic thumbnails without running thumbnail hydration queries', async () => {
+        const queries: string[] = [];
+        dbMocks.select.mockImplementation(async (query: string) => {
+            queries.push(query);
+            if (query.includes('SELECT * FROM collections')) {
+                return [makeCollectionRow({
+                    name: 'Cached',
+                    dynamic_thumbnail_path: 'C:/thumbs/cached.webp',
+                    dynamic_safe_thumbnail_path: 'C:/thumbs/cached-safe.webp',
+                    dynamic_thumbnail_is_sensitive: 1,
+                    filter_state: JSON.stringify({ dateRange: 'today' })
+                })];
+            }
+            if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 0 }];
+            return [];
+        });
+
+        const { getAllCollectionsWithStats } = await import('../collectionRepo');
+        const collections = await getAllCollectionsWithStats({ includeThumbnails: false });
+
+        expect(collections[0]).toEqual(expect.objectContaining({
+            thumbnail: 'asset://C:/thumbs/cached.webp',
+            safeThumbnail: 'asset://C:/thumbs/cached-safe.webp',
+            thumbnailIsSensitive: true,
+            thumbnailSourceKind: 'dynamic'
+        }));
+        expect(queries.join('\n')).not.toContain('c.id as collection_id');
+    });
+
+    it('keeps cached smart thumbnails during full collection reloads until smart hydration runs', async () => {
+        const queries: string[] = [];
+        dbMocks.select.mockImplementation(async (query: string) => {
+            queries.push(query);
+            if (query.includes('SELECT * FROM collections')) {
+                return [makeCollectionRow({
+                    id: 'smart-1',
+                    name: 'Cached Smart',
+                    filter_state: JSON.stringify({ dateRange: 'today' }),
+                    dynamic_thumbnail_path: 'C:/thumbs/cached-smart.webp',
+                    dynamic_safe_thumbnail_path: 'C:/thumbs/cached-smart-safe.webp',
+                    dynamic_thumbnail_is_sensitive: 0
+                })];
+            }
+            if (query.includes('COUNT(*) as count')) return [];
+            return [];
+        });
+
+        const { getAllCollectionsWithStats } = await import('../collectionRepo');
+        const collections = await getAllCollectionsWithStats();
+
+        expect(collections[0]).toEqual(expect.objectContaining({
+            id: 'smart-1',
+            count: 0,
+            thumbnail: 'asset://C:/thumbs/cached-smart.webp',
+            safeThumbnail: 'asset://C:/thumbs/cached-smart-safe.webp',
+            thumbnailIsSensitive: false,
+            thumbnailSourceKind: 'dynamic'
+        }));
+        expect(queries.join('\n')).not.toContain('c.id as collection_id');
+        expect(dbMocks.execute).not.toHaveBeenCalled();
+    });
+
+    it('does not display a cached dynamic thumbnail over a custom thumbnail', async () => {
+        dbMocks.select.mockImplementation(async (query: string) => {
+            if (query.includes('SELECT * FROM collections')) {
+                return [makeCollectionRow({
+                    custom_thumbnail: 'img-custom',
+                    dynamic_thumbnail_path: 'C:/thumbs/cached.webp',
+                    dynamic_safe_thumbnail_path: 'C:/thumbs/cached-safe.webp',
+                    dynamic_thumbnail_is_sensitive: 1
+                })];
+            }
+            if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 1 }];
+            return [];
+        });
+
+        const { getAllCollectionsWithStats } = await import('../collectionRepo');
+        const collections = await getAllCollectionsWithStats({ includeThumbnails: false });
+
+        expect(collections[0].customThumbnail).toBe('img-custom');
+        expect(collections[0].thumbnail).toBeUndefined();
+        expect(collections[0].safeThumbnail).toBeUndefined();
+        expect(collections[0].thumbnailSourceKind).toBeUndefined();
     });
 
     it('resolves custom image paths through the targeted path lookup', async () => {
@@ -238,5 +339,106 @@ describe('collectionRepo thumbnail hydration', () => {
         expect(collections[0].thumbnailSourceKind).toBe('dynamic');
         expect(dynamicQuery.match(/ORDER BY i\.is_pinned DESC, i\.timestamp DESC/g)?.length).toBeGreaterThanOrEqual(2);
         expect(dynamicQuery).toContain('AND i.privacy_hidden = 0');
+    });
+
+    it('writes raw dynamic thumbnail paths to the collection cache after static hydration', async () => {
+        dbMocks.select.mockImplementation(async (query: string) => {
+            if (query.includes('c.id as collection_id')) {
+                return [{
+                    collection_id: 'c1',
+                    dynamic_thumb: 'C:/thumbs/unsafe.webp',
+                    dynamic_privacy: 1,
+                    safe_thumb: 'C:/thumbs/safe.webp'
+                }];
+            }
+            return [];
+        });
+
+        const { getCollectionThumbnailSummaries } = await import('../collectionRepo');
+        await getCollectionThumbnailSummaries([{
+            id: 'c1',
+            name: 'Collection',
+            createdAt: 1,
+            source: 'ambit',
+            count: 1,
+            imageIds: []
+        }]);
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_thumbnail_path'),
+            ['C:/thumbs/unsafe.webp', 'C:/thumbs/safe.webp', 1, expect.any(Number), 'c1']
+        );
+    });
+
+    it('clears the dynamic thumbnail cache when static hydration finds no thumbnail', async () => {
+        dbMocks.select.mockImplementation(async (query: string) => {
+            if (query.includes('c.id as collection_id')) {
+                return [{
+                    collection_id: 'c1',
+                    dynamic_thumb: null,
+                    dynamic_privacy: null,
+                    safe_thumb: null
+                }];
+            }
+            return [];
+        });
+
+        const { getCollectionThumbnailSummaries } = await import('../collectionRepo');
+        await getCollectionThumbnailSummaries([{
+            id: 'c1',
+            name: 'Collection',
+            createdAt: 1,
+            source: 'ambit',
+            count: 1,
+            imageIds: []
+        }]);
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_thumbnail_path'),
+            [null, null, null, null, 'c1']
+        );
+    });
+
+    it('writes raw dynamic thumbnail paths to the collection cache after smart summary hydration', async () => {
+        dbMocks.select.mockImplementation(async (query: string) => {
+            if (query.includes('COUNT(*) FROM images')) return [{ id: 'smart-1', count: 2 }];
+            if (query.includes('SELECT thumbnail_path, privacy_hidden')) {
+                return [{ thumbnail_path: 'C:/thumbs/smart.webp', privacy_hidden: 0 }];
+            }
+            if (query.includes('AND privacy_hidden = 0')) {
+                return [{ thumbnail_path: 'C:/thumbs/smart-safe.webp' }];
+            }
+            return [];
+        });
+
+        const { getSmartCollectionSummaries } = await import('../collectionRepo');
+        await getSmartCollectionSummaries([{
+            id: 'smart-1',
+            name: 'Smart',
+            createdAt: 1,
+            source: 'ambit',
+            count: 0,
+            imageIds: [],
+            filters: {
+                searchQuery: '',
+                models: [],
+                tools: [],
+                loras: [],
+                embeddings: [],
+                hypernetworks: [],
+                samplers: [],
+                generationTypes: [],
+                controlNets: [],
+                ipAdapters: [],
+                dateRange: 'today',
+                favoritesOnly: false,
+                collectionId: null
+            } as FilterState
+        }]);
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_thumbnail_path'),
+            ['C:/thumbs/smart.webp', 'C:/thumbs/smart-safe.webp', 0, expect.any(Number), 'smart-1']
+        );
     });
 });

--- a/src/services/db/collectionRepo.ts
+++ b/src/services/db/collectionRepo.ts
@@ -28,6 +28,10 @@ export interface DbCollection {
     custom_thumbnail?: string;
     source: 'ambit' | 'invoke';
     updated_at?: number;
+    dynamic_thumbnail_path?: string | null;
+    dynamic_safe_thumbnail_path?: string | null;
+    dynamic_thumbnail_is_sensitive?: number | null;
+    dynamic_thumbnail_cached_at?: number | null;
 }
 
 interface CollectionThumbnailRow {
@@ -64,6 +68,18 @@ export interface CollectionThumbnailSummary {
     thumbnailSourceKind?: Collection['thumbnailSourceKind'];
 }
 
+interface CollectionThumbnailBuildResult {
+    summaries: Record<string, CollectionThumbnailSummary>;
+    cacheUpdates: DynamicThumbnailCacheUpdate[];
+}
+
+interface DynamicThumbnailCacheUpdate {
+    collectionId: string;
+    thumbnailPath?: string | null;
+    safeThumbnailPath?: string | null;
+    thumbnailIsSensitive?: boolean | null;
+}
+
 interface CollectionStatsOptions {
     includeThumbnails?: boolean;
 }
@@ -75,6 +91,10 @@ interface SmartCollectionSummaryOptions {
 interface CollectionThumbnailInput {
     id: string;
     custom_thumbnail?: string | null;
+}
+
+interface CollectionSchemaColumn {
+    name: string;
 }
 
 const toDisplayUrl = (rawPath?: string | null): string | undefined => {
@@ -135,11 +155,50 @@ const loadImageThumbnailLookup = async (
     return matches;
 };
 
+const getCachedDynamicThumbnailSummary = (collection: DbCollection): CollectionThumbnailSummary | undefined => {
+    if (collection.custom_thumbnail || !collection.dynamic_thumbnail_path) return undefined;
+
+    return {
+        thumbnail: toDisplayUrl(collection.dynamic_thumbnail_path),
+        safeThumbnail: toDisplayUrl(collection.dynamic_safe_thumbnail_path),
+        thumbnailIsSensitive: collection.dynamic_thumbnail_is_sensitive === 1,
+        thumbnailSourceKind: 'dynamic'
+    };
+};
+
+const writeDynamicThumbnailCache = async (
+    db: Awaited<ReturnType<typeof getDb>>,
+    updates: DynamicThumbnailCacheUpdate[]
+) => {
+    if (updates.length === 0) return;
+
+    const cachedAt = Date.now();
+    for (const update of updates) {
+        const hasThumbnail = !!update.thumbnailPath;
+        await db.execute(
+            `UPDATE collections
+             SET dynamic_thumbnail_path = ?,
+                 dynamic_safe_thumbnail_path = ?,
+                 dynamic_thumbnail_is_sensitive = ?,
+                 dynamic_thumbnail_cached_at = ?
+             WHERE id = ?
+               AND (custom_thumbnail IS NULL OR custom_thumbnail = '')`,
+            [
+                hasThumbnail ? update.thumbnailPath : null,
+                hasThumbnail ? update.safeThumbnailPath || null : null,
+                hasThumbnail ? (update.thumbnailIsSensitive ? 1 : 0) : null,
+                hasThumbnail ? cachedAt : null,
+                update.collectionId
+            ]
+        );
+    }
+};
+
 const buildCollectionThumbnailSummaries = async (
     db: Awaited<ReturnType<typeof getDb>>,
     collections: CollectionThumbnailInput[]
-): Promise<Record<string, CollectionThumbnailSummary>> => {
-    if (collections.length === 0) return {};
+): Promise<CollectionThumbnailBuildResult> => {
+    if (collections.length === 0) return { summaries: {}, cacheUpdates: [] };
 
     const ids = [...new Set(collections.map((collection) => collection.id).filter(Boolean))];
     const thumbnailRows: CollectionThumbnailRow[] = [];
@@ -198,7 +257,8 @@ const buildCollectionThumbnailSummaries = async (
     const unresolvedCustomValues = customThumbValues.filter((value) => !customById.has(value));
     const customByPath = await loadImageThumbnailLookup(db, 'path', unresolvedCustomValues);
 
-    return Object.fromEntries(collections.map((collection) => {
+    const cacheUpdates: DynamicThumbnailCacheUpdate[] = [];
+    const summaries = Object.fromEntries(collections.map((collection) => {
         const thumbRow = thumbMap.get(collection.id);
         const customThumb = collection.custom_thumbnail
             ? customById.get(collection.custom_thumbnail) ?? customByPath.get(collection.custom_thumbnail)
@@ -222,6 +282,15 @@ const buildCollectionThumbnailSummaries = async (
             }
         }
 
+        if (!collection.custom_thumbnail) {
+            cacheUpdates.push({
+                collectionId: collection.id,
+                thumbnailPath: rawThumb || null,
+                safeThumbnailPath: rawThumb ? safeThumb || null : null,
+                thumbnailIsSensitive: rawThumb ? thumbnailIsSensitive : null
+            });
+        }
+
         return [collection.id, {
             thumbnail: toDisplayUrl(rawThumb),
             safeThumbnail: collection.custom_thumbnail ? undefined : toDisplayUrl(safeThumb),
@@ -229,6 +298,8 @@ const buildCollectionThumbnailSummaries = async (
             thumbnailSourceKind
         }];
     }));
+
+    return { summaries, cacheUpdates };
 };
 
 export const parsePersistedCollectionFilters = (filterState?: string | null): FilterState | undefined => {
@@ -253,26 +324,54 @@ export const ensureCollectionSchema = async () => {
     return dbMutex.dispatch(async () => {
         const db = await getDb();
         try {
-            // Check if updated_at column exists
-            const columns = await db.select<{ name: string }[]>('PRAGMA table_info(collections)');
-            const hasUpdatedAt = columns.some(c => c.name === 'updated_at');
+            const columns = await db.select<CollectionSchemaColumn[]>('PRAGMA table_info(collections)');
+            const existingColumns = new Set(columns.map(c => c.name));
 
-            if (!hasUpdatedAt) {
-                console.log('[DB] Migrating collections table: adding updated_at column');
+            const addColumnIfMissing = async (
+                columnName: string,
+                alterSql: string,
+                afterAdd?: () => Promise<unknown>
+            ) => {
+                if (existingColumns.has(columnName)) return;
+
+                console.log(`[DB] Migrating collections table: adding ${columnName} column`);
                 try {
-                    await db.execute('ALTER TABLE collections ADD COLUMN updated_at INTEGER');
-                    // Backfill updated_at with created_at for existing records
-                    await db.execute('UPDATE collections SET updated_at = created_at WHERE updated_at IS NULL');
+                    await db.execute(alterSql);
+                    existingColumns.add(columnName);
+                    await afterAdd?.();
                 } catch (e: unknown) {
                     // Ignore duplicate column error if it raced despite mutex (unlikely but safe)
                     const message = e instanceof Error ? e.message : String(e);
                     if (message.includes('duplicate column')) {
-                        console.warn('[DB] Migration raced, column already exists (handled)');
+                        console.warn(`[DB] Migration raced, ${columnName} column already exists (handled)`);
+                        existingColumns.add(columnName);
                     } else {
                         throw e;
                     }
                 }
-            }
+            };
+
+            await addColumnIfMissing(
+                'updated_at',
+                'ALTER TABLE collections ADD COLUMN updated_at INTEGER',
+                () => db.execute('UPDATE collections SET updated_at = created_at WHERE updated_at IS NULL')
+            );
+            await addColumnIfMissing(
+                'dynamic_thumbnail_path',
+                'ALTER TABLE collections ADD COLUMN dynamic_thumbnail_path TEXT'
+            );
+            await addColumnIfMissing(
+                'dynamic_safe_thumbnail_path',
+                'ALTER TABLE collections ADD COLUMN dynamic_safe_thumbnail_path TEXT'
+            );
+            await addColumnIfMissing(
+                'dynamic_thumbnail_is_sensitive',
+                'ALTER TABLE collections ADD COLUMN dynamic_thumbnail_is_sensitive INTEGER'
+            );
+            await addColumnIfMissing(
+                'dynamic_thumbnail_cached_at',
+                'ALTER TABLE collections ADD COLUMN dynamic_thumbnail_cached_at INTEGER'
+            );
         } catch (e) {
             console.error('[DB] Failed to ensure collection schema', e);
         }
@@ -409,28 +508,39 @@ export const getAllCollectionsWithStats = async (options: CollectionStatsOptions
     );
     const countMap = new Map(counts.map(c => [c.collection_id, c.count]));
 
-    let mappedCollections: Collection[] = collections.map(c => ({
-        id: c.id,
-        name: c.name,
-        color: c.color,
-        isArchived: !!c.is_archived,
-        isPinned: !!c.is_pinned,
-        createdAt: c.created_at,
-        updatedAt: c.updated_at || c.created_at, // Fallback to created_at if updated_at is null
-        count: countMap.get(c.id) || 0,
-        imageIds: [] as string[],
-        customThumbnail: c.custom_thumbnail,
-        filters: parsePersistedCollectionFilters(c.filter_state),
-        manualExclusions: c.manual_exclusions ? JSON.parse(c.manual_exclusions) : undefined,
-        source: c.source
-    }));
+    let mappedCollections: Collection[] = collections.map(c => {
+        const collection: Collection = {
+            id: c.id,
+            name: c.name,
+            color: c.color,
+            isArchived: !!c.is_archived,
+            isPinned: !!c.is_pinned,
+            createdAt: c.created_at,
+            updatedAt: c.updated_at || c.created_at, // Fallback to created_at if updated_at is null
+            count: countMap.get(c.id) || 0,
+            imageIds: [],
+            customThumbnail: c.custom_thumbnail,
+            filters: parsePersistedCollectionFilters(c.filter_state),
+            manualExclusions: c.manual_exclusions ? JSON.parse(c.manual_exclusions) : undefined,
+            source: c.source
+        };
+        const cachedThumbnail = getCachedDynamicThumbnailSummary(c);
+        return cachedThumbnail ? { ...collection, ...cachedThumbnail } : collection;
+    });
 
     if (includeThumbnails) {
         const thumbnailStartedAt = nowMs();
-        const thumbnails = await buildCollectionThumbnailSummaries(db, collections);
+        const thumbnailInputs = mappedCollections
+            .filter(collection => !collection.filters || !!collection.customThumbnail)
+            .map(collection => ({
+                id: collection.id,
+                custom_thumbnail: collection.customThumbnail ?? null
+            }));
+        const { summaries, cacheUpdates } = await buildCollectionThumbnailSummaries(db, thumbnailInputs);
+        await writeDynamicThumbnailCache(db, cacheUpdates);
         mappedCollections = mappedCollections.map((collection) => ({
             ...collection,
-            ...thumbnails[collection.id]
+            ...summaries[collection.id]
         }));
         logStartupDuration('collection thumbnail hydration', thumbnailStartedAt);
     }
@@ -465,13 +575,17 @@ export const getCollectionThumbnailSummaries = async (
     return timeDbCall(
         'collectionThumbnails',
         `${collections.length} collections`,
-        () => buildCollectionThumbnailSummaries(
-            db,
-            collections.map((collection) => ({
-                id: collection.id,
-                custom_thumbnail: collection.customThumbnail ?? null
-            }))
-        )
+        async () => {
+            const { summaries, cacheUpdates } = await buildCollectionThumbnailSummaries(
+                db,
+                collections.map((collection) => ({
+                    id: collection.id,
+                    custom_thumbnail: collection.customThumbnail ?? null
+                }))
+            );
+            await writeDynamicThumbnailCache(db, cacheUpdates);
+            return summaries;
+        }
     );
 };
 
@@ -507,6 +621,10 @@ export const getSmartCollectionSummaries = async (
 
     const db = await getDb();
     const summaries: Record<string, SmartCollectionSummary> = {};
+    const customThumbnailById = new Map(
+        smartCollections.map(collection => [collection.id, collection.customThumbnail])
+    );
+    const cacheUpdates: DynamicThumbnailCacheUpdate[] = [];
 
     try {
         const queries = smartCollections.map(c => {
@@ -578,14 +696,26 @@ export const getSmartCollectionSummaries = async (
 
             const normal = normalRows[0];
             const safe = safeRows[0];
+            const thumbnailPath = normal?.thumbnail_path || null;
             summaries[query.id] = {
                 ...(summaries[query.id] || { count: 0, thumbnailSourceKind: 'dynamic' as const }),
-                thumbnail: toDisplayUrl(normal?.thumbnail_path),
+                thumbnail: toDisplayUrl(thumbnailPath),
                 safeThumbnail: toDisplayUrl(safe?.thumbnail_path),
                 thumbnailIsSensitive: normal?.privacy_hidden === 1,
                 thumbnailSourceKind: 'dynamic'
             };
+
+            if (!customThumbnailById.get(query.id)) {
+                cacheUpdates.push({
+                    collectionId: query.id,
+                    thumbnailPath,
+                    safeThumbnailPath: thumbnailPath ? safe?.thumbnail_path || null : null,
+                    thumbnailIsSensitive: thumbnailPath ? normal?.privacy_hidden === 1 : null
+                });
+            }
         }
+
+        await writeDynamicThumbnailCache(db, cacheUpdates);
     } catch (e) {
         console.error("[DB] Failed smart collection summaries", e);
     }

--- a/src/stores/__tests__/collectionStore.test.ts
+++ b/src/stores/__tests__/collectionStore.test.ts
@@ -9,6 +9,9 @@ const collectionRepoMocks = vi.hoisted(() => ({
     mockGetSmartCollectionSummaries: vi.fn(),
     mockGetCollectionThumbnailSummaries: vi.fn()
 }));
+const libraryStoreMocks = vi.hoisted(() => ({
+    isImporting: false
+}));
 
 const {
     mockGetAllCollectionsWithStats,
@@ -19,7 +22,7 @@ const {
 vi.mock('../libraryStore', () => ({
     useLibraryStore: {
         getState: () => ({
-            isImporting: false
+            isImporting: libraryStoreMocks.isImporting
         })
     }
 }));
@@ -62,6 +65,7 @@ describe('collectionStore smart count refresh', () => {
         mockGetAllCollectionsWithStats.mockResolvedValue([]);
         mockGetSmartCollectionSummaries.mockResolvedValue({});
         mockGetCollectionThumbnailSummaries.mockResolvedValue({});
+        libraryStoreMocks.isImporting = false;
         resetCollectionStore();
     });
 
@@ -478,6 +482,292 @@ describe('collectionStore smart count refresh', () => {
         );
     });
 
+    it('marks smart summary pending ids while smart thumbnails are loading', async () => {
+        let resolveSummaries: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetSmartCollectionSummaries.mockImplementationOnce(() => new Promise(resolve => {
+            resolveSummaries = resolve;
+        }));
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'smart-date',
+                    name: 'Date Smart',
+                    createdAt: 2,
+                    updatedAt: 2,
+                    source: 'ambit',
+                    count: 0,
+                    imageIds: [],
+                    filters: createDefaultFilters({ dateRange: 'today' })
+                }],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshSmartCounts({ markPending: true });
+
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({
+            'smart-date': true
+        });
+        await waitFor(() => expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(1));
+
+        resolveSummaries?.({
+            'smart-date': {
+                count: 12,
+                thumbnail: 'asset://smart-thumb.webp',
+                safeThumbnail: 'asset://smart-safe.webp',
+                thumbnailIsSensitive: false,
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await refreshPromise;
+
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            count: 12,
+            thumbnail: 'asset://smart-thumb.webp',
+            safeThumbnail: 'asset://smart-safe.webp',
+            thumbnailIsSensitive: false,
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('clears stale smart pending ids when a non-pending refresh supersedes thumbnail hydration', async () => {
+        let resolveStaleSummaries: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetSmartCollectionSummaries
+            .mockImplementationOnce(() => new Promise(resolve => {
+                resolveStaleSummaries = resolve;
+            }))
+            .mockResolvedValueOnce({
+                'smart-date': {
+                    count: 14,
+                    thumbnail: 'asset://replacement-thumb.webp',
+                    thumbnailSourceKind: 'dynamic'
+                }
+            });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'smart-date',
+                    name: 'Date Smart',
+                    createdAt: 2,
+                    updatedAt: 2,
+                    source: 'ambit',
+                    count: 0,
+                    imageIds: [],
+                    filters: createDefaultFilters({ dateRange: 'today' })
+                }],
+                isLoaded: true
+            });
+        });
+
+        const staleRun = useCollectionStore.getState().refreshSmartCounts({ markPending: true });
+        await waitFor(() => expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(1));
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({
+            'smart-date': true
+        });
+
+        const replacementRun = useCollectionStore.getState().refreshSmartCounts({
+            collectionIds: ['smart-date'],
+            includeArchived: true,
+            includePromptSearch: true
+        });
+
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+        await replacementRun;
+
+        resolveStaleSummaries?.({
+            'smart-date': {
+                count: 12,
+                thumbnail: 'asset://stale-thumb.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await staleRun;
+
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            count: 14,
+            thumbnail: 'asset://replacement-thumb.webp',
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('clears smart pending ids when an import-skip refresh supersedes thumbnail hydration', async () => {
+        let resolveStaleSummaries: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetSmartCollectionSummaries.mockImplementationOnce(() => new Promise(resolve => {
+            resolveStaleSummaries = resolve;
+        }));
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'smart-date',
+                    name: 'Date Smart',
+                    createdAt: 2,
+                    updatedAt: 2,
+                    source: 'ambit',
+                    count: 0,
+                    imageIds: [],
+                    filters: createDefaultFilters({ dateRange: 'today' })
+                }],
+                isLoaded: true
+            });
+        });
+
+        const staleRun = useCollectionStore.getState().refreshSmartCounts({ markPending: true });
+        await waitFor(() => expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(1));
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({
+            'smart-date': true
+        });
+
+        libraryStoreMocks.isImporting = true;
+        await useCollectionStore.getState().refreshSmartCounts({ markPending: true });
+
+        expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(1);
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+
+        resolveStaleSummaries?.({
+            'smart-date': {
+                count: 12,
+                thumbnail: 'asset://stale-thumb.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await staleRun;
+
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            count: 0
+        }));
+        expect(useCollectionStore.getState().collections[0].thumbnail).toBeUndefined();
+    });
+
+    it('does not mark a smart collection pending when a cached thumbnail is already loaded', async () => {
+        mockGetSmartCollectionSummaries.mockResolvedValue({
+            'smart-date': {
+                count: 12,
+                thumbnail: 'asset://fresh-smart-thumb.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'smart-date',
+                    name: 'Date Smart',
+                    createdAt: 2,
+                    updatedAt: 2,
+                    source: 'ambit',
+                    count: 0,
+                    imageIds: [],
+                    filters: createDefaultFilters({ dateRange: 'today' }),
+                    thumbnail: 'asset://cached-smart-thumb.webp',
+                    safeThumbnail: 'asset://cached-smart-safe.webp',
+                    thumbnailIsSensitive: false,
+                    thumbnailSourceKind: 'dynamic'
+                }],
+                isLoaded: true
+            });
+        });
+
+        await useCollectionStore.getState().refreshSmartCounts({ markPending: true });
+
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            count: 12,
+            thumbnail: 'asset://fresh-smart-thumb.webp',
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('keeps cached prompt-search smart thumbnails visible during automatic refreshes', async () => {
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'smart-prompt',
+                    name: 'Prompt Smart',
+                    createdAt: 1,
+                    updatedAt: 1,
+                    source: 'ambit',
+                    count: 0,
+                    imageIds: [],
+                    filters: createDefaultFilters({ searchQuery: 'apple' }),
+                    thumbnail: 'asset://cached-prompt-thumb.webp',
+                    thumbnailSourceKind: 'dynamic'
+                }],
+                isLoaded: true
+            });
+        });
+
+        await useCollectionStore.getState().refreshSmartCounts({ markPending: true });
+
+        expect(mockGetSmartCollectionSummaries).not.toHaveBeenCalled();
+        expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            thumbnail: 'asset://cached-prompt-thumb.webp',
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('hydrates prompt-search smart collections when explicitly selected', async () => {
+        mockGetSmartCollectionSummaries.mockResolvedValue({
+            'smart-prompt': {
+                count: 5,
+                thumbnail: 'asset://prompt-thumb.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    {
+                        id: 'smart-prompt',
+                        name: 'Prompt Smart',
+                        createdAt: 1,
+                        updatedAt: 1,
+                        source: 'ambit',
+                        count: 0,
+                        imageIds: [],
+                        filters: createDefaultFilters({ searchQuery: 'apple' })
+                    },
+                    {
+                        id: 'smart-date',
+                        name: 'Date Smart',
+                        createdAt: 2,
+                        updatedAt: 2,
+                        source: 'ambit',
+                        count: 0,
+                        imageIds: [],
+                        filters: createDefaultFilters({ dateRange: 'today' })
+                    }
+                ],
+                isLoaded: true
+            });
+        });
+
+        await useCollectionStore.getState().refreshSmartCounts({
+            collectionIds: ['smart-prompt'],
+            includeArchived: true,
+            includePromptSearch: true,
+            markPending: true
+        });
+
+        expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(1);
+        expect(mockGetSmartCollectionSummaries).toHaveBeenCalledWith(
+            [expect.objectContaining({ id: 'smart-prompt' })],
+            { includeThumbnails: true }
+        );
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            count: 5,
+            thumbnail: 'asset://prompt-thumb.webp',
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
     it('refreshes collection thumbnails without reloading collection rows', async () => {
         mockGetCollectionThumbnailSummaries.mockResolvedValue({
             'static-1': {
@@ -513,6 +803,42 @@ describe('collectionStore smart count refresh', () => {
             thumbnail: 'asset://thumb.webp',
             safeThumbnail: 'asset://safe.webp',
             thumbnailIsSensitive: true,
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('hydrates Invoke board collection thumbnails from derived summaries', async () => {
+        mockGetCollectionThumbnailSummaries.mockResolvedValue({
+            'invoke-board-1': {
+                thumbnail: 'asset://invoke-board-thumb.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [makeStaticCollection({
+                    id: 'invoke-board-1',
+                    name: 'Invoke Board',
+                    source: 'invoke',
+                    count: 2
+                })],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshCollectionThumbnails();
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({
+            'invoke-board-1': true
+        });
+        await refreshPromise;
+
+        expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'invoke-board-1', source: 'invoke' })
+        ]);
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            thumbnail: 'asset://invoke-board-thumb.webp',
             thumbnailSourceKind: 'dynamic'
         }));
     });

--- a/src/stores/collectionStore.ts
+++ b/src/stores/collectionStore.ts
@@ -67,6 +67,7 @@ interface RefreshSmartCountsOptions {
     delayMs?: number;
     includeThumbnails?: boolean;
     includePromptSearch?: boolean;
+    markPending?: boolean;
 }
 
 type RefreshSmartCountsInput = RefreshSmartCountsOptions | Collection[];
@@ -75,6 +76,7 @@ interface CollectionState {
     collections: Collection[];
     isLoaded: boolean;
     thumbnailHydrationPendingIds: Record<string, true>;
+    smartSummaryPendingIds: Record<string, true>;
 
     // Actions
     initialize: () => Promise<void>;
@@ -93,6 +95,7 @@ export const useCollectionStore = create<CollectionState>()(
             collections: [],
             isLoaded: false,
             thumbnailHydrationPendingIds: {},
+            smartSummaryPendingIds: {},
 
             refreshCollections: async (debounced = false) => {
                 const runId = invalidateCollectionRefreshes();
@@ -104,7 +107,7 @@ export const useCollectionStore = create<CollectionState>()(
                         set({ collections: cols });
 
                         // Lazily fetch visible smart counts in the background.
-                        void get().refreshSmartCounts({ includeArchived: false, delayMs: 500 });
+                        void get().refreshSmartCounts({ includeArchived: false, delayMs: 500, markPending: true });
                     } catch (e) {
                         console.error('[CollectionStore] Failed to refresh collections', e);
                     }
@@ -179,16 +182,25 @@ export const useCollectionStore = create<CollectionState>()(
 
             refreshSmartCounts: async (input = {}) => {
                 const runId = ++smartCountRunId;
+                const collectionsSnapshot = Array.isArray(input) ? input : undefined;
+                const options: RefreshSmartCountsOptions = Array.isArray(input)
+                    ? { includePromptSearch: true }
+                    : input;
+                const includeThumbnails = options.includeThumbnails !== false;
+                const shouldManagePending = includeThumbnails && options.markPending;
+
+                if (!shouldManagePending) {
+                    set({ smartSummaryPendingIds: {} });
+                }
+
                 try {
                     if (useLibraryStore.getState().isImporting) {
                         console.log('[CollectionStore] Skipping smart counts refresh - Import already in progress');
+                        if (shouldManagePending && runId === smartCountRunId) {
+                            set({ smartSummaryPendingIds: {} });
+                        }
                         return;
                     }
-
-                    const collectionsSnapshot = Array.isArray(input) ? input : undefined;
-                    const options: RefreshSmartCountsOptions = Array.isArray(input)
-                        ? { includePromptSearch: true }
-                        : input;
 
                     if (options.delayMs && options.delayMs > 0) {
                         await delay(options.delayMs);
@@ -204,12 +216,26 @@ export const useCollectionStore = create<CollectionState>()(
                         && (options.includePromptSearch || shouldAutoRefreshSmartCollectionSummary(c))
                     );
 
-                    if (smartCols.length === 0) return;
+                    if (smartCols.length === 0) {
+                        if (shouldManagePending) {
+                            set({ smartSummaryPendingIds: {} });
+                        }
+                        return;
+                    }
+
+                    if (shouldManagePending) {
+                        set({
+                            smartSummaryPendingIds: Object.fromEntries(
+                                smartCols
+                                    .filter(collection => !collection.thumbnail && !collection.customThumbnail)
+                                    .map(collection => [collection.id, true] as const)
+                            )
+                        });
+                    }
 
                     for (const smartCol of smartCols) {
                         if (runId !== smartCountRunId) return;
 
-                        const includeThumbnails = options.includeThumbnails !== false;
                         const summaries = await getSmartCollectionSummaries([smartCol], { includeThumbnails });
                         if (runId !== smartCountRunId) return;
                         const summary = summaries[smartCol.id];
@@ -234,11 +260,27 @@ export const useCollectionStore = create<CollectionState>()(
                                         : c
                                 )
                             }));
+                            if (shouldManagePending) {
+                                set((state) => {
+                                    const remaining = { ...state.smartSummaryPendingIds };
+                                    delete remaining[smartCol.id];
+                                    return { smartSummaryPendingIds: remaining };
+                                });
+                            }
+                        } else if (shouldManagePending) {
+                            set((state) => {
+                                const remaining = { ...state.smartSummaryPendingIds };
+                                delete remaining[smartCol.id];
+                                return { smartSummaryPendingIds: remaining };
+                            });
                         }
 
                         await delay(SMART_COUNT_YIELD_MS);
                     }
                 } catch (e) {
+                    if (runId === smartCountRunId) {
+                        set({ smartSummaryPendingIds: {} });
+                    }
                     console.error('[CollectionStore] Failed to refresh smart counts', e);
                 }
             },
@@ -340,12 +382,17 @@ export const useCollectionStore = create<CollectionState>()(
 
                         void get().refreshCollectionThumbnails();
 
-                        // Defer visible smart collection counts so startup remains responsive.
+                        // Defer smart summaries so startup remains responsive: counts first,
+                        // then thumbnails for non-prompt smart collections after the list is visible.
                         void get().refreshSmartCounts({
                             includeArchived: false,
                             delayMs: STARTUP_SMART_COUNT_DELAY_MS,
                             includeThumbnails: false
-                        });
+                        }).then(() => get().refreshSmartCounts({
+                            includeArchived: false,
+                            delayMs: 500,
+                            markPending: true
+                        }));
                     } catch (e) {
                         console.error('[CollectionStore] Failed to initialize', e);
                         set({ isLoaded: true });


### PR DESCRIPTION
## Summary

Persist last-known dynamic collection thumbnails so static collections, Invoke board collections, and Smart Collections can show a cached thumbnail immediately after restart. Background hydration still recomputes the correct summary thumbnail and updates or clears the cache.

## What changed

- Added nullable dynamic thumbnail cache columns to `collections` via migration 57 and the TypeScript schema backstop.
- Hydrated collection app state from cached dynamic thumbnails when full thumbnail queries are intentionally skipped.
- Persisted or cleared dynamic cache entries from static and smart thumbnail summary refresh paths, while preserving custom thumbnail priority.
- Refreshed the correct thumbnail summary path after Invoke syncs and manual collection membership changes.
- Added smart thumbnail pending state and skeleton behavior for uncached pending Smart Collections.

## Validation

- `pnpm exec vitest run src/services/db/__tests__/collectionRepo.test.ts src/stores/__tests__/collectionStore.test.ts src/features/filters/components/__tests__/CollectionItem.test.tsx`
- `pnpm exec vitest run src/stores/__tests__/collectionStore.test.ts`
- `pnpm run typecheck`
- `pnpm exec vitest run`
- `pnpm run test:rust`
- `git diff --check`