### PR TITLE
Fix statistics queries and progressive loading

### DIFF
--- a/src/components/ui/Charts.tsx
+++ b/src/components/ui/Charts.tsx
@@ -28,12 +28,28 @@ type ModelChartStat = {
     count: number;
 };
 
+const SKELETON_BAR_WIDTHS = ['92%', '76%', '84%', '63%', '71%'];
+
+const formatAnalysisTarget = (globalTotal: number) =>
+    globalTotal > 0
+        ? `Analyzing ${globalTotal.toLocaleString()} library images`
+        : 'Analyzing library images';
+
 export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
     // Use DB-backed global stats
-    const { stats, setFilters, isFiltering } = useLibraryContext();
+    const {
+        stats,
+        setFilters,
+        isFiltering,
+        globalTotal,
+        isStatsSummaryLoading,
+        isKeywordStatsLoading
+    } = useLibraryContext();
     const { totalGenerations, avgSteps, estSizeMB, modelStats, keywordStats } = stats;
     const modelChartStats: ModelChartStat[] = modelStats ?? [];
     const maxModelCount = Math.max(1, ...modelChartStats.map(stat => stat.count));
+    const shouldShowWordCloudLoading = isStatsSummaryLoading || (isKeywordStatsLoading && keywordStats.length === 0);
+    const analysisTargetLabel = formatAnalysisTarget(globalTotal);
 
     const [showTip, setShowTip] = useState(true);
 
@@ -76,9 +92,24 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
                     )}
 
                     <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-                        <StatCard label="Total Images" value={totalGenerations} />
-                        <StatCard label="Avg. Steps" value={avgSteps} />
-                        <StatCard label="Disk Usage (Est.)" value={`${estSizeMB} MB`} />
+                        <StatCard
+                            label="Total Images"
+                            value={totalGenerations}
+                            isLoading={isStatsSummaryLoading}
+                            loadingText={analysisTargetLabel}
+                        />
+                        <StatCard
+                            label="Avg. Steps"
+                            value={avgSteps}
+                            isLoading={isStatsSummaryLoading}
+                            loadingText="Computing generation summary"
+                        />
+                        <StatCard
+                            label="Disk Usage (Est.)"
+                            value={`${estSizeMB} MB`}
+                            isLoading={isStatsSummaryLoading}
+                            loadingText="Estimating library footprint"
+                        />
                     </div>
 
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -86,7 +117,26 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
                         <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-white/10 rounded-xl p-6 h-80 shadow-sm flex flex-col">
                             <h3 className="text-sm font-bold text-gray-400 mb-6 uppercase tracking-wider flex-shrink-0">Generations per Model (Click to Filter)</h3>
                             <div className="flex-1 min-h-0 w-full overflow-y-auto custom-scrollbar pr-1 space-y-3">
