### PR TITLE
fix: remove AI Studio project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,26 +5,28 @@
 ### High-Performance Local AI Image Manager
 </div>
 
-Ambit is a local-first desktop app for cataloging, searching, and managing large AI-generated image libraries. It is built with Tauri v2, React, TypeScript, Rust, and SQLite.
+Ambit is a local-first desktop app for organizing large AI-generated image libraries. It helps you import folders, browse fast, search by generation metadata, resolve model references, and keep library maintenance work on your own machine.
 
 ## Key Features
 
-*   **Hybrid architecture**: SQLite handles high-volume querying while lightweight config stays portable.
-*   **Local-first**: Core workflows stay on your machine.
-*   **AI-assisted workflows**: Optional analysis and metadata tooling help organize large collections.
-*   **Performance focused**: Virtualized browsing and minimized IPC keep large libraries usable.
+*   **Local library management**: Catalog image folders without moving your source files, then review, remove, recover, and maintain records from one desktop workspace.
+*   **Generation-aware metadata**: Parse prompts, workflows, resources, dimensions, hashes, and model references from common AI image outputs.
+*   **Fast search and filtering**: Use SQLite-backed queries, facets, collections, and saved search state to stay responsive across large libraries.
+*   **Performance-focused browsing**: Virtualized grids, thumbnail handling, and minimized IPC keep day-to-day browsing usable as collections grow.
+*   **Optional intelligence tools**: Gemini-backed actions are available only when you configure your own key and explicitly run an AI feature.
+*   **Privacy-conscious by default**: Core browsing, search, metadata parsing, thumbnails, and settings work locally without telemetry.
 
 ## Technology Stack
 
 *   **Frontend**: React 19, TypeScript, Tailwind CSS, Zustand, React Query
 *   **Backend**: Rust with Tauri v2 and SQLite (`rusqlite`)
-*   **Desktop distribution**: GitHub Releases plus Tauri updater artifacts
+*   **Desktop distribution**: GitHub Releases with Tauri updater artifacts
 
-## Privacy And Network Behavior
+## Privacy and Network Behavior
 
-Ambit is local-first. Core library management, browsing, search, metadata parsing, thumbnails, and settings work on local files without telemetry.
+Ambit is local-first. Core library management, browsing, search, metadata parsing, thumbnails, maintenance, and settings work on local files without telemetry.
 
-The public beta has a few disclosed network paths:
+The public beta has a small set of disclosed network paths:
 
 *   Automatic update checks contact GitHub Releases when enabled. Updates are downloaded and installed only after you confirm the prompt.
 *   Gemini features are optional. Requests are sent only when you configure a key and run an AI action or key verification.
@@ -32,12 +34,6 @@ The public beta has a few disclosed network paths:
 *   GitHub Sponsors, Ko-fi, and project links open only when clicked.
 
 ## Getting Started
