### PR TITLE
fix: replace README banner asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img width="1200" height="475" alt="Ambit banner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
+<img width="120" height="120" alt="Ambit app icon" src="public/branding/ambit-mark.svg" />
 
 # Ambit
 ### High-Performance Local AI Image Manager


### PR DESCRIPTION
## Summary
- Replace the stale external README banner image with the local Ambit app icon asset
- Remove the remaining visual Google AI Studio reference from the GitHub README

## Validation
- `git diff --check`
- `rg -n "Google AI Studio|AI Studio|aistudio.google.com|user-attachments/assets/0aa67016" README.md src docs package.json src-tauri`