-                                {modelChartStats.length === 0 ? (
+                                {isStatsSummaryLoading ? (
+                                    <div className="h-full flex flex-col justify-center gap-4">
+                                        <div className="space-y-3">
+                                            {SKELETON_BAR_WIDTHS.map((width) => (
+                                                <div key={width} className="space-y-2">
+                                                    <div className="h-3 w-32 rounded-full bg-gray-200/70 dark:bg-white/10 animate-pulse" />
+                                                    <div className="h-2.5 rounded-full bg-gray-200 dark:bg-white/10 overflow-hidden">
+                                                        <div
+                                                            className="h-full rounded-full bg-sage-300/70 dark:bg-sage-500/30 animate-pulse"
+                                                            style={{ width }}
+                                                        />
+                                                    </div>
+                                                </div>
+                                            ))}
+                                        </div>
+                                        <div className="text-[11px] uppercase tracking-[0.24em] font-semibold text-gray-400 text-center">
+                                            {analysisTargetLabel}
+                                        </div>
+                                    </div>
+                                ) : modelChartStats.length === 0 ? (
                                     <div className="h-full flex items-center justify-center text-xs uppercase tracking-wider text-gray-400">
                                         No model stats found
                                     </div>
@@ -113,7 +163,7 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
                                         >
                                             <div className="flex items-center justify-between gap-3 mb-1">
                                                 <span className="text-xs font-medium text-gray-700 dark:text-gray-200 truncate">
-                                                    {stat.name}
+                                                    {stat.fullName ?? stat.name}
                                                 </span>
                                                 <span className="text-xs font-mono text-gray-500 dark:text-gray-400 shrink-0">
                                                     {stat.count.toLocaleString()}
@@ -139,9 +189,9 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
                             </h3>
                             <div className="flex-1 min-h-0">
                                 <WordCloud
-                                    keywords={isFiltering ? [] : (keywordStats || [])}
+                                    keywords={keywordStats || []}
                                     totalImages={totalGenerations}
-                                    isLoading={isFiltering}
+                                    isLoading={shouldShowWordCloudLoading}
                                     onWordClick={(word) => {
                                         setFilters((prev) => ({
                                             ...prev,
@@ -158,9 +208,26 @@ export const StatsDashboard: React.FC<ChartsProps> = ({ images, onFilter }) => {
     );
 };
 
-const StatCard = ({ label, value }: { label: string, value: number | string }) => (
+const StatCard = ({
+    label,
+    value,
+    isLoading = false,
+    loadingText
+}: {
+    label: string;
+    value: number | string;
+    isLoading?: boolean;
+    loadingText?: string;
+}) => (
     <div className="bg-white dark:bg-slate-900 border border-gray-200 dark:border-white/10 p-4 rounded-lg shadow-sm">
         <div className="text-gray-500 dark:text-gray-400 text-xs uppercase mb-1">{label}</div>
-        <div className="text-2xl font-bold text-gray-900 dark:text-white">{value}</div>
+        {isLoading ? (
+            <div className="space-y-3">
+                <div className="h-9 w-28 rounded-lg bg-gray-200/80 dark:bg-white/10 animate-pulse" />
+                <div className="text-[10px] uppercase tracking-[0.2em] text-gray-400">{loadingText}</div>
+            </div>
+        ) : (
+            <div className="text-2xl font-bold text-gray-900 dark:text-white">{value}</div>
+        )}
     </div>
 );

--- a/src/components/ui/__tests__/Charts.test.tsx
+++ b/src/components/ui/__tests__/Charts.test.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '../../../test/testUtils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatsDashboard } from '../Charts';
+
+const createLibraryContextState = () => ({
+    stats: {
+        totalImages: 2,
+        totalGenerations: 2,
+        avgSteps: 28,
+        estSizeMB: '4.8',
+        modelStats: [
+            { name: 'Flux Super Long Model Name', fullName: 'Flux Super Long Model Name', count: 2 },
+            { name: 'Flux Super Long Model Name XL', fullName: 'Flux Super Long Model Name XL', count: 1 }
+        ],
+        keywordStats: [{ text: 'aurora', value: 2 }]
+    },
+    setFilters: vi.fn(),
+    isFiltering: false,
+    globalTotal: 118000,
+    isStatsSummaryLoading: false,
+    isKeywordStatsLoading: false
+});
+
+const libraryContextMocks = vi.hoisted(() => ({
+    stats: {
+        totalImages: 2,
+        totalGenerations: 2,
+        avgSteps: 28,
+        estSizeMB: '4.8',
+        modelStats: [
+            { name: 'Flux Super Long Model Name', fullName: 'Flux Super Long Model Name', count: 2 },
+            { name: 'Flux Super Long Model Name XL', fullName: 'Flux Super Long Model Name XL', count: 1 }
+        ],
+        keywordStats: [{ text: 'aurora', value: 2 }]
+    },
+    setFilters: vi.fn(),
+    isFiltering: false,
+    globalTotal: 118000,
+    isStatsSummaryLoading: false,
+    isKeywordStatsLoading: false
+}));
+
+vi.mock('../../../hooks/useLibraryContext', () => ({
+    useLibraryContext: () => libraryContextMocks
+}));
+
+describe('StatsDashboard', () => {
+    beforeEach(() => {
+        Object.assign(libraryContextMocks, createLibraryContextState());
+        libraryContextMocks.setFilters = vi.fn();
+        vi.clearAllMocks();
+    });
+
+    it('renders full model labels and filters by the full model name on click', () => {
+        const onFilter = vi.fn();
+
+        render(<StatsDashboard images={[]} onFilter={onFilter} />);
+
+        expect(screen.getByText('Flux Super Long Model Name')).toBeTruthy();
+        expect(screen.getByText('Flux Super Long Model Name XL')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: /Flux Super Long Model Name XL/i }));
+
+        expect(onFilter).toHaveBeenCalledWith('model', 'Flux Super Long Model Name XL');
+    });
+
+    it('shows progressive loading placeholders before the summary query resolves', () => {
+        libraryContextMocks.stats = {
+            totalImages: 0,
+            totalGenerations: 0,
+            avgSteps: 0,
+            estSizeMB: '0',
+            modelStats: [],
+            keywordStats: []
+        };
+        libraryContextMocks.isStatsSummaryLoading = true;
+
+        render(<StatsDashboard images={[]} onFilter={vi.fn()} />);
+
+        expect(screen.getAllByText('Analyzing 118,000 library images')).toHaveLength(2);
+        expect(screen.getByText('Computing generation summary')).toBeTruthy();
+        expect(screen.getByText('Estimating library footprint')).toBeTruthy();
+        expect(screen.queryByText('No model stats found')).toBeNull();
+        expect(screen.queryByText('No keywords found')).toBeNull();
+        expect(screen.queryByText('0 MB')).toBeNull();
+    });
+
+    it('renders summary cards and model bars while keyword analysis is still running', () => {
+        libraryContextMocks.stats.keywordStats = [];
+        libraryContextMocks.isKeywordStatsLoading = true;
+
+        render(<StatsDashboard images={[]} onFilter={vi.fn()} />);
+
+        expect(screen.getByText('Total Images')).toBeTruthy();
+        expect(screen.getByText('28')).toBeTruthy();
+        expect(screen.getByText('4.8 MB')).toBeTruthy();
+        expect(screen.getByText('Flux Super Long Model Name')).toBeTruthy();
+        expect(screen.getByText('Analyzing Library')).toBeTruthy();
+        expect(screen.queryByText('Computing generation summary')).toBeNull();
+        expect(screen.queryByText('No keywords found')).toBeNull();
+        expect(screen.queryByText('No model stats found')).toBeNull();
+    });
+
+    it('shows the analyzing state instead of keyword content during keyword refreshes', () => {
+        libraryContextMocks.stats.keywordStats = [];
+        libraryContextMocks.isKeywordStatsLoading = true;
+
+        render(<StatsDashboard images={[]} onFilter={vi.fn()} />);
+
+        expect(screen.getByText('Analyzing Library')).toBeTruthy();
+        expect(screen.queryByText('aurora')).toBeNull();
+        expect(screen.getByText('Flux Super Long Model Name')).toBeTruthy();
+        expect(screen.getByText('4.8 MB')).toBeTruthy();
+    });
+
+    it('shows true empty states only after summary and keyword queries both settle empty', () => {
+        libraryContextMocks.stats = {
+            totalImages: 0,
+            totalGenerations: 0,
+            avgSteps: 0,
+            estSizeMB: '0',
+            modelStats: [],
+            keywordStats: []
+        };
+
+        render(<StatsDashboard images={[]} onFilter={vi.fn()} />);
+
+        expect(screen.getByText('Total Images')).toBeTruthy();
+        expect(screen.getByText('0 MB')).toBeTruthy();
+        expect(screen.getByText('No model stats found')).toBeTruthy();
+        expect(screen.getByText('No keywords found')).toBeTruthy();
+    });
+});

--- a/src/config/wordCloud.ts
+++ b/src/config/wordCloud.ts
@@ -4,12 +4,6 @@
  */
 export const WORD_CLOUD_CONFIG = {
     /**
-     * Maximum number of prompts to fetch and analyze in a single pass.
-     * 2000 is usually enough for a high-quality word cloud and keeps processing under 100ms.
-     */
-    ANALYSIS_LIMIT: 2000,
-
-    /**
      * Keywords to exclude from the word cloud.
      * These are common English words or metadata-specific terms that don't add value.
      */

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -54,6 +54,8 @@ interface SearchContextType {
 
     isFacetsLoading: boolean;
     isLoadingMore: boolean;
+    isStatsSummaryLoading: boolean;
+    isKeywordStatsLoading: boolean;
 
     /** Valid facet names for drill-down filtering. null = show all (no active filters) */
     validFacetNames: ValidFacetNames | null;
@@ -208,9 +210,9 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     // Stats & Facets Query
     const {
         data: statsData,
-        isLoading: isStatsLoading,
-        isFetching: isStatsFetching,
-        isFacetsFetching
+        isFacetsFetching,
+        isStatsSummaryLoading,
+        isKeywordStatsLoading
     } = useLibraryStatsQuery({
         filters,
         settings,
@@ -399,6 +401,8 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             refreshHiddenAvailability,
             isFacetsLoading: isFacetsFetching,
             isLoadingMore: isFetchingNextPage,
+            isStatsSummaryLoading,
+            isKeywordStatsLoading,
             validFacetNames: activeValidNames,
             assetScope,
             setAssetScope,

--- a/src/contexts/__tests__/LibraryIntegration.test.tsx
+++ b/src/contexts/__tests__/LibraryIntegration.test.tsx
@@ -13,7 +13,8 @@ const mocks = vi.hoisted(() => ({
     searchImages: vi.fn().mockResolvedValue([]),
     countImages: vi.fn().mockResolvedValue(0),
     getFacets: vi.fn().mockResolvedValue({ models: [], loras: [], tools: [] }),
-    getLibraryStats: vi.fn().mockResolvedValue({ totalImages: 0 }),
+    getLibraryStatsSummary: vi.fn().mockResolvedValue({ totalImages: 0, totalGenerations: 0, avgSteps: 0, estSizeMB: '0', modelStats: [] }),
+    getKeywordStats: vi.fn().mockResolvedValue([]),
     syncImages: vi.fn().mockResolvedValue({ imported: 5, updated: 0, maxTimestamp: 100, syncedIds: new Set(), boardMapping: new Map(), touchedFacetTypes: [], touchedFacetResources: { checkpoints: [], loras: [], embeddings: [], hypernetworks: [], controlNets: [], ipAdapters: [], tools: [] } }),
     rebuildFacetCache: vi.fn().mockResolvedValue(0),
     rebuildFacetCacheStrict: vi.fn().mockResolvedValue(0),
@@ -93,7 +94,8 @@ vi.mock('../../services/db/searchRepo', () => ({
     searchImages: (...args: any[]) => mocks.searchImages(...args),
     countImages: (...args: any[]) => mocks.countImages(...args),
     getFacets: (...args: any[]) => mocks.getFacets(...args),
-    getLibraryStats: (...args: any[]) => mocks.getLibraryStats(...args),
+    getLibraryStatsSummary: (...args: any[]) => mocks.getLibraryStatsSummary(...args),
+    getKeywordStats: (...args: any[]) => mocks.getKeywordStats(...args),
 }));
 
 vi.mock('../../services/db/collectionRepo', () => ({
@@ -495,7 +497,7 @@ describe('Library Integration (Provider Stack)', () => {
         });
         mocks.searchImages.mockClear();
         mocks.getFacets.mockClear();
-        mocks.getLibraryStats.mockClear();
+        mocks.getLibraryStatsSummary.mockClear();
         mocks.rebuildFacetCache.mockClear();
         mocks.rebuildFacetCacheStrict.mockClear();
         mocks.rebuildFacetCacheIncrementalBatchStrict.mockClear();
@@ -520,7 +522,7 @@ describe('Library Integration (Provider Stack)', () => {
         await waitFor(() => {
             expect(mocks.searchImages).toHaveBeenCalled();
             expect(mocks.getFacets).toHaveBeenCalled();
-            expect(mocks.getLibraryStats).toHaveBeenCalled();
+            expect(mocks.getLibraryStatsSummary).toHaveBeenCalled();
         });
 
         expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();

--- a/src/contexts/__tests__/SearchContext.test.tsx
+++ b/src/contexts/__tests__/SearchContext.test.tsx
@@ -24,13 +24,15 @@ vi.mock('./CollectionContext', () => ({
 const mockSearchImages = vi.fn().mockResolvedValue([]);
 const mockCountImages = vi.fn().mockResolvedValue(0);
 const mockGetFacets = vi.fn().mockResolvedValue({ models: [], loras: [], tools: [] });
-const mockGetLibraryStats = vi.fn().mockResolvedValue({ totalImages: 0 });
+const mockGetLibraryStatsSummary = vi.fn().mockResolvedValue({ totalImages: 0, totalGenerations: 0, avgSteps: 0, estSizeMB: '0', modelStats: [] });
+const mockGetKeywordStats = vi.fn().mockResolvedValue([]);
 
 vi.mock('../services/db/searchRepo', () => ({
     searchImages: (...args: any[]) => mockSearchImages(...args),
     countImages: (...args: any[]) => mockCountImages(...args),
     getFacets: (...args: any[]) => mockGetFacets(...args),
-    getLibraryStats: (...args: any[]) => mockGetLibraryStats(...args),
+    getLibraryStatsSummary: (...args: any[]) => mockGetLibraryStatsSummary(...args),
+    getKeywordStats: (...args: any[]) => mockGetKeywordStats(...args),
 }));
 
 vi.mock('../services/repository', () => ({

--- a/src/features/filters/components/__tests__/FilterPanel.test.tsx
+++ b/src/features/filters/components/__tests__/FilterPanel.test.tsx
@@ -114,6 +114,8 @@ const defaultSearchContext = (overrides: Partial<SearchContextValue> = {}): Sear
     refreshHiddenAvailability: async () => { },
     isFacetsLoading: false,
     isLoadingMore: false,
+    isStatsSummaryLoading: false,
+    isKeywordStatsLoading: false,
     validFacetNames: null,
     assetScope: 'local',
     setAssetScope: vi.fn() as Dispatch<SetStateAction<AssetScope>>,

--- a/src/hooks/__tests__/useLibraryStatsQuery.test.tsx
+++ b/src/hooks/__tests__/useLibraryStatsQuery.test.tsx
@@ -7,12 +7,13 @@ import { AppSettings, Collection, FilterState } from '../../types';
 import type { AssetScope } from '../../types';
 import { createDefaultFilters } from '../../utils/filterState';
 import { useLibraryStore } from '../../stores/libraryStore';
-import type { Facets, LibraryStats, ValidFacetNames } from '../../services/db/searchRepo';
+import type { Facets, LibraryStats, LibraryStatsSummary, ValidFacetNames } from '../../services/db/searchRepo';
 import { SIDE_QUERY_SEARCH_DEBOUNCE_MS } from '../useDebouncedSideQueryFilters';
 
 const searchRepoMocks = vi.hoisted(() => ({
     getFacets: vi.fn(),
-    getLibraryStats: vi.fn(),
+    getLibraryStatsSummary: vi.fn(),
+    getKeywordStats: vi.fn(),
     getValidFacetNames: vi.fn(),
 }));
 
@@ -22,7 +23,8 @@ vi.mock('../../services/runtime', () => ({
 
 vi.mock('../../services/db/searchRepo', () => ({
     getFacets: searchRepoMocks.getFacets,
-    getLibraryStats: searchRepoMocks.getLibraryStats,
+    getLibraryStatsSummary: searchRepoMocks.getLibraryStatsSummary,
+    getKeywordStats: searchRepoMocks.getKeywordStats,
     getValidFacetNames: searchRepoMocks.getValidFacetNames,
 }));
 
@@ -36,14 +38,15 @@ const emptyFacets: Facets = {
     tools: [],
 };
 
-const emptyStats: LibraryStats = {
+const emptySummary: LibraryStatsSummary = {
     totalImages: 0,
     totalGenerations: 0,
     avgSteps: 0,
     estSizeMB: '0',
     modelStats: [],
-    keywordStats: [],
 };
+
+const emptyKeywordStats: LibraryStats['keywordStats'] = [];
 
 const validNames: ValidFacetNames = {
     checkpoints: ['CollectionModel'],
@@ -131,7 +134,8 @@ describe('useLibraryStatsQuery valid facets', () => {
         vi.clearAllMocks();
         useLibraryStore.setState({ facetCacheVersion: 0 });
         searchRepoMocks.getFacets.mockResolvedValue(emptyFacets);
-        searchRepoMocks.getLibraryStats.mockResolvedValue(emptyStats);
+        searchRepoMocks.getLibraryStatsSummary.mockResolvedValue(emptySummary);
+        searchRepoMocks.getKeywordStats.mockResolvedValue(emptyKeywordStats);
         searchRepoMocks.getValidFacetNames.mockResolvedValue(validNames);
     });
 
@@ -194,7 +198,7 @@ describe('useLibraryStatsQuery valid facets', () => {
     it('does not fetch valid facets for default filters', async () => {
         renderStatsHook();
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalled());
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalled());
 
         expect(searchRepoMocks.getValidFacetNames).not.toHaveBeenCalled();
     });
@@ -203,12 +207,15 @@ describe('useLibraryStatsQuery valid facets', () => {
         const filteredState = createDefaultFilters({ searchQuery: 'portrait' });
         const { rerender } = renderStatsHook(filteredState, [], 'used', false);
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalled());
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1));
         expect(searchRepoMocks.getValidFacetNames).not.toHaveBeenCalled();
 
         rerender({ currentFilters: filteredState, currentAssetScope: 'used', drilldownEnabled: true });
 
-        await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalled());
+        await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(1));
+        expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1);
+        expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1);
     });
 
     it('requests facets for the active asset scope', async () => {
@@ -217,9 +224,9 @@ describe('useLibraryStatsQuery valid facets', () => {
         await waitFor(() => expect(searchRepoMocks.getFacets).toHaveBeenCalled());
 
         const calls = searchRepoMocks.getFacets.mock.calls as Array<
-            [string, unknown[], unknown[], { assetScope: AssetScope }]
+            [string, unknown[], unknown[], { assetScope: AssetScope; collectionId?: string; loraName?: string }]
         >;
-        expect(calls[0][3]).toEqual({ assetScope: 'local' });
+        expect(calls[0][3]).toMatchObject({ assetScope: 'local' });
     });
 
     it('does not refetch stats or valid facets when only the asset scope changes', async () => {
@@ -253,15 +260,17 @@ describe('useLibraryStatsQuery valid facets', () => {
         );
 
         await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(1));
-        expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1);
+        expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1));
         expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(1);
 
         rerender({ assetScope: 'local' });
 
         await waitFor(() => expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(2));
-        expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1);
+        expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1);
+        expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1);
         expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(1);
-        expect(result.current.isFacetsFetching).toBe(false);
+        await waitFor(() => expect(result.current.isFacetsFetching).toBe(false));
     });
 
     it('keeps facet loading false while only the summary query refetches', async () => {
@@ -289,17 +298,17 @@ describe('useLibraryStatsQuery valid facets', () => {
             { wrapper }
         );
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1));
         await waitFor(() => expect(result.current.isFetching).toBe(false));
 
-        const summaryRefetch = createDeferred<LibraryStats>();
-        searchRepoMocks.getLibraryStats.mockReturnValueOnce(summaryRefetch.promise);
+        const summaryRefetch = createDeferred<LibraryStatsSummary>();
+        searchRepoMocks.getLibraryStatsSummary.mockReturnValueOnce(summaryRefetch.promise);
 
         act(() => {
             void queryClient.invalidateQueries({ queryKey: ['libraryStats', 'summary'] });
         });
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(2));
         await waitFor(() => expect(result.current.isFetching).toBe(true));
 
         expect(result.current.isFacetsFetching).toBe(false);
@@ -307,9 +316,196 @@ describe('useLibraryStatsQuery valid facets', () => {
         expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(1);
 
         act(() => {
-            summaryRefetch.resolve(emptyStats);
+            summaryRefetch.resolve(emptySummary);
         });
         await waitFor(() => expect(result.current.isFetching).toBe(false));
+    });
+
+    it('resolves summary stats without waiting for keyword analysis', async () => {
+        const summary: LibraryStatsSummary = {
+            totalImages: 42,
+            totalGenerations: 42,
+            avgSteps: 0,
+            estSizeMB: '128.4',
+            modelStats: [
+                { name: 'Flux Dev', fullName: 'Flux Dev', count: 42 }
+            ]
+        };
+        const keywordDeferred = createDeferred<LibraryStats['keywordStats']>();
+        searchRepoMocks.getLibraryStatsSummary.mockResolvedValueOnce(summary);
+        searchRepoMocks.getKeywordStats.mockReturnValueOnce(keywordDeferred.promise);
+
+        const { result } = renderStatsHook();
+
+        await waitFor(() => expect(result.current.data.stats.totalGenerations).toBe(42));
+
+        expect(result.current.data.stats.modelStats).toEqual(summary.modelStats);
+        expect(result.current.data.stats.keywordStats).toEqual([]);
+        expect(result.current.isStatsSummaryLoading).toBe(false);
+        expect(result.current.isKeywordStatsLoading).toBe(true);
+
+        act(() => {
+            keywordDeferred.resolve([{ text: 'aurora', value: 9 }]);
+        });
+
+        await waitFor(() => expect(result.current.data.stats.keywordStats).toEqual([{ text: 'aurora', value: 9 }]));
+    });
+
+    it('starts keyword analysis only after the current summary query succeeds', async () => {
+        const summaryDeferred = createDeferred<LibraryStatsSummary>();
+        const keywordDeferred = createDeferred<LibraryStats['keywordStats']>();
+        searchRepoMocks.getLibraryStatsSummary.mockReturnValueOnce(summaryDeferred.promise);
+        searchRepoMocks.getKeywordStats.mockReturnValueOnce(keywordDeferred.promise);
+
+        renderStatsHook();
+
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1));
+        expect(searchRepoMocks.getKeywordStats).not.toHaveBeenCalled();
+
+        act(() => {
+            summaryDeferred.resolve({
+                totalImages: 8,
+                totalGenerations: 8,
+                avgSteps: 0,
+                estSizeMB: '16.0',
+                modelStats: []
+            });
+        });
+
+        await waitFor(() => expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1));
+
+        act(() => {
+            keywordDeferred.resolve(emptyKeywordStats);
+        });
+    });
+
+    it('hides stale keyword results while refreshed keywords are still computing for a new summary snapshot', async () => {
+        const initialKeywords = [{ text: 'aurora', value: 4 }];
+        const refreshedSummary = createDeferred<LibraryStatsSummary>();
+        const refreshedKeywords = createDeferred<LibraryStats['keywordStats']>();
+
+        searchRepoMocks.getLibraryStatsSummary
+            .mockResolvedValueOnce({
+                totalImages: 4,
+                totalGenerations: 4,
+                avgSteps: 0,
+                estSizeMB: '12.0',
+                modelStats: []
+            })
+            .mockReturnValueOnce(refreshedSummary.promise);
+        searchRepoMocks.getKeywordStats
+            .mockResolvedValueOnce(initialKeywords)
+            .mockReturnValueOnce(refreshedKeywords.promise);
+
+        const { rerender, result } = renderStatsHook();
+
+        await waitFor(() => expect(result.current.data.stats.keywordStats).toEqual(initialKeywords));
+
+        rerender({
+            currentFilters: createDefaultFilters({ dateRange: 'today' }),
+            currentAssetScope: 'used',
+            drilldownEnabled: true
+        });
+
+        expect(result.current.data.stats.keywordStats).toEqual(initialKeywords);
+        expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1);
+
+        act(() => {
+            refreshedSummary.resolve({
+                totalImages: 7,
+                totalGenerations: 7,
+                avgSteps: 0,
+                estSizeMB: '14.0',
+                modelStats: []
+            });
+        });
+
+        await waitFor(() => expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(2));
+        expect(result.current.data.stats.totalGenerations).toBe(7);
+        expect(result.current.data.stats.keywordStats).toEqual([]);
+        expect(result.current.isKeywordStatsLoading).toBe(true);
+
+        act(() => {
+            refreshedKeywords.resolve([{ text: 'sunset', value: 6 }]);
+        });
+
+        await waitFor(() => expect(result.current.data.stats.keywordStats).toEqual([{ text: 'sunset', value: 6 }]));
+    });
+
+    it('waits for summary refetches before restarting keyword analysis on same-key invalidations', async () => {
+        const queryClient = new QueryClient({
+            defaultOptions: {
+                queries: {
+                    retry: false,
+                    gcTime: 0,
+                },
+            },
+        });
+        const wrapper = ({ children }: PropsWithChildren) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+        const initialKeywords = [{ text: 'aurora', value: 4 }];
+        const summaryRefetch = createDeferred<LibraryStatsSummary>();
+        const keywordRefetch = createDeferred<LibraryStats['keywordStats']>();
+
+        searchRepoMocks.getLibraryStatsSummary
+            .mockResolvedValueOnce({
+                totalImages: 4,
+                totalGenerations: 4,
+                avgSteps: 0,
+                estSizeMB: '12.0',
+                modelStats: []
+            })
+            .mockReturnValueOnce(summaryRefetch.promise);
+        searchRepoMocks.getKeywordStats
+            .mockResolvedValueOnce(initialKeywords)
+            .mockReturnValueOnce(keywordRefetch.promise);
+
+        const { result } = renderHook(
+            () => useLibraryStatsQuery({
+                filters: createDefaultFilters(),
+                settings,
+                privacyEnabled: false,
+                allCollections: [],
+                settingsLoaded: true,
+                assetScope: 'used',
+            }),
+            { wrapper }
+        );
+
+        await waitFor(() => expect(result.current.data.stats.keywordStats).toEqual(initialKeywords));
+
+        act(() => {
+            void queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
+        });
+
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(result.current.isFetching).toBe(true));
+
+        expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(1);
+        expect(result.current.data.stats.keywordStats).toEqual(initialKeywords);
+        expect(result.current.isKeywordStatsLoading).toBe(false);
+
+        act(() => {
+            summaryRefetch.resolve({
+                totalImages: 7,
+                totalGenerations: 7,
+                avgSteps: 0,
+                estSizeMB: '14.0',
+                modelStats: []
+            });
+        });
+
+        await waitFor(() => expect(searchRepoMocks.getKeywordStats).toHaveBeenCalledTimes(2));
+        expect(result.current.data.stats.totalGenerations).toBe(7);
+        expect(result.current.data.stats.keywordStats).toEqual([]);
+        expect(result.current.isKeywordStatsLoading).toBe(true);
+
+        act(() => {
+            keywordRefetch.resolve([{ text: 'sunset', value: 6 }]);
+        });
+
+        await waitFor(() => expect(result.current.data.stats.keywordStats).toEqual([{ text: 'sunset', value: 6 }]));
     });
 
     it('refetches stats and valid facets when the facet cache version changes', async () => {
@@ -339,7 +535,7 @@ describe('useLibraryStatsQuery valid facets', () => {
         );
 
         await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(1));
-        expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1);
+        expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1);
         expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(1);
 
         act(() => {
@@ -347,7 +543,7 @@ describe('useLibraryStatsQuery valid facets', () => {
         });
 
         await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(2));
-        expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(2);
+        expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(2);
         expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(2);
     });
 
@@ -370,19 +566,19 @@ describe('useLibraryStatsQuery valid facets', () => {
     it('debounces search-only stats updates and collapses rapid corrections', async () => {
         const { rerender } = renderStatsHook();
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1));
 
         rerender({ currentFilters: createDefaultFilters({ searchQuery: 'date:2026' }), currentAssetScope: 'used', drilldownEnabled: true });
         await waitForMs(600);
         rerender({ currentFilters: createDefaultFilters({ searchQuery: 'date:2026-04' }), currentAssetScope: 'used', drilldownEnabled: true });
         await waitForMs(SIDE_QUERY_SEARCH_DEBOUNCE_MS - 100);
 
-        expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1);
+        expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1);
         await waitForMs(120);
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(2));
 
-        const calls = searchRepoMocks.getLibraryStats.mock.calls as Array<
+        const calls = searchRepoMocks.getLibraryStatsSummary.mock.calls as Array<
             [string, unknown[], string | undefined, string | undefined]
         >;
         const [where, params] = calls[1];
@@ -398,10 +594,10 @@ describe('useLibraryStatsQuery valid facets', () => {
     it('updates stats immediately for non-search filter changes', async () => {
         const { rerender } = renderStatsHook();
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(1));
 
         rerender({ currentFilters: createDefaultFilters({ dateRange: 'today' }), currentAssetScope: 'used', drilldownEnabled: true });
 
-        await waitFor(() => expect(searchRepoMocks.getLibraryStats).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(searchRepoMocks.getLibraryStatsSummary).toHaveBeenCalledTimes(2));
     });
 });

--- a/src/hooks/useLibraryStatsQuery.ts
+++ b/src/hooks/useLibraryStatsQuery.ts
@@ -1,11 +1,11 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { AssetScope, FilterState, AppSettings, Collection, FacetType } from '../types';
-import { getFacets, getLibraryStats, Facets, getValidFacetNames, ValidFacetNames } from '../services/db/searchRepo';
+import { getFacets, getKeywordStats, getLibraryStatsSummary, Facets, LibraryStats, LibraryStatsSummary, getValidFacetNames, ValidFacetNames } from '../services/db/searchRepo';
 import { buildSqlWhereClause } from '../utils/sqlHelpers';
 import { useLibraryStore } from '../stores/libraryStore';
 import { isBrowserMockMode } from '../services/runtime';
-import { getBrowserMockFacets, getBrowserMockStats, getBrowserMockValidFacetNames } from '../services/browserMockData';
+import { getBrowserMockFacets, getBrowserMockKeywordStats, getBrowserMockStatsSummary, getBrowserMockValidFacetNames } from '../services/browserMockData';
 import { useDebouncedSideQueryFilters } from './useDebouncedSideQueryFilters';
 
 interface UseLibraryStatsQueryProps {
@@ -18,14 +18,15 @@ interface UseLibraryStatsQueryProps {
     validFacetsEnabled?: boolean;
 }
 
-const INITIAL_STATS = {
+const INITIAL_STATS_SUMMARY: LibraryStatsSummary = {
     totalImages: 0,
     totalGenerations: 0,
     avgSteps: 0,
     estSizeMB: '0',
-    modelStats: [],
-    keywordStats: []
+    modelStats: []
 };
+
+const INITIAL_KEYWORD_STATS: LibraryStats['keywordStats'] = [];
 
 const INITIAL_FACETS: Facets = {
     checkpoints: [],
@@ -133,37 +134,68 @@ export const useLibraryStatsQuery = ({
 
             if (!queryInput) return INITIAL_FACETS;
 
-            return getFacets(queryInput.where, queryInput.params, ALL_FACET_TYPES, { assetScope });
+            return getFacets(queryInput.where, queryInput.params, ALL_FACET_TYPES, {
+                assetScope,
+                collectionId: queryInput.collectionId,
+                loraName: queryInput.loraName
+            });
         },
-        placeholderData: (previousData) => previousData ?? INITIAL_FACETS,
+        placeholderData: (previousData) => previousData,
         staleTime: 1000 * 60 * 5,
         enabled: settingsLoaded
     });
 
-    const summaryQuery = useQuery({
-        queryKey: ['libraryStats', 'summary', facetCacheVersion, sideQueryFilters, privacyEnabled, settings.maskingMode, settings.maskedKeywords, smartFilterHash, validFacetsEnabled],
+    const statsSummaryQuery = useQuery({
+        queryKey: ['libraryStats', 'summary', facetCacheVersion, sideQueryFilters, privacyEnabled, settings.maskingMode, settings.maskedKeywords, smartFilterHash],
         queryFn: async () => {
             if (useBrowserMocks) {
-                return {
-                    stats: getBrowserMockStats(sideQueryFilters),
-                    validNames: fetchValidFacets ? getBrowserMockValidFacetNames(sideQueryFilters) : null
-                };
+                return getBrowserMockStatsSummary(sideQueryFilters);
             }
 
             if (!queryInput) {
-                return { stats: INITIAL_STATS, validNames: null as ValidFacetNames | null };
+                return INITIAL_STATS_SUMMARY;
+            }
+
+            const { where, params, collectionId, loraName } = queryInput;
+            return getLibraryStatsSummary(where, params, collectionId, loraName);
+        },
+        placeholderData: (previousData) => previousData,
+        staleTime: 1000 * 60 * 5,
+        enabled: settingsLoaded
+    });
+    const [activeSummaryVersion, setActiveSummaryVersion] = useState(0);
+    const lastSettledSummaryUpdatedAtRef = useRef(0);
+
+    useEffect(() => {
+        if (statsSummaryQuery.status !== 'success' || statsSummaryQuery.isFetching || statsSummaryQuery.isPlaceholderData) {
+            return;
+        }
+        if (statsSummaryQuery.dataUpdatedAt === 0 || statsSummaryQuery.dataUpdatedAt === lastSettledSummaryUpdatedAtRef.current) {
+            return;
+        }
+
+        lastSettledSummaryUpdatedAtRef.current = statsSummaryQuery.dataUpdatedAt;
+        setActiveSummaryVersion((version) => version + 1);
+    }, [
+        statsSummaryQuery.dataUpdatedAt,
+        statsSummaryQuery.isFetching,
+        statsSummaryQuery.isPlaceholderData,
+        statsSummaryQuery.status
+    ]);
+    const validNamesQuery = useQuery({
+        queryKey: ['libraryStats', 'validNames', facetCacheVersion, sideQueryFilters, privacyEnabled, settings.maskingMode, settings.maskedKeywords, smartFilterHash, validFacetsEnabled],
+        queryFn: async () => {
+            if (useBrowserMocks) {
+                return fetchValidFacets ? getBrowserMockValidFacetNames(sideQueryFilters) : null;
+            }
+
+            if (!queryInput || !fetchValidFacets) {
+                return null as ValidFacetNames | null;
             }
 
             const { where, params, collectionId, loraName } = queryInput;
 
-            // Fetch stats and valid facet names in parallel. Facets are queried separately
-            // so asset-scope changes do not rerun expensive privacy-valid facet checks.
-            const [stats, baseValidNames] = await Promise.all([
-                getLibraryStats(where, params, collectionId, loraName),
-                fetchValidFacets
-                    ? getValidFacetNames(where, params, collectionId, loraName)
-                    : Promise.resolve(null)
-            ]);
+            const baseValidNames = await getValidFacetNames(where, params, collectionId, loraName);
 
             const disjunctiveCategories: FacetType[] = [];
             if (activeCollectionId) {
@@ -222,22 +254,72 @@ export const useLibraryStatsQuery = ({
                 }
             }
 
-            return { stats, validNames: finalValidNames };
+            return finalValidNames;
         },
-        placeholderData: (previousData) => previousData ?? { stats: INITIAL_STATS, validNames: null as ValidFacetNames | null },
+        placeholderData: (previousData) => previousData,
         staleTime: 1000 * 60 * 5,
         enabled: settingsLoaded
     });
 
+    const keywordQuery = useQuery({
+        // Keep keywords on a separate root key so broad library-stats invalidations
+        // refresh the cheap summary first before restarting the prompt scan.
+        queryKey: ['libraryKeywordStats', activeSummaryVersion],
+        queryFn: async () => {
+            if (useBrowserMocks) {
+                return {
+                    summaryVersion: activeSummaryVersion,
+                    keywordStats: getBrowserMockKeywordStats(sideQueryFilters)
+                };
+            }
+
+            if (!queryInput) {
+                return {
+                    summaryVersion: activeSummaryVersion,
+                    keywordStats: INITIAL_KEYWORD_STATS
+                };
+            }
+
+            const { where, params, collectionId, loraName } = queryInput;
+            return {
+                summaryVersion: activeSummaryVersion,
+                keywordStats: await getKeywordStats(where, params, collectionId, loraName)
+            };
+        },
+        placeholderData: (previousData) => previousData,
+        staleTime: 1000 * 60 * 5,
+        enabled: settingsLoaded && activeSummaryVersion > 0 && statsSummaryQuery.status === 'success' && !statsSummaryQuery.isFetching && !statsSummaryQuery.isPlaceholderData
+    });
+
+    const keywordStatsAreCurrent = useMemo(() => (
+        Boolean(keywordQuery.data) && keywordQuery.data?.summaryVersion === activeSummaryVersion
+    ), [activeSummaryVersion, keywordQuery.data]);
+
+    const currentKeywordStats = keywordStatsAreCurrent
+        ? (keywordQuery.data?.keywordStats ?? INITIAL_KEYWORD_STATS)
+        : INITIAL_KEYWORD_STATS;
+
+    const isKeywordStatsLoading = statsSummaryQuery.status === 'success'
+        && !statsSummaryQuery.isFetching
+        && !statsSummaryQuery.isPlaceholderData
+        && !keywordStatsAreCurrent;
+
+    const combinedStats = useMemo<LibraryStats>(() => ({
+        ...(statsSummaryQuery.data ?? INITIAL_STATS_SUMMARY),
+        keywordStats: currentKeywordStats
+    }), [currentKeywordStats, statsSummaryQuery.data]);
+
     return {
         data: {
             facets: facetsQuery.data ?? INITIAL_FACETS,
-            stats: summaryQuery.data?.stats ?? INITIAL_STATS,
-            validNames: summaryQuery.data?.validNames ?? null
+            stats: combinedStats,
+            validNames: validNamesQuery.data ?? null
         },
-        isLoading: facetsQuery.isLoading || summaryQuery.isLoading,
-        isFetching: facetsQuery.isFetching || summaryQuery.isFetching,
+        isLoading: facetsQuery.isLoading || statsSummaryQuery.isLoading || validNamesQuery.isLoading || keywordQuery.isLoading,
+        isFetching: facetsQuery.isFetching || statsSummaryQuery.isFetching || validNamesQuery.isFetching || keywordQuery.isFetching,
         isFacetsLoading: facetsQuery.isLoading,
-        isFacetsFetching: facetsQuery.isFetching
+        isFacetsFetching: facetsQuery.isFetching,
+        isStatsSummaryLoading: statsSummaryQuery.isLoading,
+        isKeywordStatsLoading
     };
 };

--- a/src/services/browserMockData.ts
+++ b/src/services/browserMockData.ts
@@ -1,6 +1,6 @@
 import { AIImage, AppSettings, Collection, FacetType, FilterState, GeneratorTool, SmartCollection, SortOption } from '../types';
 import type { AppState, IRepository } from './repository';
-import type { Facets, LibraryStats, ValidFacetNames } from './db/searchRepo';
+import type { Facets, LibraryStats, LibraryStatsSummary, ValidFacetNames } from './db/searchRepo';
 import { getDateFilterBounds, getSearchDateBounds, timestampMatchesDateBounds } from '../utils/dateFilters';
 
 const STORAGE_KEY = 'ambit_browser_mock_state_v1';
@@ -521,17 +521,13 @@ export const getBrowserMockFacets = (filters?: FilterState): Facets => {
     };
 };
 
-export const getBrowserMockStats = (filters: FilterState): LibraryStats => {
+export const getBrowserMockStatsSummary = (filters: FilterState): LibraryStatsSummary => {
     const current = loadStoredState();
     const images = filterImages(current.images, filters, getBrowserMockCollections());
     const modelCounts = new Map<string, number>();
-    const keywordCounts = new Map<string, number>();
 
     images.forEach((image) => {
         modelCounts.set(image.metadata.model, (modelCounts.get(image.metadata.model) ?? 0) + 1);
-        image.metadata.positivePrompt.toLowerCase().split(/[^a-z0-9]+/).forEach((word) => {
-            if (word.length > 3) keywordCounts.set(word, (keywordCounts.get(word) ?? 0) + 1);
-        });
     });
 
     return {
@@ -543,12 +539,32 @@ export const getBrowserMockStats = (filters: FilterState): LibraryStats => {
         estSizeMB: (images.reduce((sum, image) => sum + (image.fileSize ?? 0), 0) / 1_000_000).toFixed(1),
         modelStats: Array.from(modelCounts.entries())
             .sort((a, b) => b[1] - a[1])
-            .slice(0, 20)
-            .map(([name, count]) => ({ name: name.split(' ')[0], fullName: name, count })),
-        keywordStats: Array.from(keywordCounts.entries())
+            .map(([name, count]) => ({ name, fullName: name, count }))
+    };
+};
+
+export const getBrowserMockKeywordStats = (filters: FilterState): LibraryStats['keywordStats'] => {
+    const current = loadStoredState();
+    const images = filterImages(current.images, filters, getBrowserMockCollections());
+    const keywordCounts = new Map<string, number>();
+
+    images.forEach((image) => {
+        image.metadata.positivePrompt.toLowerCase().split(/[^a-z0-9]+/).forEach((word) => {
+            if (word.length > 3) keywordCounts.set(word, (keywordCounts.get(word) ?? 0) + 1);
+        });
+    });
+
+    return Array.from(keywordCounts.entries())
             .sort((a, b) => b[1] - a[1])
             .slice(0, 40)
-            .map(([text, value]) => ({ text, value })),
+            .map(([text, value]) => ({ text, value }));
+};
+
+export const getBrowserMockStats = (filters: FilterState): LibraryStats => {
+    const summary = getBrowserMockStatsSummary(filters);
+    return {
+        ...summary,
+        keywordStats: getBrowserMockKeywordStats(filters)
     };
 };
 

--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -6,17 +6,42 @@ vi.mock('../connection', () => ({
     getDb: () => getDbMock(),
 }));
 
+const deriveScopedRows = (
+    cacheRows: Record<string, unknown>[],
+    facetType: string
+) => cacheRows
+    .filter((row) => row.facet_type === facetType && typeof row.resource_name === 'string')
+    .map((row) => ({
+        name: row.resource_name as string,
+        count: Number(row.count ?? 0)
+    }));
+
 const createFacetDb = (
     cacheRows: Record<string, unknown>[],
-    diskRows: Record<string, unknown>[] = []
+    diskRows: Record<string, unknown>[] = [],
+    scopedRows: Partial<Record<string, Record<string, unknown>[]>> = {}
 ) => ({
     select: vi.fn(async (sql: string) => {
         const normalizedSql = sql.replace(/\s+/g, ' ').trim();
-        return normalizedSql.startsWith('SELECT m.resource_type, m.name, m.hash,')
-            ? diskRows
-            : cacheRows;
+        if (normalizedSql.startsWith('SELECT m.resource_type, m.name, m.hash,')) {
+            return diskRows;
+        }
+        if (normalizedSql.includes('FROM scoped_images')) {
+            if (normalizedSql.includes('JOIN image_loras')) return scopedRows.loras ?? deriveScopedRows(cacheRows, 'loras');
+            if (normalizedSql.includes('JOIN image_embeddings')) return scopedRows.embeddings ?? deriveScopedRows(cacheRows, 'embeddings');
+            if (normalizedSql.includes('JOIN image_hypernetworks')) return scopedRows.hypernetworks ?? deriveScopedRows(cacheRows, 'hypernetworks');
+            if (normalizedSql.includes('JOIN image_controlnets')) return scopedRows.control_nets ?? deriveScopedRows(cacheRows, 'control_nets');
+            if (normalizedSql.includes('JOIN image_ipadapters')) return scopedRows.ip_adapters ?? deriveScopedRows(cacheRows, 'ip_adapters');
+            return scopedRows.checkpoints ?? deriveScopedRows(cacheRows, 'checkpoints');
+        }
+        return cacheRows;
     }),
 });
+
+const findSelectCall = (
+    db: { select: ReturnType<typeof vi.fn> },
+    predicate: (sql: string) => boolean
+) => db.select.mock.calls.find(([sql]) => predicate(sql as string)) as [string, unknown[]] | undefined;
 
 describe('searchRepo getFacets', () => {
     beforeEach(() => {
@@ -97,8 +122,8 @@ describe('searchRepo getFacets', () => {
         const { getFacets } = await import('../searchRepo');
         const facets = await getFacets('', [], ['controlNets', 'ipAdapters'], { assetScope: 'all' });
 
-        const [sql, params] = db.select.mock.calls[0] as unknown as [string, string[]];
-        const [diskSql, diskParams] = db.select.mock.calls[1] as unknown as [string, string[]];
+        const [sql, params] = findSelectCall(db, (value) => value.includes('FROM facet_cache fc')) as [string, string[]];
+        const [diskSql, diskParams] = findSelectCall(db, (value) => value.includes('FROM models m')) as [string, string[]];
         expect(sql).not.toContain('EXISTS');
         expect(sql).not.toContain('FROM models m');
         expect(sql).not.toContain('LOWER(m.name)');
@@ -155,7 +180,7 @@ describe('searchRepo getFacets', () => {
             count: 8,
             isLocalDisk: true,
             assetMatchKey: 'ponydiffusionv6xl',
-            filterAliases: ['Pony Diffusion V6 XL']
+            filterAliases: ['Pony Diffusion V6 XL', 'ponyDiffusionV6XL']
         });
     });
 
@@ -202,7 +227,7 @@ describe('searchRepo getFacets', () => {
             name: 'Detailer-Style',
             count: 7,
             isLocalDisk: true,
-            filterAliases: ['Detailer-Style', 'detailer style']
+            filterAliases: ['Detailer-Style', 'detailer style', 'detailer_style']
         });
     });
 
@@ -237,15 +262,79 @@ describe('searchRepo getFacets', () => {
         const { getFacets } = await import('../searchRepo');
         const facets = await getFacets('', [], ['loras'], { assetScope: 'used' });
 
-        const [sql] = db.select.mock.calls[0] as unknown as [string, string[]];
-        expect(sql).toContain('fc.count > 0');
+        const [sql] = findSelectCall(db, (value) => value.includes('FROM facet_cache fc')) as [string, string[]];
+        expect(sql).not.toContain('fc.count > 0');
         expect(sql).not.toContain('EXISTS');
         expect(sql).not.toContain('FROM models m');
         expect(sql).not.toContain('LOWER(m.name)');
         expect(facets.loras.map(item => item.name)).toEqual(['UsedLora']);
     });
 
-    it('marks a used asset as local in used scope when only a disk alias matches', async () => {
+    it('skips scoped facet overlays for the default unfiltered used scope', async () => {
+        const db = createFacetDb([
+            {
+                facet_type: 'checkpoints',
+                resource_name: 'Model A',
+                resource_hash: 'hash-a',
+                count: 5
+            },
+            {
+                facet_type: 'checkpoints',
+                resource_name: 'Model B',
+                resource_hash: 'hash-b',
+                count: 2
+            }
+        ]);
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('', [], ['checkpoints'], { assetScope: 'used' });
+
+        expect(facets.checkpoints).toEqual([
+            expect.objectContaining({ name: 'Model A', count: 5 }),
+            expect.objectContaining({ name: 'Model B', count: 2 })
+        ]);
+        expect(db.select.mock.calls.some(([sql]) => (sql as string).includes('FROM scoped_images'))).toBe(false);
+    });
+
+    it('skips scoped facet overlays for the default unfiltered all scope', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Model A',
+                    resource_hash: 'hash-a',
+                    count: 5
+                },
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Unused Local',
+                    resource_hash: 'file:C:/models/Unused Local.safetensors',
+                    count: 0,
+                    is_local_disk: 1
+                }
+            ],
+            [
+                {
+                    resource_type: 'checkpoint',
+                    name: 'Unused Local',
+                    hash: 'file:C:/models/Unused Local.safetensors'
+                }
+            ]
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('', [], ['checkpoints'], { assetScope: 'all' });
+
+        expect(facets.checkpoints).toEqual([
+            expect.objectContaining({ name: 'Model A', count: 5 }),
+            expect.objectContaining({ name: 'Unused Local', count: 0, isLocalDisk: true })
+        ]);
+        expect(db.select.mock.calls.some(([sql]) => (sql as string).includes('FROM scoped_images'))).toBe(false);
+    });
+
+    it('preserves zero-count disk aliases for used assets in used scope', async () => {
         const db = createFacetDb(
             [
                 {
@@ -254,6 +343,13 @@ describe('searchRepo getFacets', () => {
                     resource_hash: 'metadata-hash',
                     count: 8,
                     is_local_disk: 0
+                },
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'ponyDiffusionV6XL',
+                    resource_hash: 'file:C:/models/ponyDiffusionV6XL.safetensors',
+                    count: 0,
+                    is_local_disk: 1
                 }
             ],
             [
@@ -273,8 +369,162 @@ describe('searchRepo getFacets', () => {
         expect(facets.checkpoints[0]).toMatchObject({
             name: 'Pony Diffusion V6 XL',
             count: 8,
-            isLocalDisk: true
+            isLocalDisk: true,
+            filterAliases: ['Pony Diffusion V6 XL', 'ponyDiffusionV6XL']
         });
+    });
+
+    it('uses filter-scoped counts for checkpoints in the used scope', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Model A',
+                    resource_hash: 'hash-a',
+                    count: 10
+                },
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Model B',
+                    resource_hash: 'hash-b',
+                    count: 5
+                }
+            ],
+            [],
+            {
+                checkpoints: [{ name: 'Model B', count: 1 }]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE resolved_model_name = ?', ['Model B'], ['checkpoints'], { assetScope: 'used' });
+
+        expect(facets.checkpoints).toEqual([
+            expect.objectContaining({
+                name: 'Model B',
+                count: 1
+            })
+        ]);
+        expect(db.select.mock.calls.some(([sql]) => (sql as string).includes('FROM scoped_images'))).toBe(true);
+    });
+
+    it('normalizes scoped checkpoint counts across merged aliases in used scope', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Foo.safetensors',
+                    resource_hash: 'hash-foo-a',
+                    count: 1
+                },
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Foo',
+                    resource_hash: 'hash-foo-b',
+                    count: 1
+                },
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Bar',
+                    resource_hash: 'hash-bar',
+                    count: 100
+                }
+            ],
+            [],
+            {
+                checkpoints: [
+                    { name: 'Foo', count: 4 },
+                    { name: 'Bar', count: 1 }
+                ]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE resolved_model_name IN (?, ?)', ['Foo', 'Bar'], ['checkpoints'], { assetScope: 'used' });
+
+        expect(facets.checkpoints).toEqual([
+            expect.objectContaining({
+                name: 'Foo.safetensors',
+                count: 4,
+                filterAliases: ['Foo.safetensors', 'Foo']
+            }),
+            expect.objectContaining({
+                name: 'Bar',
+                count: 1
+            })
+        ]);
+    });
+
+    it('keeps local inventory markers while applying scoped used counts in all scope', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Pony Diffusion V6 XL',
+                    resource_hash: 'metadata-hash',
+                    count: 8
+                }
+            ],
+            [
+                {
+                    resource_type: 'checkpoint',
+                    name: 'ponyDiffusionV6XL',
+                    hash: 'file:C:/models/ponyDiffusionV6XL.safetensors'
+                }
+            ],
+            {
+                checkpoints: [{ name: 'Pony Diffusion V6 XL', count: 2 }]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE resolved_model_name = ?', ['Pony Diffusion V6 XL'], ['checkpoints'], { assetScope: 'all' });
+
+        expect(facets.checkpoints).toEqual([
+            expect.objectContaining({
+                name: 'Pony Diffusion V6 XL',
+                count: 2,
+                isLocalDisk: true
+            })
+        ]);
+    });
+
+    it('keeps local disk markers while applying normalized scoped alias counts in all scope', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'checkpoints',
+                    resource_name: 'Foo Model.safetensors',
+                    resource_hash: 'metadata-hash',
+                    count: 8
+                }
+            ],
+            [
+                {
+                    resource_type: 'checkpoint',
+                    name: 'foo_model',
+                    hash: 'file:C:/models/Foo Model.safetensors'
+                }
+            ],
+            {
+                checkpoints: [{ name: 'Foo Model', count: 2 }]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE resolved_model_name = ?', ['Foo Model'], ['checkpoints'], { assetScope: 'all' });
+
+        expect(facets.checkpoints).toEqual([
+            expect.objectContaining({
+                name: 'Foo Model.safetensors',
+                count: 2,
+                isLocalDisk: true
+            })
+        ]);
     });
 
     it('includes unused disk assets in local scope', async () => {
@@ -406,8 +656,8 @@ describe('searchRepo scoped stats queries', () => {
         const db = {
             select: vi.fn(async (sql: string) => {
                 const normalizedSql = sql.replace(/\s+/g, ' ').trim();
-                if (normalizedSql.includes('count(*) as total')) {
-                    return [{ total: 0 }];
+                if (normalizedSql.includes('count(*) as count')) {
+                    return [{ count: 0 }];
                 }
                 return [];
             })
@@ -419,19 +669,221 @@ describe('searchRepo scoped stats queries', () => {
 
         await getLibraryStats('WHERE is_deleted = ?', [0], collectionId, loraName);
 
-        const [statsSql, statsParams] = db.select.mock.calls[0] as unknown as [string, unknown[]];
-        const [keywordSql, keywordParams] = db.select.mock.calls[2] as unknown as [string, unknown[]];
+        const [statsSql, statsParams] = findSelectCall(db, (value) => value.includes('count(*) as count')) as [string, unknown[]];
+        const [keywordSql, keywordParams] = findSelectCall(db, (value) => value.includes('JOIN images_fts')) as [string, unknown[]];
 
+        expect(statsSql).toContain('FROM collection_images ci');
+        expect(statsSql).toContain('JOIN image_loras il ON il.image_id = ci.image_id');
+        expect(statsSql).toContain('JOIN images ON images.id = ci.image_id');
         expect(statsSql).toContain('ci.collection_id = ?');
         expect(statsSql).toContain('il.lora_name = ?');
         expect(statsSql).not.toContain(collectionId);
         expect(statsSql).not.toContain(loraName);
         expect(statsParams).toEqual([collectionId, loraName, 0]);
 
+        expect(keywordSql).toContain('FROM collection_images ci');
+        expect(keywordSql).toContain('JOIN image_loras il ON il.image_id = ci.image_id');
+        expect(keywordSql).toContain('JOIN images ON images.id = ci.image_id');
         expect(keywordSql).toContain('ci.collection_id = ?');
         expect(keywordSql).toContain('il.lora_name = ?');
+        expect(keywordSql).toContain('images.rowid > ?');
+        expect(keywordSql).not.toContain('WHERE si.rowid > ?');
         expect(keywordSql).not.toContain(collectionId);
         expect(keywordSql).not.toContain(loraName);
-        expect(keywordParams).toEqual([collectionId, loraName, 0]);
+        expect(keywordParams).toEqual([collectionId, loraName, 0, 0]);
+    });
+
+    it('uses collection_images as the scoped source for collection-only summary stats', async () => {
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as count')) return [{ count: 3 }];
+                if (normalizedSql.includes('GROUP BY name')) return [];
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { clearLibraryStatsCache, getLibraryStatsSummary } = await import('../searchRepo');
+        clearLibraryStatsCache();
+
+        await getLibraryStatsSummary('WHERE is_deleted = ?', [0], 'collection-1');
+
+        const [statsSql, statsParams] = findSelectCall(db, (value) => value.includes('count(*) as count')) as [string, unknown[]];
+        const [modelSql, modelParams] = findSelectCall(db, (value) => value.includes('GROUP BY name')) as [string, unknown[]];
+
+        expect(statsSql).toContain('FROM collection_images ci');
+        expect(statsSql).toContain('CROSS JOIN images ON images.id = ci.image_id');
+        expect(statsSql).not.toContain('FROM images INDEXED BY');
+        expect(statsParams).toEqual(['collection-1', 0]);
+
+        expect(modelSql).toContain('FROM collection_images ci');
+        expect(modelSql).toContain('CROSS JOIN images ON images.id = ci.image_id');
+        expect(modelSql).not.toContain('FROM images INDEXED BY');
+        expect(modelParams).toEqual(['collection-1', 0]);
+    });
+
+    it('uses image_loras as the scoped source for lora-only summary and keyword stats', async () => {
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as count')) return [{ count: 2 }];
+                if (normalizedSql.includes('GROUP BY name')) return [];
+                if (normalizedSql.includes('JOIN images_fts')) return [];
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { clearLibraryStatsCache, getLibraryStats } = await import('../searchRepo');
+        clearLibraryStatsCache();
+
+        await getLibraryStats('WHERE is_deleted = ?', [0], undefined, 'Detailer');
+
+        const [statsSql, statsParams] = findSelectCall(db, (value) => value.includes('count(*) as count')) as [string, unknown[]];
+        const [keywordSql, keywordParams] = findSelectCall(db, (value) => value.includes('JOIN images_fts')) as [string, unknown[]];
+
+        expect(statsSql).toContain('FROM image_loras il');
+        expect(statsSql).toContain('CROSS JOIN images ON images.id = il.image_id');
+        expect(statsSql).not.toContain('FROM images INDEXED BY');
+        expect(statsParams).toEqual(['Detailer', 0]);
+
+        expect(keywordSql).toContain('FROM image_loras il');
+        expect(keywordSql).toContain('CROSS JOIN images ON images.id = il.image_id');
+        expect(keywordSql).toContain('images.rowid > ?');
+        expect(keywordSql).not.toContain('WHERE si.rowid > ?');
+        expect(keywordSql).not.toContain('FROM images INDEXED BY');
+        expect(keywordParams).toEqual(['Detailer', 0, 0]);
+    });
+
+    it('returns full model names without a top-20 cap for scoped stats', async () => {
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as total')) return [{ total: 22 }];
+                if (normalizedSql.includes('GROUP BY name')) {
+                    return Array.from({ length: 22 }, (_, index) => ({
+                        name: `Flux Variant ${index + 1}`,
+                        count: 22 - index
+                    }));
+                }
+                if (normalizedSql.includes('JOIN images_fts')) return [];
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { clearLibraryStatsCache, getLibraryStatsSummary } = await import('../searchRepo');
+        clearLibraryStatsCache();
+
+        const stats = await getLibraryStatsSummary('WHERE is_deleted = ?', [0], 'collection-1', 'Detailer');
+
+        expect(stats.modelStats).toHaveLength(22);
+        expect(stats.modelStats[0]).toEqual({
+            name: 'Flux Variant 1',
+            fullName: 'Flux Variant 1',
+            count: 22
+        });
+
+        const [modelSql, modelParams] = findSelectCall(db, (value) => value.includes('GROUP BY name')) as [string, unknown[]];
+        expect(modelSql).toContain('WITH scoped_images');
+        expect(modelSql).toContain('ci.collection_id = ?');
+        expect(modelSql).toContain('il.lora_name = ?');
+        expect(modelSql).not.toContain('LIMIT 20');
+        expect(modelParams).toEqual(['collection-1', 'Detailer', 0]);
+    });
+
+    it('uses the optimized model-stats indexes for unscoped summaries', async () => {
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as count')) return [{ count: 1 }];
+                if (normalizedSql.includes('GROUP BY name')) return [];
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { clearLibraryStatsCache, getLibraryStatsSummary } = await import('../searchRepo');
+        clearLibraryStatsCache();
+
+        await getLibraryStatsSummary('WHERE is_deleted = 0 AND IFNULL(is_intermediate_gen, 0) = 0 AND IFNULL(is_grid_gen, 0) = 0', []);
+        await getLibraryStatsSummary('WHERE is_deleted = 0 AND IFNULL(is_intermediate_gen, 0) = 0 AND IFNULL(is_grid_gen, 0) = 0 AND privacy_hidden = 0', []);
+
+        const modelCalls = db.select.mock.calls.filter(([sql]) => (sql as string).includes('GROUP BY name'));
+
+        expect(modelCalls).toHaveLength(2);
+        expect(modelCalls[0]?.[0]).toContain('FROM images INDEXED BY idx_images_model_stats_v2');
+        expect(modelCalls[1]?.[0]).toContain('FROM images INDEXED BY idx_images_privacy_model_stats_v1');
+    });
+
+    it('uses the restored fast count path for unscoped summary totals', async () => {
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as count')) return [{ count: 3 }];
+                if (normalizedSql.includes('GROUP BY name')) return [];
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { clearLibraryStatsCache, getLibraryStatsSummary } = await import('../searchRepo');
+        clearLibraryStatsCache();
+
+        const summary = await getLibraryStatsSummary('', []);
+
+        expect(summary.totalImages).toBe(3);
+        const [countSql, countParams] = findSelectCall(db, (value) => value.includes('count(*) as count')) as [string, unknown[]];
+        expect(countSql).toContain('FROM images');
+        expect(countSql).not.toContain('FROM scoped_images');
+        expect(countParams).toEqual([]);
+        expect(findSelectCall(db, (value) => value.includes('count(*) as total'))).toBeUndefined();
+    });
+
+    it('includes prompts beyond the old 2000-row limit when building keyword stats', async () => {
+        const promptBatches = [
+            Array.from({ length: 500 }, (_, index) => ({ rowid: index + 1, positive_prompt: 'alpha alpha' })),
+            Array.from({ length: 500 }, (_, index) => ({ rowid: index + 501, positive_prompt: 'alpha alpha' })),
+            Array.from({ length: 500 }, (_, index) => ({ rowid: index + 1001, positive_prompt: 'alpha alpha' })),
+            Array.from({ length: 500 }, (_, index) => ({ rowid: index + 1501, positive_prompt: 'alpha alpha' })),
+            [{ rowid: 2001, positive_prompt: 'sentinelword alpha' }]
+        ];
+        let promptBatchIndex = 0;
+
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('JOIN images_fts')) {
+                    const batch = promptBatches[promptBatchIndex] ?? [];
+                    promptBatchIndex += 1;
+                    return batch;
+                }
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { getKeywordStats } = await import('../searchRepo');
+        const keywords = await getKeywordStats('WHERE is_deleted = ?', [0]);
+
+        expect(keywords.some((item) => item.text === 'sentinelword')).toBe(true);
+        const keywordCalls = db.select.mock.calls
+            .filter(([sql]) => (sql as string).includes('JOIN images_fts'))
+            .map((call) => [call[0] as string, ((call as unknown[])[1] ?? []) as unknown[]] as [string, unknown[]]);
+
+        expect(keywordCalls).toHaveLength(5);
+        expect(keywordCalls.map(([, params]) => params)).toEqual([
+            [0, 0],
+            [0, 500],
+            [0, 1000],
+            [0, 1500],
+            [0, 2000]
+        ]);
+        keywordCalls.forEach(([sql]) => {
+            expect(sql).toContain('images.rowid > ?');
+            expect(sql).not.toContain('WHERE si.rowid > ?');
+            expect(sql).not.toContain('OFFSET');
+        });
     });
 });

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -15,6 +15,14 @@ export interface LibraryStats {
     keywordStats: { text: string; value: number }[];
 }
 
+export interface LibraryStatsSummary {
+    totalImages: number;
+    totalGenerations: number;
+    avgSteps: number;
+    estSizeMB: string;
+    modelStats: { name: string; fullName: string; count: number }[];
+}
+
 export interface FacetItem {
     name: string;
     count: number;
@@ -101,12 +109,34 @@ interface ModelStatsRow {
     count: number;
 }
 
-interface PromptRow {
+interface PromptBatchRow {
+    rowid: number;
     positive_prompt: string | null;
 }
 
 export interface GetFacetsOptions {
     assetScope?: AssetScope;
+    collectionId?: string;
+    loraName?: string;
+}
+
+interface ScopedImageQueryParts {
+    cteSql: string;
+    queryParams: unknown[];
+    reason: string;
+}
+
+interface ScopedImageSourceParts {
+    fromClause: string;
+    scopedWhere: string;
+    queryParams: unknown[];
+    reason: string;
+}
+
+interface ScopedImageQueryOptions {
+    defaultFromClause?: string;
+    trailingPredicate?: string;
+    trailingParams?: unknown[];
 }
 
 const maxOptionalNumber = (a: number | undefined, b: number | undefined): number | undefined => {
@@ -142,9 +172,7 @@ const copyFallbackFacetFields = (target: FacetItem, source: FacetItem): FacetIte
 });
 
 const mergeFacetItem = (group: FacetMergeGroup, candidate: FacetItem): void => {
-    if (candidate.count > 0) {
-        group.usedAliases.add(candidate.name);
-    }
+    group.usedAliases.add(candidate.name);
 
     const totalCount = group.item.count + candidate.count;
     const isLocalDisk = Boolean(group.item.isLocalDisk || candidate.isLocalDisk);
@@ -184,6 +212,10 @@ const mergeFacetItem = (group: FacetMergeGroup, candidate: FacetItem): void => {
 
 const sortFacetItems = (items: FacetItem[]): FacetItem[] => (
     items.sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+);
+
+const normalizeFacetCountKey = (value: string | null | undefined): string => (
+    getAssetMatchKey(value) || (value || 'Unknown').toLowerCase()
 );
 
 const cacheTypeToDiskResourceType = (cacheType: string): string | null => {
@@ -295,6 +327,17 @@ const getDiskModifiedAtForFacetRow = (
 };
 
 const DEFAULT_VISIBLE_WHERE = "WHERE is_deleted = 0 AND IFNULL(is_intermediate_gen, 0) = 0 AND IFNULL(is_grid_gen, 0) = 0";
+const KEYWORD_BATCH_SIZE = 500;
+
+const isDefaultGlobalScope = (
+    whereClause: string = '',
+    params: unknown[] = [],
+    collectionId?: string,
+    loraName?: string
+): boolean => {
+    const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
+    return !collectionId && !loraName && finalWhere === DEFAULT_VISIBLE_WHERE && params.length === 0;
+};
 
 const hasPrivacyFilter = (whereClause: string) => /\bprivacy_hidden\s*=\s*0\b/.test(whereClause);
 const hasFastSortVisibilityPrefix = (whereClause: string) =>
@@ -313,6 +356,15 @@ const selectImageSortIndex = (whereClause: string, sortField: string): string | 
 
     return null;
 };
+
+const selectModelStatsIndex = (whereClause: string): string =>
+    hasPrivacyFilter(whereClause) && hasFastSortVisibilityPrefix(whereClause)
+        ? 'idx_images_privacy_model_stats_v1'
+        : 'idx_images_model_stats_v2';
+
+const appendTrailingPredicate = (whereClause: string, predicate?: string): string => (
+    predicate ? `${whereClause} AND ${predicate}` : whereClause
+);
 
 export const countImages = async (whereClause: string, params: unknown[], collectionId?: string, loraName?: string): Promise<number> => {
     const db = await getDb();
@@ -523,98 +575,289 @@ export const searchImages = async (
     return rows.map(mapRowToImage);
 };
 
-let globalStatsCache: LibraryStats | null = null;
+let globalStatsSummaryCache: LibraryStatsSummary | null = null;
 
 export const clearLibraryStatsCache = () => {
-    globalStatsCache = null;
+    globalStatsSummaryCache = null;
 };
 
-const buildScopedImageJoins = (collectionId?: string, loraName?: string): { joinClause: string; joinParams: unknown[] } => {
-    const joins: string[] = [];
-    const joinParams: unknown[] = [];
+const buildScopedImageSourceParts = (
+    whereClause: string = '',
+    params: unknown[] = [],
+    collectionId?: string,
+    loraName?: string,
+    options: ScopedImageQueryOptions = {}
+): ScopedImageSourceParts => {
+    const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
+    const reason = describeDbQueryReason(finalWhere, collectionId, loraName);
+    const {
+        defaultFromClause = 'FROM images',
+        trailingPredicate,
+        trailingParams = []
+    } = options;
+
+    if (collectionId && loraName) {
+        return {
+            fromClause: `
+                FROM collection_images ci
+                JOIN image_loras il ON il.image_id = ci.image_id
+                JOIN images ON images.id = ci.image_id
+            `,
+            scopedWhere: appendTrailingPredicate(
+                finalWhere.replace('WHERE', 'WHERE ci.collection_id = ? AND il.lora_name = ? AND'),
+                trailingPredicate
+            ),
+            queryParams: [collectionId, loraName, ...params, ...trailingParams],
+            reason
+        };
+    }
 
     if (collectionId) {
-        joins.push('JOIN collection_images ci ON ci.image_id = images.id AND ci.collection_id = ?');
-        joinParams.push(collectionId);
+        return {
+            fromClause: `
+                FROM collection_images ci
+                CROSS JOIN images ON images.id = ci.image_id
+            `,
+            scopedWhere: appendTrailingPredicate(
+                finalWhere.replace('WHERE', 'WHERE ci.collection_id = ? AND'),
+                trailingPredicate
+            ),
+            queryParams: [collectionId, ...params, ...trailingParams],
+            reason
+        };
     }
 
     if (loraName) {
-        joins.push('JOIN image_loras il ON il.image_id = images.id AND il.lora_name = ?');
-        joinParams.push(loraName);
+        return {
+            fromClause: `
+                FROM image_loras il
+                CROSS JOIN images ON images.id = il.image_id
+            `,
+            scopedWhere: appendTrailingPredicate(
+                finalWhere.replace('WHERE', 'WHERE il.lora_name = ? AND'),
+                trailingPredicate
+            ),
+            queryParams: [loraName, ...params, ...trailingParams],
+            reason
+        };
     }
 
     return {
-        joinClause: joins.join('\n'),
-        joinParams
+        fromClause: defaultFromClause,
+        scopedWhere: appendTrailingPredicate(finalWhere, trailingPredicate),
+        queryParams: [...params, ...trailingParams],
+        reason
     };
 };
 
-export const getLibraryStats = async (whereClause: string = '', params: unknown[] = [], collectionId?: string, loraName?: string): Promise<LibraryStats> => {
-    // Return cached result instantly for unfiltered dashboard loads
-    if (!whereClause && !collectionId && !loraName && globalStatsCache) {
-        return globalStatsCache;
+const buildScopedImageQueryParts = (
+    whereClause: string = '',
+    params: unknown[] = [],
+    collectionId?: string,
+    loraName?: string,
+    selectedColumns: string[] = ['images.id AS id', 'images.rowid AS rowid'],
+    options: ScopedImageQueryOptions = {}
+): ScopedImageQueryParts => {
+    const sourceParts = buildScopedImageSourceParts(whereClause, params, collectionId, loraName, options);
+
+    return {
+        cteSql: `
+            WITH scoped_images AS (
+                SELECT ${selectedColumns.join(', ')}
+                ${sourceParts.fromClause}
+                ${sourceParts.scopedWhere}
+            )
+        `,
+        queryParams: sourceParts.queryParams,
+        reason: sourceParts.reason
+    };
+};
+
+const buildScopedFacetCountSql = (cacheType: string, cteSql: string): string | null => {
+    switch (cacheType) {
+        case 'checkpoints':
+            return `
+                ${cteSql}
+                SELECT COALESCE(resolved_model_name, model_name, 'Unknown') AS name, count(*) AS count
+                FROM scoped_images
+                GROUP BY name
+            `;
+        case 'loras':
+            return `
+                ${cteSql}
+                SELECT COALESCE(il.lora_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                FROM scoped_images si
+                JOIN image_loras il ON il.image_id = si.id
+                GROUP BY il.lora_name
+            `;
+        case 'embeddings':
+            return `
+                ${cteSql}
+                SELECT COALESCE(ie.embedding_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                FROM scoped_images si
+                JOIN image_embeddings ie ON ie.image_id = si.id
+                GROUP BY ie.embedding_name
+            `;
+        case 'hypernetworks':
+            return `
+                ${cteSql}
+                SELECT COALESCE(ih.hypernetwork_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                FROM scoped_images si
+                JOIN image_hypernetworks ih ON ih.image_id = si.id
+                GROUP BY ih.hypernetwork_name
+            `;
+        case 'control_nets':
+            return `
+                ${cteSql}
+                SELECT COALESCE(ic.controlnet_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                FROM scoped_images si
+                JOIN image_controlnets ic ON ic.image_id = si.id
+                GROUP BY ic.controlnet_name
+            `;
+        case 'ip_adapters':
+            return `
+                ${cteSql}
+                SELECT COALESCE(ii.ipadapter_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                FROM scoped_images si
+                JOIN image_ipadapters ii ON ii.image_id = si.id
+                GROUP BY ii.ipadapter_name
+            `;
+        default:
+            return null;
+    }
+};
+
+const getScopedFacetCountMaps = async (
+    whereClause: string = '',
+    params: unknown[] = [],
+    cacheTypes: string[],
+    collectionId?: string,
+    loraName?: string
+): Promise<Map<string, Map<string, number>>> => {
+    const db = await getDb();
+    const scopedParts = buildScopedImageQueryParts(whereClause, params, collectionId, loraName, [
+        'images.id AS id',
+        'images.resolved_model_name AS resolved_model_name',
+        'images.model_name AS model_name'
+    ]);
+
+    const queries = cacheTypes
+        .filter(cacheType => cacheType !== 'tools')
+        .map(async (cacheType) => {
+            const sql = buildScopedFacetCountSql(cacheType, scopedParts.cteSql);
+            if (!sql) return [cacheType, new Map<string, number>()] as const;
+
+            const rows = await timeDbCall(
+                `facets.scoped.${cacheType}`,
+                scopedParts.reason,
+                () => db.select<ModelStatsRow[]>(sql, scopedParts.queryParams)
+            );
+
+            return [
+                cacheType,
+                rows.reduce((counts, row) => {
+                    const key = normalizeFacetCountKey(row.name);
+                    counts.set(key, (counts.get(key) ?? 0) + row.count);
+                    return counts;
+                }, new Map<string, number>())
+            ] as const;
+        });
+
+    return new Map(await Promise.all(queries));
+};
+
+const buildLibraryStatsSummary = (
+    total: number,
+    modelRows: ModelStatsRow[]
+): LibraryStatsSummary => ({
+    totalImages: total,
+    totalGenerations: total,
+    avgSteps: 0,
+    estSizeMB: ((total * 2.4)).toFixed(1),
+    modelStats: modelRows.map(r => ({
+        name: r.name || 'Unknown',
+        fullName: r.name || 'Unknown',
+        count: r.count
+    }))
+});
+
+export const getLibraryStatsSummary = async (
+    whereClause: string = '',
+    params: unknown[] = [],
+    collectionId?: string,
+    loraName?: string
+): Promise<LibraryStatsSummary> => {
+    const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
+
+    if (!whereClause && !collectionId && !loraName && globalStatsSummaryCache) {
+        return globalStatsSummaryCache;
     }
 
     const db = await getDb();
-    const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
-    const reason = describeDbQueryReason(finalWhere, collectionId, loraName);
-    const { joinClause, joinParams } = buildScopedImageJoins(collectionId, loraName);
+    const scopedParts = buildScopedImageQueryParts(whereClause, params, collectionId, loraName, [
+        'images.id AS id',
+        'images.rowid AS rowid',
+        'images.resolved_model_name AS resolved_model_name',
+        'images.model_name AS model_name'
+    ]);
+    const modelScopedParts = buildScopedImageQueryParts(
+        whereClause,
+        params,
+        collectionId,
+        loraName,
+        [
+            'images.id AS id',
+            'images.rowid AS rowid',
+            'images.resolved_model_name AS resolved_model_name',
+            'images.model_name AS model_name'
+        ],
+        { defaultFromClause: `FROM images INDEXED BY ${selectModelStatsIndex(finalWhere)}` }
+    );
 
     try {
-        const statsQuery = `
-            SELECT 
-                count(*) as total
+        const total = await countImages(whereClause, params, collectionId, loraName);
 
-            FROM images 
-            ${joinClause}
-            ${finalWhere}
-        `;
-
-        const basicStats = await timeDbCall('libraryStats.basicStats', reason, () => db.select<BasicStatsRow[]>(statsQuery, [...joinParams, ...params]));
-        
-        const total = basicStats[0]?.total || 0;
-        const avgSteps = 0; // Temporarily disabled for performance
-
-        // Use denormalized resolved_model_name column for model stats
-        const modelStatsIndex = hasPrivacyFilter(finalWhere) && hasFastSortVisibilityPrefix(finalWhere)
-            ? 'idx_images_privacy_model_stats_v1'
-            : 'idx_images_model_stats_v2';
         const modelQuery = `
-        SELECT
-        COALESCE(resolved_model_name, model_name, 'Unknown') as name,
-            count(*) as count
-            FROM images INDEXED BY ${modelStatsIndex}
-            ${finalWhere}
+            ${modelScopedParts.cteSql}
+            SELECT
+                COALESCE(resolved_model_name, model_name, 'Unknown') as name,
+                count(*) as count
+            FROM scoped_images
             GROUP BY name
             ORDER BY count DESC
-            LIMIT 20
-            `;
-            
-        const modelRows = await timeDbCall('libraryStats.modelStats', reason, () => db.select<ModelStatsRow[]>(modelQuery, params));
+        `;
 
-        const modelStats = modelRows.map(r => ({
-            name: (r.name || 'Unknown').split(' ')[0],
-            fullName: r.name || 'Unknown',
-            count: r.count
-        }));
-
-        // Get Keyword Stats
-        const keywordStats = await timeDbCall('libraryStats.keywordStats', reason, () => getKeywordStats(finalWhere, params, collectionId, loraName));
-
-        const finalResult = {
-            totalImages: total,
-            totalGenerations: total,
-            avgSteps: avgSteps,
-            estSizeMB: ((total * 2.4)).toFixed(1),
-            modelStats,
-            keywordStats
-        };
+        const modelRows = await timeDbCall('libraryStats.modelStats', modelScopedParts.reason, () => db.select<ModelStatsRow[]>(modelQuery, modelScopedParts.queryParams));
+        const summary = buildLibraryStatsSummary(total, modelRows);
 
         if (!whereClause && !collectionId && !loraName) {
-            globalStatsCache = finalResult;
+            globalStatsSummaryCache = summary;
         }
 
-        return finalResult;
+        return summary;
+    } catch (e) {
+        console.error('[DB] Failed to get library stats summary', e);
+        return {
+            totalImages: 0,
+            totalGenerations: 0,
+            avgSteps: 0,
+            estSizeMB: '0',
+            modelStats: []
+        };
+    }
+};
+
+export const getLibraryStats = async (whereClause: string = '', params: unknown[] = [], collectionId?: string, loraName?: string): Promise<LibraryStats> => {
+    try {
+        const [summary, keywordStats] = await Promise.all([
+            getLibraryStatsSummary(whereClause, params, collectionId, loraName),
+            getKeywordStats(whereClause, params, collectionId, loraName)
+        ]);
+
+        return {
+            ...summary,
+            keywordStats
+        };
     } catch (e) {
         console.error('[DB] Failed to get library stats', e);
         return {
@@ -632,75 +875,59 @@ export const getKeywordStats = async (whereClause: string = '', params: unknown[
     const db = await getDb();
 
     try {
-        // Debug: Log the incoming filter to debug "static" issues
-        console.log('[DB] getKeywordStats filter:', whereClause);
-
-        // Fix ambiguity for JOIN: replace and ensure columns are prefixed with 'images.'
-        const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
-
-        // Comprehensive list of columns in the 'images' table to prefix
-        const columnsToPrefix = [
-            'id', 'is_deleted', 'metadata_json', 'path', 'width', 'height', 'file_size',
-            'timestamp', 'thumbnail_path', 'is_favorite', 'is_pinned', 'is_missing',
-            'user_masked', 'group_id', 'board_id', 'notes', 'original_metadata_json',
-            // New denormalized columns
-            'model_hash', 'model_name', 'tool', 'resolved_model_name', 'is_intermediate_gen', 'is_grid_gen', 'privacy_hidden', 'sampler', 'generation_type',
-            'positive_prompt', 'negative_prompt'
-        ];
-
-        // Improved Regex:
-        // (?:\\bimages\\.)? -> Matches optional "images." prefix (non-capturing)
-        // \\b(${columnsToPrefix.join('|')}) -> Matches the column name itself
-        // \\b -> Word boundary to ensure full match
-        const columnRegex = new RegExp(`(?:\\bimages\\.)?\\b(${columnsToPrefix.join('|')})\\b`, 'g');
-
-        const safeWhere = finalWhere.replace(columnRegex, (match, col) => {
-            // Note: 'match' is the full string (e.g. "id" or "images.id")
-            // 'col' is the captured group 1 (e.g. "id")
-            // We always want to return "images.id"
-            return `images.${col}`;
-        });
-
-        // 1. Flip JOIN order: Filter 'images' first, then lookup FTS text
-        // 2. Add RANDOM() sort to LIMIT to get a representative sample of the filtered set
-        //    (instead of just the first N oldest images)
-        /*
-         * Note on Performance: 
-         * ORDER BY RANDOM() on the full set is slow. 
-         * But since we have a LIMIT, SQLite can sometimes optimize.
-         * For a word cloud, we need a diverse sample.
-         */
-        const { joinClause: scopedJoinClause, joinParams } = buildScopedImageJoins(collectionId, loraName);
-        const joinClause = `
-            ${scopedJoinClause}
-            JOIN images_fts ON images_fts.rowid = images.rowid
-        `;
-
-        const promptQuery = `
-            SELECT images_fts.positive_prompt 
-            FROM images
-            ${joinClause}
-            ${safeWhere}
-            LIMIT ${WORD_CLOUD_CONFIG.ANALYSIS_LIMIT}
-        `;
-        
-        const reason = describeDbQueryReason(finalWhere, collectionId, loraName);
-        const rows = await timeDbCall('keywordStats.promptSample', reason, () => db.select<PromptRow[]>(promptQuery, [...joinParams, ...params]));
-        
         const stopWords = new Set(WORD_CLOUD_CONFIG.STOP_WORDS);
         const counts: Record<string, number> = {};
-        rows.forEach(r => {
-            const tokens = (r.positive_prompt || '')
-                .toLowerCase()
-                .replace(/[^a-z0-9\s]/g, ' ')
-                .split(/\s+/);
+        let lastRowId = 0;
 
-            tokens.forEach((token: string) => {
-                if (token.length > 3 && !stopWords.has(token) && !/^\d+$/.test(token)) {
-                    counts[token] = (counts[token] || 0) + 1;
+        for (;;) {
+            const scopedParts = buildScopedImageQueryParts(
+                whereClause,
+                params,
+                collectionId,
+                loraName,
+                [
+                    'images.id AS id',
+                    'images.rowid AS rowid'
+                ],
+                {
+                    trailingPredicate: 'images.rowid > ?',
+                    trailingParams: [lastRowId]
                 }
+            );
+            const promptQuery = `
+                ${scopedParts.cteSql}
+                SELECT si.rowid, images_fts.positive_prompt
+                FROM scoped_images si
+                JOIN images_fts ON images_fts.rowid = si.rowid
+                ORDER BY si.rowid ASC
+                LIMIT ${KEYWORD_BATCH_SIZE}
+            `;
+
+            const rows = await timeDbCall(
+                'keywordStats.promptBatch',
+                scopedParts.reason,
+                () => db.select<PromptBatchRow[]>(promptQuery, scopedParts.queryParams)
+            );
+
+            rows.forEach(r => {
+                const tokens = (r.positive_prompt || '')
+                    .toLowerCase()
+                    .replace(/[^a-z0-9\s]/g, ' ')
+                    .split(/\s+/);
+
+                tokens.forEach((token: string) => {
+                    if (token.length > 3 && !stopWords.has(token) && !/^\d+$/.test(token)) {
+                        counts[token] = (counts[token] || 0) + 1;
+                    }
+                });
             });
-        });
+
+            const finalRow = rows.at(-1);
+            if (!finalRow) break;
+            lastRowId = finalRow.rowid;
+
+            if (rows.length < KEYWORD_BATCH_SIZE) break;
+        }
 
         return Object.entries(counts)
             .map(([text, value]) => ({ text, value }))
@@ -716,15 +943,11 @@ export const getKeywordStats = async (whereClause: string = '', params: unknown[
 
 
 /**
- * Fetches facets from the pre-built cache.
- * 
- * TODO: _whereClause and _params are placeholders for future support of
- * "filtered facet counts" (e.g., "how many LoRAs in images from this week?").
- * The current implementation reads from `facet_cache` which represents global counts.
+ * Fetches facets from the pre-built cache, overlaying filter-scoped usage counts for used/all scopes.
  */
 export const getFacets = async (
-    _whereClause: string = '',
-    _params: unknown[] = [],
+    whereClause: string = '',
+    params: unknown[] = [],
     types: FacetType[] = ['checkpoints', 'loras', 'embeddings', 'hypernetworks', 'tools'],
     options: GetFacetsOptions = {}
 ): Promise<Facets> => {
@@ -753,9 +976,11 @@ export const getFacets = async (
                 .filter((type): type is string => type !== null)
         ));
         const diskPlaceholders = diskResourceTypes.map(() => '?').join(',');
-        const scopePredicate = assetScope === 'used'
-            ? 'AND fc.count > 0'
-            : '';
+        const shouldUseScopedFacetOverlay = assetScope !== 'local'
+            && !isDefaultGlobalScope(whereClause, params, options.collectionId, options.loraName);
+        const scopedCountMaps = shouldUseScopedFacetOverlay
+            ? await getScopedFacetCountMaps(whereClause, params, cacheTypes, options.collectionId, options.loraName)
+            : new Map<string, Map<string, number>>();
 
         const [cacheRows, diskRows] = await Promise.all([
             db.select<FacetCacheRow[]>(`
@@ -765,7 +990,6 @@ export const getFacets = async (
                 fc.safe_thumbnail_path, fc.thumbnail_image_id, fc.thumbnail_is_sensitive, fc.thumbnail_sensitivity_override
             FROM facet_cache fc
             WHERE fc.facet_type IN(${placeholders})
-            ${scopePredicate}
             ORDER BY fc.count DESC, fc.resource_name ASC
             `, cacheTypes),
             diskResourceTypes.length > 0
@@ -834,7 +1058,7 @@ export const getFacets = async (
             } else {
                 groupMap.set(assetMatchKey, {
                     item,
-                    usedAliases: new Set(item.count > 0 ? [item.name] : []),
+                    usedAliases: new Set([item.name]),
                     displayCount: item.count
                 });
             }
@@ -846,12 +1070,19 @@ export const getFacets = async (
             return item.count > 0 || Boolean(item.isLocalDisk);
         };
 
-        const finalizeGroups = (facetType: keyof typeof mergedResources): FacetItem[] => sortFacetItems(
-            Array.from(mergedResources[facetType].values()).map(group => ({
-                ...group.item,
-                filterAliases: uniqueAssetAliases([group.item.name, ...group.usedAliases]),
-            })).filter(shouldIncludeFacetItem)
-        );
+        const finalizeGroups = (facetType: keyof typeof mergedResources): FacetItem[] => {
+            const scopedCountMap = scopedCountMaps.get(facetType);
+
+            return sortFacetItems(
+                Array.from(mergedResources[facetType].values()).map(group => ({
+                    ...group.item,
+                    count: assetScope === 'local' || !shouldUseScopedFacetOverlay
+                        ? group.item.count
+                        : (scopedCountMap?.get(group.item.assetMatchKey || normalizeFacetCountKey(group.item.name)) ?? 0),
+                    filterAliases: uniqueAssetAliases([group.item.name, ...group.usedAliases]),
+                })).filter(shouldIncludeFacetItem)
+            );
+        };
 
         result.checkpoints = finalizeGroups('checkpoints');
         result.loras = finalizeGroups('loras');


### PR DESCRIPTION
## Summary
- make statistics queries scope-correct for models, facets, and word-cloud analysis
- split summary stats from keyword analysis so cards and model bars render before the full prompt scan
- fix stale keyword rendering, alias-normalized facet counts, and large-library stats performance regressions

## Testing
- `pnpm run typecheck`
- `pnpm vitest run src/hooks/__tests__/useLibraryStatsQuery.test.tsx src/components/ui/__tests__/Charts.test.tsx src/services/db/__tests__/searchRepo.test.ts`

## Notes
- Vitest was run outside the sandbox on Windows because sandboxed Vite startup hit `spawn EPERM`.