-
-### Prerequisites
-
-*   [Node.js](https://nodejs.org/) v20 or newer
-*   [Rust](https://www.rust-lang.org/tools/install) stable
-*   [VS Code](https://code.visualstudio.com/) with the Tauri extension and standard TypeScript tooling
 
 ### Public Beta Builds
 
@@ -49,7 +45,16 @@ Official public beta builds are currently available for **Windows only** while m
 2.  Install and launch the app.
 3.  Report bugs or feedback through [GitHub Issues](https://github.com/AsuraAce/ambit/issues).
 
+The Windows installer includes the packaged app. You do not need Node.js, pnpm, Rust, or VS Code unless you want to build Ambit from source.
+
 ### Development Installation
+
+Development prerequisites:
+
+*   [Node.js](https://nodejs.org/) v20 or newer
+*   [pnpm](https://pnpm.io/) v9 or newer
+*   [Rust](https://www.rust-lang.org/tools/install) stable
+*   Optional: [VS Code](https://code.visualstudio.com/) with the Tauri extension and standard TypeScript tooling
 
 1.  Clone the repository:
     ```bash
@@ -64,6 +69,11 @@ Official public beta builds are currently available for **Windows only** while m
 4.  Run the desktop app:
     ```bash
     pnpm run app:dev
+    ```
+5.  Run focused checks before opening a pull request:
+    ```bash
+    pnpm run typecheck
+    pnpm run test:run
     ```
 
 ## Contributing

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -143,9 +143,6 @@
         },
         {
           "href": "https://ko-fi.com/astraoriondev"
-        },
-        {
-          "href": "https://aistudio.google.com/app/apikey"
         }
       ]
     }

--- a/src/components/ui/OnboardingWizard.tsx
+++ b/src/components/ui/OnboardingWizard.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Sparkles, BrainCircuit, Shield, Key, Check, ArrowRight, Lock, EyeOff, ServerOff, FileJson, Link2, Workflow, Palette, Image, ChevronRight, Zap, Search, Wand2, History, XCircle, Loader2 } from 'lucide-react';
+import { Sparkles, BrainCircuit, Shield, Key, Check, ArrowRight, Lock, EyeOff, ServerOff, FileJson, Link2, Workflow, Palette, Image, Zap, Search, Wand2, History, XCircle, Loader2 } from 'lucide-react';
 import { AppSettings } from '../../types';
 import { APP_NAME } from '../../constants/app';
 import { useToast } from '../../hooks/useToast';
 import { ApiKeyInput } from './ApiKeyInput';
 import { useSettingsStore } from '../../stores/settingsStore';
-import { GOOGLE_AI_STUDIO_API_KEY_URL, openExternalUrl } from '../../utils/externalLinks';
 
 interface OnboardingWizardProps {
     isOpen: boolean;
@@ -281,16 +280,7 @@ export const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
                                             animate={{ opacity: 1, y: 0 }}
                                             className="space-y-4"
                                         >
-                                            <div className="flex justify-between items-end">
-                                                <label className="text-xs font-bold text-gray-500 uppercase tracking-widest">Gemini API Key</label>
-                                                <button
-                                                    type="button"
-                                                    onClick={() => openExternalUrl(GOOGLE_AI_STUDIO_API_KEY_URL)}
-                                                    className="text-xs text-sage-500 hover:text-sage-400 font-bold flex items-center gap-1 transition-colors"
-                                                >
-                                                    Get Free Key <ChevronRight className="w-3 h-3" />
-                                                </button>
-                                            </div>
+                                            <label className="text-xs font-bold text-gray-500 uppercase tracking-widest">Gemini API Key</label>
 
                                             <ApiKeyInput
                                                 value={apiKey}
@@ -311,6 +301,9 @@ export const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
                                                     }
                                                 }}
                                             />
+                                            <p className="text-xs text-gray-500 dark:text-gray-400">
+                                                Use your own Gemini API key. The key is stored locally and requests run only when you explicitly trigger an AI action.
+                                            </p>
                                         </motion.div>
                                     )}
                                 </div>

--- a/src/features/settings/components/IntelligenceTab.tsx
+++ b/src/features/settings/components/IntelligenceTab.tsx
@@ -5,7 +5,6 @@ import { useToast } from '../../../hooks/useToast';
 import { AI_MODELS, DEFAULT_AI_MODEL } from '../../../constants/aiModels';
 import { ApiKeyInput } from '../../../components/ui/ApiKeyInput';
 import { useSettingsStore } from '../../../stores/settingsStore';
-import { GOOGLE_AI_STUDIO_API_KEY_URL, openExternalUrl } from '../../../utils/externalLinks';
 
 interface TabProps {
     settings: AppSettings;
@@ -167,14 +166,7 @@ export const IntelligenceTab: React.FC<TabProps> = React.memo(({ settings, setSe
                             )}
 
                             <p className="text-xs text-gray-500 mt-2">
-                                Your key is stored locally in the OS keyring. Gemini requests are sent only when you verify the key or run an AI feature. Get a key at{' '}
-                                <button
-                                    type="button"
-                                    onClick={() => openExternalUrl(GOOGLE_AI_STUDIO_API_KEY_URL)}
-                                    className="text-sage-600 hover:underline"
-                                >
-                                    Google AI Studio
-                                </button>.
+                                Use your own Gemini API key. Your key is stored locally in the OS keyring, and requests are sent only when you verify the key or run an AI feature.
                             </p>
                         </div>
                     )}

--- a/src/utils/__tests__/externalLinks.test.ts
+++ b/src/utils/__tests__/externalLinks.test.ts
@@ -1,10 +1,6 @@
 import { open } from '@tauri-apps/plugin-shell';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-    GOOGLE_AI_STUDIO_API_KEY_URL,
-    isAllowedExternalUrl,
-    openExternalUrl,
-} from '../externalLinks';
+import { isAllowedExternalUrl, openExternalUrl } from '../externalLinks';
 
 describe('externalLinks', () => {
     beforeEach(() => {
@@ -22,11 +18,13 @@ describe('externalLinks', () => {
     it('falls back to window.open only for allowlisted URLs after Tauri shell fails', async () => {
         vi.mocked(open).mockRejectedValueOnce(new Error('shell unavailable'));
 
-        await openExternalUrl(GOOGLE_AI_STUDIO_API_KEY_URL);
+        const releasesUrl = 'https://github.com/AsuraAce/ambit/releases';
 
-        expect(open).toHaveBeenCalledWith(GOOGLE_AI_STUDIO_API_KEY_URL);
+        await openExternalUrl(releasesUrl);
+
+        expect(open).toHaveBeenCalledWith(releasesUrl);
         expect(window.open).toHaveBeenCalledWith(
-            GOOGLE_AI_STUDIO_API_KEY_URL,
+            releasesUrl,
             '_blank',
             'noopener,noreferrer'
         );

--- a/src/utils/externalLinks.ts
+++ b/src/utils/externalLinks.ts
@@ -6,8 +6,6 @@ import {
     REPOSITORY_URL,
 } from '../constants/support';
 
-export const GOOGLE_AI_STUDIO_API_KEY_URL = 'https://aistudio.google.com/app/apikey';
-
 const normalizeAllowedExternalUrl = (value: string): string | null => {
     try {
         const parsed = new URL(value);
@@ -29,7 +27,6 @@ const allowedExternalUrls = new Set(
         RELEASES_URL,
         GITHUB_SPONSORS_URL,
         KO_FI_URL,
-        GOOGLE_AI_STUDIO_API_KEY_URL,
     ].map((url) => normalizeAllowedExternalUrl(url)).filter((url): url is string => !!url)
 );
 


### PR DESCRIPTION
## Summary
- Refresh the README as a clearer product/public beta README
- Remove user-facing Google AI Studio links from onboarding and intelligence settings
- Remove the AI Studio URL from frontend and Tauri shell allowlists while keeping optional Gemini key support

## Validation
- `pnpm run test:run -- externalLinks`
- `pnpm run typecheck`
- `git diff --check`
- `rg -n "Google AI Studio|AI Studio|GOOGLE_AI_STUDIO_API_KEY_URL|aistudio.google.com|Get Free Key" README.md src docs package.json src-tauri`