### PR TITLE
fix: repair InvokeAI nested image paths

### DIFF
--- a/src-tauri/src/db/commands/image_commands.rs
+++ b/src-tauri/src/db/commands/image_commands.rs
@@ -23,6 +23,23 @@ pub struct PrivacyMaskRefreshResult {
     pub updated: usize,
 }
 
+#[derive(serde::Deserialize, specta::Type, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagePathIdentityMove {
+    pub old_id: String,
+    pub new_id: String,
+    pub thumbnail_path: Option<String>,
+    pub thumbnail_source: Option<String>,
+}
+
+#[derive(serde::Serialize, specta::Type, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagePathIdentityMoveResult {
+    pub moved: usize,
+    pub skipped_target_exists: usize,
+    pub skipped_source_missing: usize,
+}
+
 fn normalize_privacy_keywords(masked_keywords: &[String]) -> Vec<String> {
     masked_keywords
         .iter()
@@ -390,6 +407,227 @@ fn save_images_batch_inner(
     Ok(images.len())
 }
 
+fn normalize_image_identity_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn move_image_path_identities_inner(
+    conn: &rusqlite::Connection,
+    moves: &[ImagePathIdentityMove],
+) -> Result<ImagePathIdentityMoveResult, String> {
+    let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+    tx.execute_batch("PRAGMA defer_foreign_keys = ON;")
+        .map_err(|e| e.to_string())?;
+
+    let mut result = ImagePathIdentityMoveResult {
+        moved: 0,
+        skipped_target_exists: 0,
+        skipped_source_missing: 0,
+    };
+
+    {
+        let mut target_exists = tx
+            .prepare_cached("SELECT 1 FROM images WHERE id = ?1 LIMIT 1")
+            .map_err(|e| e.to_string())?;
+        let mut source_identity = tx
+            .prepare_cached("SELECT path, thumbnail_path FROM images WHERE id = ?1 LIMIT 1")
+            .map_err(|e| e.to_string())?;
+        let mut update_image = tx
+            .prepare_cached(
+                "UPDATE images
+                 SET id = ?1,
+                     path = ?1,
+                     thumbnail_path = COALESCE(NULLIF(?2, ''), thumbnail_path),
+                     thumbnail_source = ?3,
+                     is_missing = 0
+                 WHERE id = ?4",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut update_collections = tx
+            .prepare_cached("UPDATE collection_images SET image_id = ?1 WHERE image_id = ?2")
+            .map_err(|e| e.to_string())?;
+        let mut update_loras = tx
+            .prepare_cached("UPDATE image_loras SET image_id = ?1 WHERE image_id = ?2")
+            .map_err(|e| e.to_string())?;
+        let mut update_embeddings = tx
+            .prepare_cached("UPDATE image_embeddings SET image_id = ?1 WHERE image_id = ?2")
+            .map_err(|e| e.to_string())?;
+        let mut update_hypernetworks = tx
+            .prepare_cached("UPDATE image_hypernetworks SET image_id = ?1 WHERE image_id = ?2")
+            .map_err(|e| e.to_string())?;
+        let mut update_controlnets = tx
+            .prepare_cached("UPDATE image_controlnets SET image_id = ?1 WHERE image_id = ?2")
+            .map_err(|e| e.to_string())?;
+        let mut update_ipadapters = tx
+            .prepare_cached("UPDATE image_ipadapters SET image_id = ?1 WHERE image_id = ?2")
+            .map_err(|e| e.to_string())?;
+        let mut update_facet_thumbnail_image = tx
+            .prepare_cached(
+                "UPDATE facet_cache SET thumbnail_image_id = ?1 WHERE thumbnail_image_id = ?2",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut update_facet_thumbnail_path = tx
+            .prepare_cached(
+                "UPDATE facet_cache
+                 SET thumbnail_path = ?1
+                 WHERE thumbnail_path = ?2
+                    OR thumbnail_path = ?3
+                    OR (?4 IS NOT NULL AND thumbnail_path = ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut update_facet_safe_thumbnail_path = tx
+            .prepare_cached(
+                "UPDATE facet_cache
+                 SET safe_thumbnail_path = ?1
+                 WHERE safe_thumbnail_path = ?2
+                    OR safe_thumbnail_path = ?3
+                    OR (?4 IS NOT NULL AND safe_thumbnail_path = ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut update_collection_dynamic_thumbnail_path = tx
+            .prepare_cached(
+                "UPDATE collections
+                 SET dynamic_thumbnail_path = ?1
+                 WHERE dynamic_thumbnail_path = ?2
+                    OR dynamic_thumbnail_path = ?3
+                    OR (?4 IS NOT NULL AND dynamic_thumbnail_path = ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut update_collection_dynamic_safe_thumbnail_path = tx
+            .prepare_cached(
+                "UPDATE collections
+                 SET dynamic_safe_thumbnail_path = ?1
+                 WHERE dynamic_safe_thumbnail_path = ?2
+                    OR dynamic_safe_thumbnail_path = ?3
+                    OR (?4 IS NOT NULL AND dynamic_safe_thumbnail_path = ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut update_model_thumbnail_path = tx
+            .prepare_cached(
+                "UPDATE models
+                 SET thumbnail_path = ?1
+                 WHERE thumbnail_path = ?2
+                    OR thumbnail_path = ?3
+                    OR (?4 IS NOT NULL AND thumbnail_path = ?4)",
+            )
+            .map_err(|e| e.to_string())?;
+
+        for item in moves {
+            let old_id = normalize_image_identity_path(&item.old_id);
+            let new_id = normalize_image_identity_path(&item.new_id);
+            if old_id == new_id {
+                continue;
+            }
+
+            let has_target = target_exists
+                .exists(params![&new_id])
+                .map_err(|e| e.to_string())?;
+            if has_target {
+                result.skipped_target_exists += 1;
+                continue;
+            }
+
+            let source_row = source_identity
+                .query_row(params![&old_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+                })
+                .optional()
+                .map_err(|e| e.to_string())?;
+            let Some((source_path, source_thumbnail_path)) = source_row else {
+                result.skipped_source_missing += 1;
+                continue;
+            };
+            let old_path = normalize_image_identity_path(&source_path);
+            let old_thumbnail_path = source_thumbnail_path
+                .as_deref()
+                .map(normalize_image_identity_path);
+
+            let thumbnail_path = item
+                .thumbnail_path
+                .as_deref()
+                .map(normalize_image_identity_path);
+
+            update_image
+                .execute(params![
+                    &new_id,
+                    thumbnail_path,
+                    item.thumbnail_source.as_deref(),
+                    &old_id
+                ])
+                .map_err(|e| e.to_string())?;
+            update_collections
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+            update_loras
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+            update_embeddings
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+            update_hypernetworks
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+            update_controlnets
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+            update_ipadapters
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+            update_facet_thumbnail_image
+                .execute(params![&new_id, &old_id])
+                .map_err(|e| e.to_string())?;
+
+            if let Some(new_thumbnail_path) = thumbnail_path.as_deref() {
+                update_model_thumbnail_path
+                    .execute(params![
+                        new_thumbnail_path,
+                        &old_id,
+                        &old_path,
+                        old_thumbnail_path.as_deref()
+                    ])
+                    .map_err(|e| e.to_string())?;
+                update_facet_thumbnail_path
+                    .execute(params![
+                        new_thumbnail_path,
+                        &old_id,
+                        &old_path,
+                        old_thumbnail_path.as_deref()
+                    ])
+                    .map_err(|e| e.to_string())?;
+                update_facet_safe_thumbnail_path
+                    .execute(params![
+                        new_thumbnail_path,
+                        &old_id,
+                        &old_path,
+                        old_thumbnail_path.as_deref()
+                    ])
+                    .map_err(|e| e.to_string())?;
+                update_collection_dynamic_thumbnail_path
+                    .execute(params![
+                        new_thumbnail_path,
+                        &old_id,
+                        &old_path,
+                        old_thumbnail_path.as_deref()
+                    ])
+                    .map_err(|e| e.to_string())?;
+                update_collection_dynamic_safe_thumbnail_path
+                    .execute(params![
+                        new_thumbnail_path,
+                        &old_id,
+                        &old_path,
+                        old_thumbnail_path.as_deref()
+                    ])
+                    .map_err(|e| e.to_string())?;
+            }
+
+            result.moved += 1;
+        }
+    }
+
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(result)
+}
+
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
 pub async fn refresh_privacy_mask_index(
@@ -424,6 +662,35 @@ pub async fn save_images_batch(app: AppHandle, images: Vec<ImageRecord>) -> Resu
             }
         }
         Err("Failed to save images after max retries".to_string())
+    })
+    .await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn move_image_path_identities(
+    app: AppHandle,
+    moves: Vec<ImagePathIdentityMove>,
+) -> Result<ImagePathIdentityMoveResult, String> {
+    run_blocking(app, move |conn| {
+        let max_retries = 5;
+        let mut retry_delay_ms = 100;
+
+        for attempt in 0..max_retries {
+            let result = move_image_path_identities_inner(conn, &moves);
+
+            match result {
+                Ok(result) => return Ok(result),
+                Err(e) if e.contains("database is locked") && attempt < max_retries - 1 => {
+                    std::thread::sleep(std::time::Duration::from_millis(retry_delay_ms));
+                    retry_delay_ms *= 2;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err("Failed to move image paths after max retries".to_string())
     })
     .await
 }
@@ -904,6 +1171,390 @@ mod tests {
         assert_eq!(row.3, 0);
         assert_eq!(row.4, None);
         assert_eq!(row.5, None);
+    }
+
+    #[test]
+    fn move_image_path_identities_moves_image_and_preserves_relationships() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        apply_all_migrations(&conn);
+
+        let old_id = "D:/Invoke/outputs/images/old.png";
+        let old_path = "D:/Invoke/outputs/images/legacy/old.png";
+        let old_thumbnail_path = "D:/Invoke/outputs/images/thumbnails/old.webp";
+        let new_id = "D:/Invoke/outputs/images/2026/05/old.png";
+        let mut image = create_image_record(old_id, 100, 200, "{}");
+        image.path = old_path.to_string();
+        image.thumbnail_path = old_thumbnail_path.to_string();
+        image.thumbnail_source = Some("invokeai".to_string());
+        super::save_images_batch_inner(&conn, &[image]).expect("initial save");
+
+        conn.execute(
+            "INSERT INTO collections (id, name, created_at, source) VALUES ('board-1', 'Board', 1, 'invoke')",
+            [],
+        )
+        .expect("collection");
+        conn.execute(
+            "INSERT INTO collection_images (collection_id, image_id) VALUES ('board-1', ?1)",
+            params![old_id],
+        )
+        .expect("collection image");
+        conn.execute(
+            "INSERT INTO image_loras (image_id, lora_name) VALUES (?1, 'DetailBoost')",
+            params![old_id],
+        )
+        .expect("lora");
+        conn.execute(
+            "INSERT INTO image_embeddings (image_id, embedding_name) VALUES (?1, 'EasyNegative')",
+            params![old_id],
+        )
+        .expect("embedding");
+        conn.execute(
+            "INSERT INTO image_hypernetworks (image_id, hypernetwork_name) VALUES (?1, 'Hyper')",
+            params![old_id],
+        )
+        .expect("hypernetwork");
+        conn.execute(
+            "INSERT INTO image_controlnets (image_id, controlnet_name) VALUES (?1, 'Depth')",
+            params![old_id],
+        )
+        .expect("controlnet");
+        conn.execute(
+            "INSERT INTO image_ipadapters (image_id, ipadapter_name) VALUES (?1, 'Face')",
+            params![old_id],
+        )
+        .expect("ipadapter");
+        conn.execute(
+            "INSERT INTO facet_cache (
+                facet_type,
+                resource_name,
+                thumbnail_path,
+                safe_thumbnail_path,
+                thumbnail_image_id
+             ) VALUES (
+                'checkpoints',
+                'Model A',
+                ?1,
+                ?2,
+                ?3
+             )",
+            params![old_path, old_thumbnail_path, old_id],
+        )
+        .expect("facet cache");
+        conn.execute(
+            "UPDATE collections
+             SET dynamic_thumbnail_path = ?1,
+                 dynamic_safe_thumbnail_path = ?2,
+                 dynamic_thumbnail_is_sensitive = 0,
+                 dynamic_thumbnail_cached_at = 123
+             WHERE id = 'board-1'",
+            params![old_path, old_thumbnail_path],
+        )
+        .expect("collection thumbnail cache");
+        for (hash, name, thumbnail_path) in [
+            ("model-old-id", "Model Old Id", old_id),
+            ("model-old-path", "Model Old Path", old_path),
+            (
+                "model-old-thumbnail",
+                "Model Old Thumbnail",
+                old_thumbnail_path,
+            ),
+        ] {
+            conn.execute(
+                "INSERT INTO models (
+                    hash,
+                    name,
+                    lookup_source,
+                    scanned_at,
+                    thumbnail_path,
+                    resource_type
+                 ) VALUES (?1, ?2, 'manual_thumbnail', 1, ?3, 'checkpoint')",
+                params![hash, name, thumbnail_path],
+            )
+            .expect("manual model thumbnail");
+        }
+
+        let result = super::move_image_path_identities_inner(
+            &conn,
+            &[super::ImagePathIdentityMove {
+                old_id: old_id.to_string(),
+                new_id: new_id.to_string(),
+                thumbnail_path: Some(new_id.to_string()),
+                thumbnail_source: None,
+            }],
+        )
+        .expect("move paths");
+
+        assert_eq!(result.moved, 1);
+        assert_eq!(result.skipped_target_exists, 0);
+        assert_eq!(result.skipped_source_missing, 0);
+
+        let row = conn
+            .query_row(
+                "SELECT id, path, thumbnail_path, thumbnail_source, is_missing FROM images WHERE id = ?1",
+                params![new_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                        row.get::<_, i64>(4)?,
+                    ))
+                },
+            )
+            .expect("moved image");
+        assert_eq!(row.0, new_id);
+        assert_eq!(row.1, new_id);
+        assert_eq!(row.2, new_id);
+        assert_eq!(row.3, None);
+        assert_eq!(row.4, 0);
+
+        let relation_tables = [
+            ("collection_images", "image_id"),
+            ("image_loras", "image_id"),
+            ("image_embeddings", "image_id"),
+            ("image_hypernetworks", "image_id"),
+            ("image_controlnets", "image_id"),
+            ("image_ipadapters", "image_id"),
+        ];
+        for (table, column) in relation_tables {
+            let count: i64 = conn
+                .query_row(
+                    &format!("SELECT COUNT(*) FROM {table} WHERE {column} = ?1"),
+                    params![new_id],
+                    |row| row.get(0),
+                )
+                .expect("relation count");
+            assert_eq!(count, 1, "{table} should point at moved image id");
+        }
+
+        let facet_row = conn
+            .query_row(
+                "SELECT thumbnail_path, safe_thumbnail_path, thumbnail_image_id
+                 FROM facet_cache
+                 WHERE facet_type = 'checkpoints' AND resource_name = 'Model A'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                },
+            )
+            .expect("facet cache row");
+        assert_eq!(facet_row.0.as_deref(), Some(new_id));
+        assert_eq!(facet_row.1.as_deref(), Some(new_id));
+        assert_eq!(facet_row.2.as_deref(), Some(new_id));
+
+        let collection_thumb_row = conn
+            .query_row(
+                "SELECT dynamic_thumbnail_path,
+                        dynamic_safe_thumbnail_path,
+                        dynamic_thumbnail_is_sensitive,
+                        dynamic_thumbnail_cached_at
+                 FROM collections
+                 WHERE id = 'board-1'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<i64>>(2)?,
+                        row.get::<_, Option<i64>>(3)?,
+                    ))
+                },
+            )
+            .expect("collection thumbnail cache row");
+        assert_eq!(collection_thumb_row.0.as_deref(), Some(new_id));
+        assert_eq!(collection_thumb_row.1.as_deref(), Some(new_id));
+        assert_eq!(collection_thumb_row.2, Some(0));
+        assert_eq!(collection_thumb_row.3, Some(123));
+
+        let repaired_model_thumbnails: i64 = conn
+            .query_row(
+                "SELECT COUNT(*)
+                 FROM models
+                 WHERE hash IN ('model-old-id', 'model-old-path', 'model-old-thumbnail')
+                   AND thumbnail_path = ?1",
+                params![new_id],
+                |row| row.get(0),
+            )
+            .expect("repaired model thumbnails");
+        assert_eq!(
+            repaired_model_thumbnails, 3,
+            "manual model thumbnail sources should follow moved image identities"
+        );
+    }
+
+    #[test]
+    fn move_image_path_identities_skips_existing_target() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        apply_all_migrations(&conn);
+
+        let old_id = "D:/Invoke/outputs/images/old.png";
+        let new_id = "D:/Invoke/outputs/images/2026/05/old.png";
+        let old_thumbnail_path = "D:/Invoke/outputs/images/thumbnails/old.webp";
+        let mut old_image = create_image_record(old_id, 100, 200, "{}");
+        old_image.path = old_id.to_string();
+        old_image.thumbnail_path = old_thumbnail_path.to_string();
+        let mut new_image = create_image_record(new_id, 101, 201, "{}");
+        new_image.path = new_id.to_string();
+        super::save_images_batch_inner(&conn, &[old_image, new_image]).expect("initial save");
+        conn.execute(
+            "INSERT INTO facet_cache (
+                facet_type,
+                resource_name,
+                thumbnail_path,
+                safe_thumbnail_path,
+                thumbnail_image_id
+             ) VALUES (
+                'checkpoints',
+                'Model A',
+                ?1,
+                ?2,
+                ?3
+             )",
+            params![old_id, old_thumbnail_path, old_id],
+        )
+        .expect("facet cache");
+        conn.execute(
+            "INSERT INTO models (
+                hash,
+                name,
+                lookup_source,
+                scanned_at,
+                thumbnail_path,
+                resource_type
+             ) VALUES ('model-skip-target', 'Model A', 'manual_thumbnail', 1, ?1, 'checkpoint')",
+            params![old_id],
+        )
+        .expect("manual model thumbnail");
+
+        let result = super::move_image_path_identities_inner(
+            &conn,
+            &[super::ImagePathIdentityMove {
+                old_id: old_id.to_string(),
+                new_id: new_id.to_string(),
+                thumbnail_path: Some(new_id.to_string()),
+                thumbnail_source: None,
+            }],
+        )
+        .expect("skip target");
+
+        assert_eq!(result.moved, 0);
+        assert_eq!(result.skipped_target_exists, 1);
+        assert_eq!(result.skipped_source_missing, 0);
+
+        let facet_row = conn
+            .query_row(
+                "SELECT thumbnail_path, safe_thumbnail_path, thumbnail_image_id
+                 FROM facet_cache
+                 WHERE facet_type = 'checkpoints' AND resource_name = 'Model A'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                },
+            )
+            .expect("facet cache row");
+        assert_eq!(facet_row.0.as_deref(), Some(old_id));
+        assert_eq!(facet_row.1.as_deref(), Some(old_thumbnail_path));
+        assert_eq!(facet_row.2.as_deref(), Some(old_id));
+
+        let model_thumbnail_path: Option<String> = conn
+            .query_row(
+                "SELECT thumbnail_path FROM models WHERE hash = 'model-skip-target'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("model thumbnail");
+        assert_eq!(model_thumbnail_path.as_deref(), Some(old_id));
+    }
+
+    #[test]
+    fn move_image_path_identities_skips_missing_source_without_repairing_caches() {
+        let conn = Connection::open_in_memory().expect("in-memory db");
+        apply_all_migrations(&conn);
+
+        let old_id = "D:/Invoke/outputs/images/missing.png";
+        let old_thumbnail_path = "D:/Invoke/outputs/images/thumbnails/missing.webp";
+        let new_id = "D:/Invoke/outputs/images/2026/05/missing.png";
+        conn.execute(
+            "INSERT INTO facet_cache (
+                facet_type,
+                resource_name,
+                thumbnail_path,
+                safe_thumbnail_path,
+                thumbnail_image_id
+             ) VALUES (
+                'checkpoints',
+                'Model A',
+                ?1,
+                ?2,
+                ?3
+             )",
+            params![old_id, old_thumbnail_path, old_id],
+        )
+        .expect("facet cache");
+        conn.execute(
+            "INSERT INTO models (
+                hash,
+                name,
+                lookup_source,
+                scanned_at,
+                thumbnail_path,
+                resource_type
+             ) VALUES ('model-missing-source', 'Model A', 'manual_thumbnail', 1, ?1, 'checkpoint')",
+            params![old_id],
+        )
+        .expect("manual model thumbnail");
+
+        let result = super::move_image_path_identities_inner(
+            &conn,
+            &[super::ImagePathIdentityMove {
+                old_id: old_id.to_string(),
+                new_id: new_id.to_string(),
+                thumbnail_path: Some(new_id.to_string()),
+                thumbnail_source: None,
+            }],
+        )
+        .expect("skip missing source");
+
+        assert_eq!(result.moved, 0);
+        assert_eq!(result.skipped_target_exists, 0);
+        assert_eq!(result.skipped_source_missing, 1);
+
+        let facet_row = conn
+            .query_row(
+                "SELECT thumbnail_path, safe_thumbnail_path, thumbnail_image_id
+                 FROM facet_cache
+                 WHERE facet_type = 'checkpoints' AND resource_name = 'Model A'",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                    ))
+                },
+            )
+            .expect("facet cache row");
+        assert_eq!(facet_row.0.as_deref(), Some(old_id));
+        assert_eq!(facet_row.1.as_deref(), Some(old_thumbnail_path));
+        assert_eq!(facet_row.2.as_deref(), Some(old_id));
+
+        let model_thumbnail_path: Option<String> = conn
+            .query_row(
+                "SELECT thumbnail_path FROM models WHERE hash = 'model-missing-source'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("model thumbnail");
+        assert_eq!(model_thumbnail_path.as_deref(), Some(old_id));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         security::delete_api_key,
         // db commands
         db::commands::image_commands::save_images_batch,
+        db::commands::image_commands::move_image_path_identities,
         db::commands::maintenance::get_db_diagnostics,
         db::commands::maintenance::backfill_image_file_hashes,
         db::commands::maintenance::cancel_image_file_hash_backfill,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -37,6 +37,14 @@ async saveImagesBatch(images: ImageRecord[]) : Promise<Result<number, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async moveImagePathIdentities(moves: ImagePathIdentityMove[]) : Promise<Result<ImagePathIdentityMoveResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("move_image_path_identities", { moves }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getDbDiagnostics() : Promise<Result<DbDiagnostics, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_db_diagnostics") };
@@ -539,6 +547,8 @@ export type FileEntry = { path: string; modified: number; size: number }
 export type FileHashBackfillResult = { scanned: number; updated: number; missing: number; errors: number; remaining: number; wasCancelled: boolean }
 export type FolderStats = { totalFiles: number; imageFiles: number; thumbnailFiles: number; otherFiles: number; directoryChecked: string; subfolders: Partial<{ [key in string]: number }> }
 export type ImageMetadata = { tool: string; model: string; rawParameters?: string | null; steps: number; cfg: number; seed: number; sampler: string; positivePrompt: string; negativePrompt: string; loras: string[]; controlNets: string[]; ipAdapters: string[]; embeddings: string[]; hypernetworks: string[]; variationId?: string | null; isIntermediate?: boolean; isGrid?: boolean; workflowJson?: string | null; vae?: string | null; clipSkip?: number | null; denoisingStrength?: number | null; hiresUpscale?: number | null; hiresSteps?: number | null; hiresUpscaler?: string | null; modelHash?: string | null; generationType: string; isFavorite?: boolean; hasWorkflowHint?: boolean }
+export type ImagePathIdentityMove = { oldId: string; newId: string; thumbnailPath: string | null; thumbnailSource: string | null }
+export type ImagePathIdentityMoveResult = { moved: number; skippedTargetExists: number; skippedSourceMissing: number }
 export type ImageRecord = { id: string; path: string; width: number; height: number; fileSize: number; fileHash: string | null; timestamp: number; metadataJson: string; thumbnailPath: string; 
 /**
  * Base64 encoded 32px WebP micro-thumbnail for instant previews

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -293,7 +293,17 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         lastSyncedAt
                     }
                 );
-                setSettings(prev => ({ ...prev, invokeDbSnapshot: snapshot }));
+                const nextSettings = {
+                    ...useSettingsStore.getState().settings,
+                    invokeDbSnapshot: snapshot
+                };
+                setSettings(nextSettings);
+
+                const appState = await appRepository.load();
+                await appRepository.save({
+                    ...appState,
+                    settings: nextSettings
+                });
             } catch (snapshotError) {
                 console.warn('[Startup Catch-up] Failed to persist Invoke DB snapshot.', snapshotError);
             }

--- a/src/contexts/__tests__/LibraryIntegration.test.tsx
+++ b/src/contexts/__tests__/LibraryIntegration.test.tsx
@@ -6,6 +6,8 @@ import { LibraryProvider, useLibraryContext } from '../LibraryContext';
 import { useSync } from '../SyncContext';
 import { ToastProvider } from '../ToastContext';
 import { useLibraryStore } from '../../stores/libraryStore';
+import type { InvokeDbSnapshotState } from '../../types';
+import { INVOKE_PATH_REPAIR_SNAPSHOT_VERSION } from '../../services/invoke/dbSnapshot';
 
 // --- Extensive Mocks for Integration ---
 
@@ -329,7 +331,8 @@ describe('Library Integration (Provider Stack)', () => {
         await act(async () => {
             hook.setSettings({
                 invokeAiPath: 'D:/AI/art/webUI/invokeai/databases',
-                lastSyncedAt: 100
+                lastSyncedAt: 100,
+                importOrphans: false
             });
         });
 
@@ -348,6 +351,7 @@ describe('Library Integration (Provider Stack)', () => {
         });
         mocks.searchImages.mockClear();
         mocks.getFacets.mockClear();
+        mocks.appRepository.save.mockClear();
 
         await act(async () => {
             await hook.startInvokeSync({ mode: 'startup' });
@@ -361,6 +365,17 @@ describe('Library Integration (Provider Stack)', () => {
         );
         expect(mocks.searchImages).not.toHaveBeenCalled();
         expect(mocks.getFacets).not.toHaveBeenCalled();
+        expect(mocks.appRepository.save).toHaveBeenCalledWith(expect.objectContaining({
+            settings: expect.objectContaining({
+                invokeDbSnapshot: expect.objectContaining({
+                    pathRepairVersion: INVOKE_PATH_REPAIR_SNAPSHOT_VERSION
+                })
+            })
+        }));
+
+        await act(async () => {
+            hook.setSettings({ invokeDbSnapshot: undefined });
+        });
     });
 
     it('uses startup resource-incremental facet refresh for a small known Invoke catch-up', async () => {
@@ -800,6 +815,7 @@ describe('Library Integration (Provider Stack)', () => {
                     importIntermediates: false,
                     importOrphans: false,
                     syncBoardsToCollections: false,
+                    pathRepairVersion: INVOKE_PATH_REPAIR_SNAPSHOT_VERSION,
                     files
                 }
             });
@@ -817,6 +833,76 @@ describe('Library Integration (Provider Stack)', () => {
 
         expect(mocks.getInvokeDbSnapshot).toHaveBeenCalled();
         expect(mocks.syncImages).not.toHaveBeenCalled();
+    });
+
+    it('runs startup Invoke SQLite sync once when the saved DB snapshot predates path repair', async () => {
+        let hook: any;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook.isLoaded).toBe(true));
+
+        const files = [
+            {
+                path: 'D:/AI/art/webUI/invokeai/databases/invokeai.db',
+                exists: true,
+                size: 10,
+                modifiedMs: 100
+            }
+        ];
+        const legacySnapshot = {
+            dbPath: 'D:/AI/art/webUI/invokeai/databases/invokeai.db',
+            lastSyncedAt: 100,
+            importIntermediates: false,
+            importOrphans: false,
+            syncBoardsToCollections: false,
+            files
+        } satisfies Omit<InvokeDbSnapshotState, 'pathRepairVersion'>;
+
+        mocks.getInvokeDbSnapshot.mockResolvedValueOnce({
+            status: 'ok',
+            data: {
+                dbPath: 'D:/AI/art/webUI/invokeai/databases/invokeai.db',
+                files
+            }
+        });
+        mocks.syncImages.mockResolvedValueOnce({
+            imported: 0,
+            updated: 0,
+            maxTimestamp: 100,
+            syncedIds: new Set(),
+            boardMapping: new Map(),
+            touchedFacetTypes: [],
+            touchedFacetResources: { checkpoints: [], loras: [], embeddings: [], hypernetworks: [], controlNets: [], ipAdapters: [], tools: [] }
+        });
+
+        await act(async () => {
+            hook.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai/databases',
+                lastSyncedAt: 100,
+                importIntermediates: false,
+                importOrphans: false,
+                syncBoardsToCollections: false,
+                invokeDbSnapshot: legacySnapshot as InvokeDbSnapshotState
+            });
+        });
+
+        await waitFor(() => {
+            expect(hook.settings.invokeAiPath).toBe('D:/AI/art/webUI/invokeai/databases');
+        });
+
+        mocks.syncImages.mockClear();
+
+        await act(async () => {
+            await hook.startInvokeSync({ mode: 'startup' });
+        });
+
+        expect(mocks.getInvokeDbSnapshot).toHaveBeenCalled();
+        expect(mocks.syncImages).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.any(Function),
+            expect.any(AbortSignal),
+            expect.objectContaining({ mode: 'startup' })
+        );
     });
 
     it('skips startup Invoke SQLite sync when the DB file is missing', async () => {
@@ -853,6 +939,7 @@ describe('Library Integration (Provider Stack)', () => {
                     importIntermediates: false,
                     importOrphans: false,
                     syncBoardsToCollections: false,
+                    pathRepairVersion: INVOKE_PATH_REPAIR_SNAPSHOT_VERSION,
                     files: [
                         {
                             path: 'D:/AI/art/webUI/invokeai/databases/invokeai.db',

--- a/src/features/settings/components/__tests__/SyncSection.test.tsx
+++ b/src/features/settings/components/__tests__/SyncSection.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '../../../../test/testUtils';
+import { AppSettings } from '../../../../types';
+import { SyncSection } from '../SyncSection';
+
+const mocks = vi.hoisted(() => ({
+    startInvokeSync: vi.fn(),
+    cancelSync: vi.fn(),
+    addToast: vi.fn()
+}));
+
+vi.mock('../../../../contexts/LibraryContext', () => ({
+    useLibrary: () => ({
+        syncState: {
+            status: 'idle',
+            progress: { current: 0, total: 0 }
+        },
+        startInvokeSync: mocks.startInvokeSync,
+        cancelSync: mocks.cancelSync
+    })
+}));
+
+vi.mock('../../../../hooks/useToast', () => ({
+    useToast: () => ({
+        addToast: mocks.addToast
+    })
+}));
+
+const createSettings = (): AppSettings => ({
+    hasCompletedOnboarding: true,
+    theme: 'dark',
+    thumbnailSize: 220,
+    confirmDelete: true,
+    defaultTheaterMode: false,
+    monitoredFolders: [],
+    maskedKeywords: [],
+    maskingMode: 'blur',
+    enableAI: false,
+    invokeAiPath: 'D:/Invoke',
+    lastSyncedAt: 123456,
+    importIntermediates: false,
+    importOrphans: true,
+    starredAs: 'favorite',
+    syncBoardsToCollections: true
+});
+
+describe('SyncSection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('starts manual sync from the saved cursor so stale repair does not force a full resync', () => {
+        render(<SyncSection settings={createSettings()} setSettings={vi.fn()} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /initiate sync/i }));
+
+        expect(mocks.startInvokeSync).toHaveBeenCalledWith(expect.objectContaining({
+            afterTimestamp: 123456
+        }));
+    });
+});

--- a/src/services/db/__tests__/imageRepo.test.ts
+++ b/src/services/db/__tests__/imageRepo.test.ts
@@ -8,6 +8,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 vi.mock('../../../bindings', () => ({
     commands: {
         saveImagesBatch: vi.fn(),
+        moveImagePathIdentities: vi.fn(),
         moveToTrash: vi.fn(),
         deleteThumbnail: vi.fn(),
         rebuildFacetCache: vi.fn(),
@@ -186,6 +187,25 @@ describe('imageRepo batch removal', () => {
         expect(images[0].originalMetadata?.positivePrompt).toBe('original prompt');
         expect(images[0].originalChunks?.invokeai_metadata).toBe(JSON.stringify({ positive_prompt: 'raw prompt' }));
         expect(images[0].originalState).toEqual(originalState);
+    });
+
+    it('finds only flat InvokeAI image rows for stale path repair', async () => {
+        const db = {
+            select: vi.fn(async () => [
+                { id: 'D:/Invoke/outputs/images/old.png' }
+            ]),
+            execute: vi.fn(),
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { getFlatInvokeImageIdsForRoot } = await import('../imageRepo');
+        const ids = await getFlatInvokeImageIdsForRoot('D:/Invoke');
+
+        expect(ids).toEqual(['D:/Invoke/outputs/images/old.png']);
+        expect(db.select).toHaveBeenCalledWith(
+            expect.stringContaining("instr(substr(id, ?), '/') = 0"),
+            ['D:/Invoke/outputs/images/%', 'D:/Invoke/outputs/images/'.length + 1]
+        );
     });
 
     it('chunks multi-image library removal so large selections do not exceed sqlite parameter limits', async () => {

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -248,6 +248,87 @@ export const insertImagesBatch = async (images: AIImage[]) => {
     // It should be called once at the end of the sync/import process.
 };
 
+export interface ImagePathIdentityMove {
+    oldId: string;
+    newId: string;
+    thumbnailPath?: string | null;
+    thumbnailSource?: string | null;
+}
+
+export interface ImagePathIdentityMoveResult {
+    moved: number;
+    skippedTargetExists: number;
+    skippedSourceMissing: number;
+}
+
+export const moveImagePathIdentities = async (
+    moves: ImagePathIdentityMove[]
+): Promise<ImagePathIdentityMoveResult> => {
+    if (moves.length === 0) {
+        return { moved: 0, skippedTargetExists: 0, skippedSourceMissing: 0 };
+    }
+
+    if (isBrowserMockMode()) {
+        let moved = 0;
+        let skippedTargetExists = 0;
+        let skippedSourceMissing = 0;
+
+        for (const move of moves) {
+            const oldImage = getBrowserMockImages().find(image => image.id === move.oldId);
+            if (!oldImage) {
+                skippedSourceMissing++;
+                continue;
+            }
+
+            if (getBrowserMockImages().some(image => image.id === move.newId)) {
+                skippedTargetExists++;
+                continue;
+            }
+
+            updateBrowserMockImage(move.oldId, {
+                id: move.newId,
+                url: move.newId,
+                thumbnailUrl: move.thumbnailPath || move.newId,
+                thumbnailSource: move.thumbnailSource || undefined,
+                isMissing: false
+            });
+            moved++;
+        }
+
+        return { moved, skippedTargetExists, skippedSourceMissing };
+    }
+
+    const normalizedMoves = moves
+        .map(move => ({
+            oldId: normalizePath(move.oldId),
+            newId: normalizePath(move.newId),
+            thumbnailPath: move.thumbnailPath ? normalizePath(move.thumbnailPath) : null,
+            thumbnailSource: move.thumbnailSource || null
+        }))
+        .filter(move => move.oldId !== move.newId);
+
+    if (normalizedMoves.length === 0) {
+        return { moved: 0, skippedTargetExists: 0, skippedSourceMissing: 0 };
+    }
+
+    return unwrap(commands.moveImagePathIdentities(normalizedMoves));
+};
+
+export const moveImagePathIdentity = async (
+    oldId: string,
+    newId: string,
+    thumbnailPath?: string | null,
+    thumbnailSource?: string | null
+): Promise<boolean> => {
+    const result = await moveImagePathIdentities([{
+        oldId,
+        newId,
+        thumbnailPath,
+        thumbnailSource
+    }]);
+    return result.moved === 1;
+};
+
 /**
  * Rebuilds the facet_cache table with pre-computed counts for all resources.
  * This runs the expensive queries once per import, so getFacets becomes instant.
@@ -583,6 +664,28 @@ export const getImagesByIds = async (ids: string[]): Promise<AIImage[]> => {
     }
 
     return allImages;
+};
+
+export const getFlatInvokeImageIdsForRoot = async (invokeRoot: string): Promise<string[]> => {
+    const normalizedRoot = normalizePath(invokeRoot).replace(/\/$/, '');
+    const imagesPrefix = `${normalizedRoot}/outputs/images/`;
+
+    if (isBrowserMockMode()) {
+        return getBrowserMockImages()
+            .map(image => normalizePath(image.id))
+            .filter(id => id.startsWith(imagesPrefix) && !id.slice(imagesPrefix.length).includes('/'));
+    }
+
+    const db = await getDb();
+    const rows = await db.select<Array<{ id: string }>>(
+        `SELECT id
+         FROM images
+         WHERE id LIKE ?
+           AND instr(substr(id, ?), '/') = 0`,
+        [`${imagesPrefix}%`, imagesPrefix.length + 1]
+    );
+
+    return rows.map(row => normalizePath(row.id));
 };
 
 export const getRemovedImagesByIds = async (ids: string[]): Promise<AIImage[]> => {

--- a/src/services/invoke/__tests__/dbSnapshot.test.ts
+++ b/src/services/invoke/__tests__/dbSnapshot.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildInvokeDbSnapshotState, isInvokeDbSnapshotCurrent } from '../dbSnapshot';
+import type { InvokeDbSnapshotState } from '../../../types';
+import {
+    buildInvokeDbSnapshotState,
+    INVOKE_PATH_REPAIR_SNAPSHOT_VERSION,
+    isInvokeDbSnapshotCurrent
+} from '../dbSnapshot';
 
 const baseSnapshot = {
     dbPath: 'D:/Invoke/databases/invokeai.db',
@@ -45,6 +50,7 @@ describe('Invoke DB startup snapshot matching', () => {
         });
 
         expect(isInvokeDbSnapshotCurrent(saved, current)).toBe(true);
+        expect(current.pathRepairVersion).toBe(INVOKE_PATH_REPAIR_SNAPSHOT_VERSION);
     });
 
     it('invalidates when sync cursor or import flags change', () => {
@@ -101,5 +107,33 @@ describe('Invoke DB startup snapshot matching', () => {
         });
 
         expect(isInvokeDbSnapshotCurrent(saved, current)).toBe(false);
+    });
+
+    it('invalidates saved snapshots that predate the Invoke path repair marker', () => {
+        const current = buildInvokeDbSnapshotState(baseSnapshot, {
+            lastSyncedAt: 1000,
+            importIntermediates: false,
+            importOrphans: false,
+            syncBoardsToCollections: false
+        });
+        const legacySaved = { ...current } as Partial<InvokeDbSnapshotState>;
+        delete legacySaved.pathRepairVersion;
+
+        expect(isInvokeDbSnapshotCurrent(legacySaved as InvokeDbSnapshotState, current)).toBe(false);
+    });
+
+    it('invalidates saved snapshots with an older path repair marker', () => {
+        const current = buildInvokeDbSnapshotState(baseSnapshot, {
+            lastSyncedAt: 1000,
+            importIntermediates: false,
+            importOrphans: false,
+            syncBoardsToCollections: false
+        });
+        const oldRepairSnapshot = {
+            ...current,
+            pathRepairVersion: INVOKE_PATH_REPAIR_SNAPSHOT_VERSION - 1
+        };
+
+        expect(isInvokeDbSnapshotCurrent(oldRepairSnapshot, current)).toBe(false);
     });
 });

--- a/src/services/invoke/__tests__/orphanScanner.test.ts
+++ b/src/services/invoke/__tests__/orphanScanner.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Database from '@tauri-apps/plugin-sql';
+import { commands } from '../../../bindings';
+import { getDb } from '../../db/connection';
+import { insertImagesBatch } from '../../db/imageRepo';
+import { scanForOrphans } from '../orphanScanner';
+
+vi.mock('@tauri-apps/plugin-sql', () => ({
+    default: {
+        load: vi.fn()
+    }
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+    convertFileSrc: vi.fn((path: string) => `asset://${path}`)
+}));
+
+vi.mock('../../../bindings', () => ({
+    commands: {
+        listInvokeaiImages: vi.fn(),
+        scanImagesBulk: vi.fn()
+    }
+}));
+
+vi.mock('../../db/connection', () => ({
+    getDb: vi.fn()
+}));
+
+vi.mock('../../db/imageRepo', () => ({
+    insertImagesBatch: vi.fn()
+}));
+
+const createDb = (rows: Array<{ image_name: string, image_subfolder?: string | null }> = [], columns: string[] = []) => ({
+    select: vi.fn(async (query: string) => {
+        if (query.includes('PRAGMA table_info(images)')) {
+            return columns.map(name => ({ name }));
+        }
+        return rows;
+    })
+});
+
+describe('scanForOrphans', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getDb).mockResolvedValue({
+            select: vi.fn().mockResolvedValue([])
+        } as never);
+        vi.mocked(Database.load).mockResolvedValue(createDb() as never);
+        vi.mocked(commands.scanImagesBulk).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths.map((path) => ({
+                width: 512,
+                height: 512,
+                size: 123,
+                modified: 1000,
+                thumbnail: path,
+                microThumbnail: null,
+                thumbnailSource: null,
+                chunks: {},
+                metadata: {
+                    tool: 'InvokeAI',
+                    model: 'Model',
+                    seed: 1,
+                    steps: 20,
+                    cfg: 7,
+                    positivePrompt: 'prompt',
+                    negativePrompt: '',
+                    sampler: 'Euler',
+                    loras: [],
+                    controlNets: []
+                },
+                error: null
+            }))
+        }) as never);
+        vi.mocked(insertImagesBatch).mockResolvedValue(undefined as never);
+    });
+
+    it('imports nested orphan files while skipping DB-synced and intermediate entries', async () => {
+        vi.mocked(Database.load).mockResolvedValue(createDb([{ image_name: 'intermediate.png' }]) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: [
+                'outputs/images/2026/05/25/new.png',
+                'outputs/images/2026/05/25/already.png',
+                'outputs/images/txt2img/intermediate.png'
+            ]
+        } as never);
+
+        const imported = await scanForOrphans(
+            'D:/Invoke',
+            new Set(['outputs/images/2026/05/25/already.png']),
+            vi.fn(),
+            { importIntermediates: false }
+        );
+
+        expect(imported).toBe(1);
+        expect(commands.scanImagesBulk).toHaveBeenCalledWith(
+            ['D:/Invoke/outputs/images/2026/05/25/new.png'],
+            null,
+            true,
+            false,
+            null,
+            null
+        );
+        expect(vi.mocked(insertImagesBatch).mock.calls[0][0][0]).toEqual(expect.objectContaining({
+            id: 'D:/Invoke/outputs/images/2026/05/25/new.png',
+            filename: 'new.png'
+        }));
+    });
+
+    it('matches intermediate rows by relative nested path', async () => {
+        vi.mocked(Database.load).mockResolvedValue(createDb([{ image_name: '2026/05/25/intermediate.png' }]) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: ['outputs/images/2026/05/25/intermediate.png']
+        } as never);
+
+        const imported = await scanForOrphans('D:/Invoke', new Set(), vi.fn(), { importIntermediates: false });
+
+        expect(imported).toBe(0);
+        expect(commands.scanImagesBulk).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('matches intermediate rows by InvokeAI image_subfolder plus basename', async () => {
+        vi.mocked(Database.load).mockResolvedValue(createDb(
+            [{ image_name: 'intermediate.png', image_subfolder: '2026/05/25' }],
+            ['image_subfolder']
+        ) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: ['outputs/images/2026/05/25/intermediate.png']
+        } as never);
+
+        const imported = await scanForOrphans('D:/Invoke', new Set(), vi.fn(), { importIntermediates: false });
+
+        expect(imported).toBe(0);
+        expect(commands.scanImagesBulk).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('does not suppress nested orphan files just because another synced file shares the basename', async () => {
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: [
+                'outputs/images/2026/05/25/foo.png',
+                'outputs/images/txt2img/foo.png'
+            ]
+        } as never);
+
+        const imported = await scanForOrphans(
+            'D:/Invoke',
+            new Set(['outputs/images/2026/05/25/foo.png']),
+            vi.fn(),
+            { importIntermediates: false }
+        );
+
+        expect(imported).toBe(1);
+        expect(commands.scanImagesBulk).toHaveBeenCalledWith(
+            ['D:/Invoke/outputs/images/txt2img/foo.png'],
+            null,
+            true,
+            false,
+            null,
+            null
+        );
+        expect(vi.mocked(insertImagesBatch).mock.calls[0][0][0]).toEqual(expect.objectContaining({
+            id: 'D:/Invoke/outputs/images/txt2img/foo.png',
+            filename: 'foo.png'
+        }));
+    });
+
+    it('does not suppress a different folder when the intermediate row has a path-specific nested name', async () => {
+        vi.mocked(Database.load).mockResolvedValue(createDb([{ image_name: '2026/05/25/foo.png' }]) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: [
+                'outputs/images/2026/05/25/foo.png',
+                'outputs/images/txt2img/foo.png'
+            ]
+        } as never);
+
+        const imported = await scanForOrphans('D:/Invoke', new Set(), vi.fn(), { importIntermediates: false });
+
+        expect(imported).toBe(1);
+        expect(commands.scanImagesBulk).toHaveBeenCalledWith(
+            ['D:/Invoke/outputs/images/txt2img/foo.png'],
+            null,
+            true,
+            false,
+            null,
+            null
+        );
+    });
+
+    it('keeps basename-only matching for legacy intermediate rows without path truth', async () => {
+        vi.mocked(Database.load).mockResolvedValue(createDb([{ image_name: 'legacy-intermediate.png' }]) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: ['outputs/images/txt2img/legacy-intermediate.png']
+        } as never);
+
+        const imported = await scanForOrphans('D:/Invoke', new Set(), vi.fn(), { importIntermediates: false });
+
+        expect(imported).toBe(0);
+        expect(commands.scanImagesBulk).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+});

--- a/src/services/invoke/__tests__/pathResolver.test.ts
+++ b/src/services/invoke/__tests__/pathResolver.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createInvokeImagePathResolver } from '../pathResolver';
+
+const files = [
+    'outputs/images/flat.png',
+    'outputs/images/2026/05/25/date.png',
+    'outputs/images/txt2img/type.png',
+    'outputs/images/ab/hash.png',
+    'outputs/images/2026/05/25/relative.png',
+    'outputs/images/2026/05/25/duplicate.png',
+    'outputs/images/txt2img/duplicate.png'
+];
+
+describe('InvokeAI image path resolver', () => {
+    it.each([
+        ['flat layout', 'flat.png', 'D:/Invoke/outputs/images/flat.png'],
+        ['date layout', 'date.png', 'D:/Invoke/outputs/images/2026/05/25/date.png'],
+        ['type layout', 'type.png', 'D:/Invoke/outputs/images/txt2img/type.png'],
+        ['hash layout', 'hash.png', 'D:/Invoke/outputs/images/ab/hash.png'],
+        ['relative image name', '2026/05/25/relative.png', 'D:/Invoke/outputs/images/2026/05/25/relative.png'],
+        ['root-relative image name', 'outputs/images/2026/05/25/relative.png', 'D:/Invoke/outputs/images/2026/05/25/relative.png']
+    ])('resolves %s', async (_label, imageName, expectedPath) => {
+        const listImages = vi.fn().mockResolvedValue(files);
+        const resolver = createInvokeImagePathResolver('D:/Invoke', listImages);
+
+        await expect(resolver.resolveImagePath(imageName)).resolves.toEqual({
+            absolutePath: expectedPath,
+            relativePath: expectedPath.replace('D:/Invoke/', ''),
+            ambiguous: false
+        });
+        expect(listImages).toHaveBeenCalledTimes(/[\\/]/.test(imageName) ? 0 : 1);
+    });
+
+    it('uses image_subfolder as the authoritative path before disk fallback', async () => {
+        const listImages = vi.fn().mockResolvedValue(files);
+        const resolver = createInvokeImagePathResolver('D:/Invoke', listImages);
+
+        await expect(resolver.resolveImagePath('duplicate.png', 'custom/folder')).resolves.toEqual({
+            absolutePath: 'D:/Invoke/outputs/images/custom/folder/duplicate.png',
+            relativePath: 'outputs/images/custom/folder/duplicate.png',
+            ambiguous: false
+        });
+        expect(listImages).not.toHaveBeenCalled();
+    });
+
+    it('marks basename collisions ambiguous instead of choosing a nested file silently', async () => {
+        const resolver = createInvokeImagePathResolver('D:/Invoke', vi.fn().mockResolvedValue(files));
+
+        await expect(resolver.resolveImagePath('duplicate.png')).resolves.toEqual({
+            absolutePath: null,
+            relativePath: null,
+            ambiguous: true
+        });
+    });
+
+    it('uses existing InvokeAI thumbnail candidates and falls back to the source image when none exist', async () => {
+        const resolver = createInvokeImagePathResolver('D:/Invoke', vi.fn().mockResolvedValue(files));
+
+        const flat = await resolver.resolveImagePath('flat.png');
+        const nested = await resolver.resolveImagePath('date.png');
+        const existing = new Set([
+            'D:/Invoke/outputs/images/thumbnails/flat.webp',
+            'D:/Invoke/outputs/images/2026/05/25/date.webp',
+            'D:/Invoke/outputs/images/2026/05/25/date-custom.webp'
+        ]);
+
+        expect(resolver.resolveThumbnailPath(null, flat, existing)).toBe('D:/Invoke/outputs/images/thumbnails/flat.webp');
+        expect(resolver.resolveThumbnailPath(null, nested, existing)).toBe('D:/Invoke/outputs/images/2026/05/25/date.webp');
+        expect(resolver.resolveThumbnailPath('flat.webp', flat, existing)).toBe('D:/Invoke/outputs/images/thumbnails/flat.webp');
+        expect(resolver.resolveThumbnailPath('date-custom.webp', nested, existing)).toBe('D:/Invoke/outputs/images/2026/05/25/date-custom.webp');
+        expect(resolver.resolveThumbnailPath('missing.webp', nested, existing)).toBe('D:/Invoke/outputs/images/2026/05/25/date.png');
+        expect(resolver.resolveThumbnailPath('2026/05/25/date.webp', nested, existing)).toBe('D:/Invoke/outputs/images/2026/05/25/date.webp');
+    });
+
+    it('checks central nested thumbnail folders before the legacy flat thumbnail folder', async () => {
+        const resolver = createInvokeImagePathResolver('D:/Invoke', vi.fn().mockResolvedValue(files));
+        const nested = await resolver.resolveImagePath('date.png');
+        const existing = new Set([
+            'D:/Invoke/outputs/images/thumbnails/2026/05/25/date.webp',
+            'D:/Invoke/outputs/images/thumbnails/date.webp'
+        ]);
+
+        expect(resolver.resolveThumbnailPath(null, nested, existing)).toBe('D:/Invoke/outputs/images/thumbnails/2026/05/25/date.webp');
+    });
+});

--- a/src/services/invoke/__tests__/syncService.test.ts
+++ b/src/services/invoke/__tests__/syncService.test.ts
@@ -4,8 +4,15 @@ import { commands } from '../../../bindings';
 import { fetchBoardMappings } from '../connection';
 import { insertImagesBatch } from '../../db';
 import { upsertCollection } from '../../db/collectionRepo';
-import { getImagesByIds, syncCollectionImages } from '../../db/imageRepo';
+import {
+    getFlatInvokeImageIdsForRoot,
+    getImagesByIds,
+    moveImagePathIdentities,
+    moveImagePathIdentity,
+    syncCollectionImages
+} from '../../db/imageRepo';
 import { syncImages } from '../syncService';
+import { GeneratorTool } from '../../../types';
 
 vi.mock('@tauri-apps/plugin-sql', () => ({
     default: {
@@ -19,7 +26,9 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 vi.mock('../../../bindings', () => ({
     commands: {
-        getFileSizesBulk: vi.fn()
+        getFileSizesBulk: vi.fn(),
+        listInvokeaiImages: vi.fn(),
+        verifyImagePaths: vi.fn()
     }
 }));
 
@@ -50,7 +59,10 @@ vi.mock('../../db', () => ({
 }));
 
 vi.mock('../../db/imageRepo', () => ({
+    getFlatInvokeImageIdsForRoot: vi.fn(),
     getImagesByIds: vi.fn(),
+    moveImagePathIdentities: vi.fn(),
+    moveImagePathIdentity: vi.fn(),
     syncCollectionImages: vi.fn()
 }));
 
@@ -65,9 +77,21 @@ const createInvokeDb = (selectMock: ReturnType<typeof vi.fn>) => ({
 describe('syncImages live mode', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        vi.mocked(commands.getFileSizesBulk).mockResolvedValue({ status: 'ok', data: [123] } as never);
+        vi.mocked(commands.getFileSizesBulk).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths.map(() => 123)
+        }) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({ status: 'ok', data: [] } as never);
+        vi.mocked(commands.verifyImagePaths).mockResolvedValue({ status: 'ok', data: [] } as never);
         vi.mocked(insertImagesBatch).mockResolvedValue(undefined as never);
+        vi.mocked(getFlatInvokeImageIdsForRoot).mockResolvedValue([]);
         vi.mocked(getImagesByIds).mockResolvedValue([]);
+        vi.mocked(moveImagePathIdentities).mockResolvedValue({
+            moved: 0,
+            skippedTargetExists: 0,
+            skippedSourceMissing: 0
+        });
+        vi.mocked(moveImagePathIdentity).mockResolvedValue(false);
         vi.mocked(syncCollectionImages).mockResolvedValue(undefined as never);
         vi.mocked(upsertCollection).mockResolvedValue(undefined as never);
         vi.mocked(fetchBoardMappings).mockResolvedValue({
@@ -318,5 +342,721 @@ describe('syncImages live mode', () => {
             'D:/AI/art/webUI/invokeai/outputs/images/startup-image.png'
         ]);
         expect(upsertCollection).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves flat, date, type, hash, custom, and relative InvokeAI subfolder paths during DB sync', async () => {
+        const rows = [
+            { image_name: 'flat.png', image_subfolder: '', metadata_blob: {}, created_at: '2026-04-18 12:00:00', width: 512, height: 512 },
+            { image_name: 'date.png', image_subfolder: '2026/04/18', metadata_blob: {}, created_at: '2026-04-18 12:00:01', width: 512, height: 512 },
+            { image_name: 'type.png', image_subfolder: 'txt2img', metadata_blob: {}, created_at: '2026-04-18 12:00:02', width: 512, height: 512 },
+            { image_name: 'hash.png', image_subfolder: 'ab', metadata_blob: {}, created_at: '2026-04-18 12:00:03', width: 512, height: 512 },
+            { image_name: 'custom.png', image_subfolder: 'custom/nested/path', metadata_blob: {}, created_at: '2026-04-18 12:00:04', width: 512, height: 512 },
+            { image_name: '2026/04/relative.png', image_subfolder: '', metadata_blob: {}, created_at: '2026-04-18 12:00:05', width: 512, height: 512 }
+        ];
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [{ name: 'metadata_json' }, { name: 'image_subfolder' }];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [{ found: 1 }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: rows.length }];
+            }
+            if (query.includes('FROM images i') && query.includes('OFFSET 0')) {
+                return rows;
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: [
+                'outputs/images/flat.png',
+                'outputs/images/2026/04/relative.png'
+            ]
+        } as never);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'live',
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(6);
+        expect(commands.listInvokeaiImages).toHaveBeenCalledTimes(1);
+        expect(getImagesByIds).toHaveBeenCalledWith(expect.arrayContaining([
+            'D:/AI/art/webUI/invokeai/outputs/images/flat.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/date.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/txt2img/type.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/ab/hash.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/custom/nested/path/custom.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/2026/04/relative.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/date.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/type.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/hash.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/custom.png'
+        ]));
+        expect(vi.mocked(insertImagesBatch).mock.calls[0][0].map((image) => image.id)).toEqual([
+            'D:/AI/art/webUI/invokeai/outputs/images/flat.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/date.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/txt2img/type.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/ab/hash.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/custom/nested/path/custom.png',
+            'D:/AI/art/webUI/invokeai/outputs/images/2026/04/relative.png'
+        ]);
+    });
+
+    it('skips ambiguous basename rows instead of importing an arbitrary nested file', async () => {
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [{ name: 'metadata_json' }];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [{ found: 1 }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 1 }];
+            }
+            if (query.includes('FROM images i') && query.includes('OFFSET 0')) {
+                return [{
+                    image_name: 'duplicate.png',
+                    metadata_blob: {},
+                    created_at: '2026-04-18 12:00:00',
+                    width: 512,
+                    height: 512
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: [
+                'outputs/images/2026/04/18/duplicate.png',
+                'outputs/images/txt2img/duplicate.png'
+            ]
+        } as never);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'live',
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('repairs an existing stale flat InvokeAI row when the real file resolves to a subfolder', async () => {
+        const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/date.png';
+        const resolvedPath = 'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/date.png';
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [{ name: 'metadata_json' }, { name: 'thumbnail_name' }, { name: 'image_subfolder' }];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [{ found: 1 }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 1 }];
+            }
+            if (query.includes('FROM images i') && query.includes('OFFSET 0')) {
+                return [{
+                    image_name: 'date.png',
+                    image_subfolder: '2026/04/18',
+                    metadata_blob: {},
+                    created_at: '2026-04-18 12:00:00',
+                    width: 512,
+                    height: 512,
+                    thumbnail_name: 'date.webp'
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: ['outputs/images/2026/04/18/date.png']
+        } as never);
+        vi.mocked(commands.verifyImagePaths).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths
+        }) as never);
+        vi.mocked(getImagesByIds).mockResolvedValue([{
+            id: staleFlatPath,
+            url: `asset://${staleFlatPath}`,
+            thumbnailUrl: `asset://${staleFlatPath}`,
+            filename: 'date.png',
+            fileSize: 123,
+            timestamp: 100,
+            width: 512,
+            height: 512,
+            isFavorite: true,
+            isPinned: false,
+            isDeleted: false,
+            isMissing: false,
+            metadata: {
+                tool: GeneratorTool.INVOKEAI,
+                model: 'Test Model',
+                seed: 1,
+                steps: 20,
+                cfg: 7,
+                sampler: 'Euler',
+                positivePrompt: 'test',
+                negativePrompt: '',
+                loras: [],
+                controlNets: []
+            }
+        }]);
+        vi.mocked(moveImagePathIdentity).mockResolvedValue(true);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'live',
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.updated).toBe(1);
+        expect(result.imported).toBe(0);
+        expect(moveImagePathIdentity).toHaveBeenCalledWith(
+            staleFlatPath,
+            resolvedPath,
+            resolvedPath,
+            null
+        );
+        expect(insertImagesBatch).toHaveBeenCalledWith([
+            expect.objectContaining({
+                id: resolvedPath,
+                isFavorite: true,
+                thumbnailUrl: resolvedPath
+            })
+        ]);
+    });
+
+    it('repairs stale existing rows during a timestamp-filtered manual sync even when there are no import candidates', async () => {
+        const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/old.png';
+        const resolvedPath = 'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/old.png';
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'image_subfolder' },
+                    { name: 'thumbnail_name' },
+                    { name: 'is_intermediate' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 0 }];
+            }
+            if (query.includes('SELECT i.image_name, i.image_subfolder')) {
+                return [{
+                    image_name: 'old.png',
+                    image_subfolder: '2026/04/18',
+                    thumbnail_name: 'old.webp',
+                    metadata_blob: null,
+                    created_at: '2026-04-18 12:00:00',
+                    is_intermediate: 0
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: ['outputs/images/wrong/old.png']
+        } as never);
+        vi.mocked(commands.verifyImagePaths).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths
+        }) as never);
+        vi.mocked(getFlatInvokeImageIdsForRoot).mockResolvedValue([staleFlatPath]);
+        vi.mocked(getImagesByIds).mockResolvedValue([{
+            id: staleFlatPath,
+            url: `asset://${staleFlatPath}`,
+            thumbnailUrl: `asset://${staleFlatPath}`,
+            filename: 'old.png',
+            fileSize: 123,
+            timestamp: 100,
+            width: 512,
+            height: 512,
+            isFavorite: false,
+            isPinned: false,
+            isDeleted: false,
+            isMissing: false,
+            metadata: {
+                tool: GeneratorTool.INVOKEAI,
+                model: 'Test Model',
+                seed: 1,
+                steps: 20,
+                cfg: 7,
+                sampler: 'Euler',
+                positivePrompt: 'test',
+                negativePrompt: '',
+                loras: [],
+                controlNets: []
+            }
+        }]);
+        vi.mocked(moveImagePathIdentities).mockResolvedValue({
+            moved: 1,
+            skippedTargetExists: 0,
+            skippedSourceMissing: 0
+        });
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'manual',
+                afterTimestamp: Date.now(),
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(1);
+        expect(moveImagePathIdentities).toHaveBeenCalledWith([{
+            oldId: staleFlatPath,
+            newId: resolvedPath,
+            thumbnailPath: resolvedPath,
+            thumbnailSource: null
+        }]);
+        expect(commands.listInvokeaiImages).not.toHaveBeenCalled();
+        expect(moveImagePathIdentity).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('does not run broad stale-path repair during startup catch-up when there are no new InvokeAI rows', async () => {
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'image_subfolder' },
+                    { name: 'is_intermediate' },
+                    { name: 'updated_at' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 0 }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'startup',
+                afterTimestamp: Date.now(),
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(0);
+        expect(getFlatInvokeImageIdsForRoot).not.toHaveBeenCalled();
+        expect(moveImagePathIdentities).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('repairs stale rows through unique disk fallback when image_subfolder is unavailable', async () => {
+        const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/legacy.png';
+        const resolvedPath = 'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/legacy.png';
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'thumbnail_name' },
+                    { name: 'is_intermediate' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 0 }];
+            }
+            if (query.includes('SELECT i.image_name')) {
+                return [{
+                    image_name: 'legacy.png',
+                    thumbnail_name: 'legacy.webp',
+                    metadata_blob: null,
+                    created_at: '2026-04-18 12:00:00',
+                    is_intermediate: 0
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: ['outputs/images/2026/04/18/legacy.png']
+        } as never);
+        vi.mocked(commands.verifyImagePaths).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths
+        }) as never);
+        vi.mocked(getFlatInvokeImageIdsForRoot).mockResolvedValue([staleFlatPath]);
+        vi.mocked(getImagesByIds).mockResolvedValue([{
+            id: staleFlatPath,
+            url: `asset://${staleFlatPath}`,
+            thumbnailUrl: `asset://${staleFlatPath}`,
+            filename: 'legacy.png',
+            fileSize: 123,
+            timestamp: 100,
+            width: 512,
+            height: 512,
+            isFavorite: false,
+            isPinned: false,
+            isDeleted: false,
+            isMissing: false,
+            metadata: {
+                tool: GeneratorTool.INVOKEAI,
+                model: 'Test Model',
+                seed: 1,
+                steps: 20,
+                cfg: 7,
+                sampler: 'Euler',
+                positivePrompt: 'test',
+                negativePrompt: '',
+                loras: [],
+                controlNets: []
+            }
+        }]);
+        vi.mocked(moveImagePathIdentities).mockResolvedValue({
+            moved: 1,
+            skippedTargetExists: 0,
+            skippedSourceMissing: 0
+        });
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'manual',
+                afterTimestamp: Date.now(),
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(1);
+        expect(moveImagePathIdentities).toHaveBeenCalledWith([{
+            oldId: staleFlatPath,
+            newId: resolvedPath,
+            thumbnailPath: resolvedPath,
+            thumbnailSource: null
+        }]);
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('repairs stale rows when legacy InvokeAI image_name already contains a relative path', async () => {
+        const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/relative.png';
+        const resolvedPath = 'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/relative.png';
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'is_intermediate' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 0 }];
+            }
+            if (query.includes('SELECT i.image_name') && query.includes(' IN (')) {
+                return [];
+            }
+            if (query.includes('SELECT i.image_name') && query.includes("instr(REPLACE(i.image_name")) {
+                return [{
+                    image_name: '2026/04/18/relative.png',
+                    metadata_blob: null,
+                    created_at: '2026-04-18 12:00:00',
+                    is_intermediate: 0
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.verifyImagePaths).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths
+        }) as never);
+        vi.mocked(getFlatInvokeImageIdsForRoot).mockResolvedValue([staleFlatPath]);
+        vi.mocked(getImagesByIds).mockResolvedValue([{
+            id: staleFlatPath,
+            url: `asset://${staleFlatPath}`,
+            thumbnailUrl: `asset://${staleFlatPath}`,
+            filename: 'relative.png',
+            fileSize: 123,
+            timestamp: 100,
+            width: 512,
+            height: 512,
+            isFavorite: false,
+            isPinned: false,
+            isDeleted: false,
+            isMissing: false,
+            metadata: {
+                tool: GeneratorTool.INVOKEAI,
+                model: 'Test Model',
+                seed: 1,
+                steps: 20,
+                cfg: 7,
+                sampler: 'Euler',
+                positivePrompt: 'test',
+                negativePrompt: '',
+                loras: [],
+                controlNets: []
+            }
+        }]);
+        vi.mocked(moveImagePathIdentities).mockResolvedValue({
+            moved: 1,
+            skippedTargetExists: 0,
+            skippedSourceMissing: 0
+        });
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'manual',
+                afterTimestamp: Date.now(),
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(1);
+        expect(moveImagePathIdentities).toHaveBeenCalledWith([{
+            oldId: staleFlatPath,
+            newId: resolvedPath,
+            thumbnailPath: resolvedPath,
+            thumbnailSource: null
+        }]);
+        const repairQueries = selectMock.mock.calls
+            .map(([query]) => query)
+            .filter(query => query.includes('SELECT i.image_name'));
+        expect(repairQueries.some(query => query.includes("instr(REPLACE(i.image_name"))).toBe(true);
+        expect(repairQueries.some(query => query.includes('LIKE ? ESCAPE'))).toBe(false);
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('skips stale relative-name repair when one flat source matches multiple resolved targets', async () => {
+        const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/duplicate.png';
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'is_intermediate' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 0 }];
+            }
+            if (query.includes('SELECT i.image_name') && query.includes(' IN (')) {
+                return [];
+            }
+            if (query.includes('SELECT i.image_name') && query.includes("instr(REPLACE(i.image_name")) {
+                return [
+                    {
+                        image_name: '2026/04/18/duplicate.png',
+                        metadata_blob: null,
+                        created_at: '2026-04-18 12:00:00',
+                        is_intermediate: 0
+                    },
+                    {
+                        image_name: 'txt2img/duplicate.png',
+                        metadata_blob: null,
+                        created_at: '2026-04-18 12:00:01',
+                        is_intermediate: 0
+                    }
+                ];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.verifyImagePaths).mockImplementation(async (paths: string[]) => ({
+            status: 'ok',
+            data: paths
+        }) as never);
+        vi.mocked(getFlatInvokeImageIdsForRoot).mockResolvedValue([staleFlatPath]);
+        vi.mocked(getImagesByIds).mockResolvedValue([{
+            id: staleFlatPath,
+            url: `asset://${staleFlatPath}`,
+            thumbnailUrl: `asset://${staleFlatPath}`,
+            filename: 'duplicate.png',
+            fileSize: 123,
+            timestamp: 100,
+            width: 512,
+            height: 512,
+            isFavorite: false,
+            isPinned: false,
+            isDeleted: false,
+            isMissing: false,
+            metadata: {
+                tool: GeneratorTool.INVOKEAI,
+                model: 'Test Model',
+                seed: 1,
+                steps: 20,
+                cfg: 7,
+                sampler: 'Euler',
+                positivePrompt: 'test',
+                negativePrompt: '',
+                loras: [],
+                controlNets: []
+            }
+        }]);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'manual',
+                afterTimestamp: Date.now(),
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(0);
+        expect(moveImagePathIdentities).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
+    it('skips stale repair fallback when duplicate basenames make the disk match ambiguous', async () => {
+        const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/duplicate.png';
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [
+                    { name: 'metadata_json' },
+                    { name: 'is_intermediate' }
+                ];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 0 }];
+            }
+            if (query.includes('SELECT i.image_name')) {
+                return [{
+                    image_name: 'duplicate.png',
+                    metadata_blob: null,
+                    created_at: '2026-04-18 12:00:00',
+                    is_intermediate: 0
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+        vi.mocked(commands.listInvokeaiImages).mockResolvedValue({
+            status: 'ok',
+            data: [
+                'outputs/images/2026/04/18/duplicate.png',
+                'outputs/images/txt2img/duplicate.png'
+            ]
+        } as never);
+        vi.mocked(getFlatInvokeImageIdsForRoot).mockResolvedValue([staleFlatPath]);
+        vi.mocked(getImagesByIds).mockResolvedValue([{
+            id: staleFlatPath,
+            url: `asset://${staleFlatPath}`,
+            thumbnailUrl: `asset://${staleFlatPath}`,
+            filename: 'duplicate.png',
+            fileSize: 123,
+            timestamp: 100,
+            width: 512,
+            height: 512,
+            isFavorite: false,
+            isPinned: false,
+            isDeleted: false,
+            isMissing: false,
+            metadata: {
+                tool: GeneratorTool.INVOKEAI,
+                model: 'Test Model',
+                seed: 1,
+                steps: 20,
+                cfg: 7,
+                sampler: 'Euler',
+                positivePrompt: 'test',
+                negativePrompt: '',
+                loras: [],
+                controlNets: []
+            }
+        }]);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'manual',
+                afterTimestamp: Date.now(),
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(result.updated).toBe(0);
+        expect(moveImagePathIdentities).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
     });
 });

--- a/src/services/invoke/dbSnapshot.ts
+++ b/src/services/invoke/dbSnapshot.ts
@@ -14,6 +14,8 @@ interface InvokeDbSnapshotConfig {
     syncBoardsToCollections?: boolean;
 }
 
+export const INVOKE_PATH_REPAIR_SNAPSHOT_VERSION = 1;
+
 const sortedFiles = (files: InvokeDbSnapshotFile[]): InvokeDbSnapshotFile[] =>
     [...files].sort((a, b) => a.path.localeCompare(b.path));
 
@@ -32,6 +34,7 @@ export const buildInvokeDbSnapshotState = (
     importIntermediates: config.importIntermediates ?? false,
     importOrphans: config.importOrphans ?? false,
     syncBoardsToCollections: config.syncBoardsToCollections ?? false,
+    pathRepairVersion: INVOKE_PATH_REPAIR_SNAPSHOT_VERSION,
     files: sortedFiles(snapshot.files).map(file => ({
         path: file.path,
         exists: file.exists,
@@ -50,6 +53,7 @@ export const isInvokeDbSnapshotCurrent = (
     if ((saved.importIntermediates ?? false) !== current.importIntermediates) return false;
     if ((saved.importOrphans ?? false) !== current.importOrphans) return false;
     if ((saved.syncBoardsToCollections ?? false) !== current.syncBoardsToCollections) return false;
+    if ((saved.pathRepairVersion ?? 0) !== current.pathRepairVersion) return false;
 
     const savedFiles = sortedFiles(saved.files ?? []);
     const currentFiles = sortedFiles(current.files);

--- a/src/services/invoke/orphanScanner.ts
+++ b/src/services/invoke/orphanScanner.ts
@@ -1,10 +1,47 @@
 import Database from '@tauri-apps/plugin-sql';
 import { convertFileSrc } from '@tauri-apps/api/core';
-import { commands, ScanResult } from '../../bindings';
+import { commands } from '../../bindings';
 import { unwrap } from '../../utils/spectaUtils';
 import { getDb } from '../db/connection';
 import { insertImagesBatch } from '../db/imageRepo';
 import { AIImage, GeneratorTool, ImageMetadata } from '../../types';
+import { getFilename, normalizePath } from '../../utils/pathUtils';
+
+const normalizeRelativePath = (path: string): string =>
+    normalizePath(path).replace(/^\/+/, '');
+
+const buildPathMatchKeys = (path: string): string[] => {
+    const normalized = normalizeRelativePath(path);
+    const withoutOutputPrefix = normalized.replace(/^outputs\/images\//i, '');
+
+    return Array.from(new Set([
+        normalized,
+        withoutOutputPrefix
+    ].filter(Boolean)));
+};
+
+const buildInvokeRowPath = (imageName: string, imageSubfolder?: string | null): string => {
+    const normalizedName = normalizeRelativePath(imageName);
+    const normalizedSubfolder = normalizeRelativePath(imageSubfolder || '');
+    if (!normalizedSubfolder) return normalizedName;
+
+    const filename = getFilename(normalizedName) || normalizedName;
+    const subfolder = normalizedSubfolder.replace(/^outputs\/images\//i, '');
+    return `outputs/images/${subfolder}/${filename}`;
+};
+
+const buildIntermediateMatchKeys = (imageName: string, imageSubfolder?: string | null): string[] => {
+    const normalizedName = normalizeRelativePath(imageName);
+    const normalizedSubfolder = normalizeRelativePath(imageSubfolder || '');
+    const hasPathTruth = !!normalizedSubfolder || /[\\/]/.test(normalizedName);
+
+    if (hasPathTruth) {
+        return buildPathMatchKeys(buildInvokeRowPath(imageName, imageSubfolder));
+    }
+
+    const filename = getFilename(normalizedName);
+    return filename ? [filename] : [];
+};
 
 export const scanForOrphans = async (
     rootPath: string,
@@ -31,8 +68,14 @@ export const scanForOrphans = async (
         try {
             const dbPath = isFile ? rootPath : `${imagesRoot}/databases/invokeai.db`;
             const invokeDb = await Database.load(`sqlite:${dbPath.replace(/\\/g, '/')}`);
-            const interRows = await invokeDb.select<Array<{ image_name: string }>>("SELECT image_name FROM images WHERE is_intermediate = 1");
-            knownIntermediates = new Set(interRows.map((r) => r.image_name));
+            const tableInfo = await invokeDb.select<Array<{ name: string }>>('PRAGMA table_info(images)');
+            const hasImageSubfolder = tableInfo.some(column => column.name === 'image_subfolder');
+            const interRows = await invokeDb.select<Array<{ image_name: string, image_subfolder?: string | null }>>(
+                `SELECT image_name ${hasImageSubfolder ? ', image_subfolder' : ''} FROM images WHERE is_intermediate = 1`
+            );
+            knownIntermediates = new Set(interRows.flatMap((r) =>
+                buildIntermediateMatchKeys(r.image_name, r.image_subfolder)
+            ));
         } catch (e) {
             console.error("[Hybrid Sync] ERROR loading intermediates:", e);
         }
@@ -51,8 +94,13 @@ export const scanForOrphans = async (
     }
 
     const orphans = allFiles.filter(f => {
-        const filename = f.split('/').pop();
-        if (!options.importIntermediates && filename && knownIntermediates.has(filename)) return false;
+        const pathMatchKeys = buildPathMatchKeys(f);
+        const filename = getFilename(f);
+        if (!options.importIntermediates && (
+            pathMatchKeys.some(key => knownIntermediates.has(key)) ||
+            (filename && knownIntermediates.has(filename))
+        )) return false;
+        if (pathMatchKeys.some(key => syncedIds.has(key))) return false;
 
         // f is relative to root (e.g. "outputs/images/uuid.png")
         // So we just join it with root.

--- a/src/services/invoke/pathResolver.ts
+++ b/src/services/invoke/pathResolver.ts
@@ -1,0 +1,224 @@
+import { getFilename, normalizePath } from '../../utils/pathUtils';
+
+export interface ResolvedInvokeImagePath {
+    absolutePath: string | null;
+    relativePath: string | null;
+    ambiguous: boolean;
+}
+
+interface InvokeDiskIndex {
+    byRootRelative: Map<string, string>;
+    byImagesRelative: Map<string, string>;
+    byBasename: Map<string, string | null>;
+}
+
+const OUTPUT_IMAGES_PREFIX = 'outputs/images/';
+
+const trimLeadingSlash = (path: string): string => path.replace(/^\/+/, '');
+
+const isOutputImagesRelative = (path: string): boolean =>
+    path.toLowerCase().startsWith(OUTPUT_IMAGES_PREFIX);
+
+const hasPathSeparator = (path: string): boolean => /[\\/]/.test(path);
+
+const normalizeRelativePath = (path: string): string =>
+    trimLeadingSlash(normalizePath(path)).replace(/\/+$/, '');
+
+const joinRelativePath = (...parts: Array<string | null | undefined>): string =>
+    parts
+        .map(part => part ? normalizeRelativePath(part) : '')
+        .filter(Boolean)
+        .join('/');
+
+const toRootRelativeImagePath = (imageName: string): string => {
+    const normalized = normalizeRelativePath(imageName);
+    return isOutputImagesRelative(normalized)
+        ? normalized
+        : `${OUTPUT_IMAGES_PREFIX}${normalized}`;
+};
+
+const toSubfolderImagePath = (imageName: string, imageSubfolder: string): string => {
+    const normalizedName = normalizeRelativePath(imageName);
+    const filename = getFilename(normalizedName) || normalizedName;
+    const normalizedSubfolder = isOutputImagesRelative(imageSubfolder)
+        ? imageSubfolder.slice(OUTPUT_IMAGES_PREFIX.length)
+        : imageSubfolder;
+    return `${OUTPUT_IMAGES_PREFIX}${joinRelativePath(normalizedSubfolder, filename)}`;
+};
+
+const fromOutputImagesRelative = (rootRelativePath: string): string | null => {
+    const normalized = normalizeRelativePath(rootRelativePath);
+    return isOutputImagesRelative(normalized)
+        ? normalized.slice(OUTPUT_IMAGES_PREFIX.length)
+        : null;
+};
+
+const toAbsolutePath = (invokeRoot: string, rootRelativePath: string): string =>
+    normalizePath(`${invokeRoot}/${normalizeRelativePath(rootRelativePath)}`);
+
+export const buildInvokeImageDiskIndex = (files: string[]): InvokeDiskIndex => {
+    const byRootRelative = new Map<string, string>();
+    const byImagesRelative = new Map<string, string>();
+    const byBasename = new Map<string, string | null>();
+
+    files.forEach((file) => {
+        const rootRelative = normalizeRelativePath(file);
+        if (!rootRelative) return;
+
+        byRootRelative.set(rootRelative.toLowerCase(), rootRelative);
+
+        const imagesRelative = fromOutputImagesRelative(rootRelative);
+        if (imagesRelative) {
+            byImagesRelative.set(imagesRelative.toLowerCase(), rootRelative);
+        }
+
+        const basename = getFilename(rootRelative).toLowerCase();
+        if (!basename) return;
+
+        if (!byBasename.has(basename)) {
+            byBasename.set(basename, rootRelative);
+            return;
+        }
+
+        if (byBasename.get(basename) !== rootRelative) {
+            byBasename.set(basename, null);
+        }
+    });
+
+    return { byRootRelative, byImagesRelative, byBasename };
+};
+
+export const createInvokeImagePathResolver = (
+    invokeRoot: string,
+    listImages: () => Promise<string[]>
+) => {
+    const normalizedRoot = normalizePath(invokeRoot).replace(/\/$/, '');
+    let diskIndexPromise: Promise<InvokeDiskIndex> | null = null;
+
+    const getDiskIndex = async (): Promise<InvokeDiskIndex> => {
+        if (!diskIndexPromise) {
+            diskIndexPromise = listImages().then(buildInvokeImageDiskIndex);
+        }
+        return diskIndexPromise;
+    };
+
+    const resolveImagePath = async (
+        imageName: string,
+        imageSubfolder?: string | null
+    ): Promise<ResolvedInvokeImagePath> => {
+        const normalizedName = normalizeRelativePath(imageName);
+        const normalizedSubfolder = normalizeRelativePath(imageSubfolder || '');
+        const directRelativePath = normalizedSubfolder
+            ? toSubfolderImagePath(imageName, normalizedSubfolder)
+            : toRootRelativeImagePath(imageName);
+        const fallbackRelativePath = directRelativePath;
+        const fallback: ResolvedInvokeImagePath = {
+            absolutePath: toAbsolutePath(normalizedRoot, fallbackRelativePath),
+            relativePath: fallbackRelativePath,
+            ambiguous: false
+        };
+
+        if (normalizedSubfolder || hasPathSeparator(normalizedName)) {
+            return fallback;
+        }
+
+        try {
+            const index = await getDiskIndex();
+            const rootRelativeMatch = index.byRootRelative.get(fallbackRelativePath.toLowerCase());
+            const imagesRelativeMatch = index.byImagesRelative.get(normalizedName.toLowerCase());
+            const exactMatch = rootRelativeMatch ?? imagesRelativeMatch;
+
+            if (exactMatch) {
+                return {
+                    absolutePath: toAbsolutePath(normalizedRoot, exactMatch),
+                    relativePath: exactMatch,
+                    ambiguous: false
+                };
+            }
+
+            if (!hasPathSeparator(normalizedName)) {
+                const basenameMatch = index.byBasename.get(normalizedName.toLowerCase());
+                if (basenameMatch === null) {
+                    console.warn('[InvokeAI Sync] Ambiguous image basename; skipping DB row to avoid importing the wrong file.', {
+                        imageName
+                    });
+                    return { absolutePath: null, relativePath: null, ambiguous: true };
+                }
+
+                if (basenameMatch) {
+                    return {
+                        absolutePath: toAbsolutePath(normalizedRoot, basenameMatch),
+                        relativePath: basenameMatch,
+                        ambiguous: false
+                    };
+                }
+            }
+        } catch (error) {
+            console.warn('[InvokeAI Sync] Failed to build InvokeAI image path index; falling back to flat path resolution.', error);
+        }
+
+        return fallback;
+    };
+
+    const getThumbnailPathCandidates = (
+        thumbnailName: string | null | undefined,
+        resolvedImage: ResolvedInvokeImagePath
+    ): string[] => {
+        if (!resolvedImage.absolutePath) return [];
+        const imagesRelative = resolvedImage.relativePath
+            ? fromOutputImagesRelative(resolvedImage.relativePath)
+            : null;
+        const imageParent = imagesRelative?.split('/').slice(0, -1).join('/') ?? '';
+        const imageBasename = imagesRelative ? getFilename(imagesRelative) : getFilename(resolvedImage.absolutePath);
+        const fallbackThumbnailName = imageBasename.replace(/\.[^/.]+$/, '.webp');
+
+        const normalizedThumbnail = normalizeRelativePath(thumbnailName || fallbackThumbnailName);
+        if (!normalizedThumbnail) return [];
+
+        const candidates: string[] = [];
+        const addCandidate = (rootRelative: string) => {
+            const absolute = toAbsolutePath(normalizedRoot, rootRelative);
+            if (!candidates.includes(absolute)) candidates.push(absolute);
+        };
+
+        if (hasPathSeparator(normalizedThumbnail)) {
+            addCandidate(isOutputImagesRelative(normalizedThumbnail)
+                ? normalizedThumbnail
+                : `${OUTPUT_IMAGES_PREFIX}${normalizedThumbnail}`);
+            return candidates;
+        }
+
+        if (imageParent) {
+            addCandidate(`${OUTPUT_IMAGES_PREFIX}${imageParent}/${normalizedThumbnail}`);
+            addCandidate(`${OUTPUT_IMAGES_PREFIX}${imageParent}/thumbnails/${normalizedThumbnail}`);
+            addCandidate(`${OUTPUT_IMAGES_PREFIX}thumbnails/${imageParent}/${normalizedThumbnail}`);
+        }
+
+        addCandidate(`${OUTPUT_IMAGES_PREFIX}thumbnails/${normalizedThumbnail}`);
+        return candidates;
+    };
+
+    const resolveThumbnailPath = (
+        thumbnailName: string | null | undefined,
+        resolvedImage: ResolvedInvokeImagePath,
+        existingPaths?: ReadonlySet<string>
+    ): string | null => {
+        if (!resolvedImage.absolutePath) return null;
+        const candidates = getThumbnailPathCandidates(thumbnailName, resolvedImage);
+        if (existingPaths) {
+            return candidates.find(candidate => existingPaths.has(candidate)) || resolvedImage.absolutePath;
+        }
+
+        return candidates[0] || resolvedImage.absolutePath;
+    };
+
+    const getLegacyFlatImagePath = (imageName: string): string | null => {
+        const normalizedName = normalizeRelativePath(imageName);
+        const filename = getFilename(normalizedName);
+        if (!filename) return null;
+
+        return toAbsolutePath(normalizedRoot, `${OUTPUT_IMAGES_PREFIX}${filename}`);
+    };
+
+    return { resolveImagePath, resolveThumbnailPath, getThumbnailPathCandidates, getLegacyFlatImagePath };
+};

--- a/src/services/invoke/syncService.ts
+++ b/src/services/invoke/syncService.ts
@@ -22,8 +22,17 @@ import {
     TouchedFacetResources
 } from '../../utils/touchedFacetTypes';
 import { insertImagesBatch } from '../db';
-import { getImagesByIds, syncCollectionImages } from '../db/imageRepo';
+import {
+    getFlatInvokeImageIdsForRoot,
+    getImagesByIds,
+    ImagePathIdentityMove,
+    moveImagePathIdentities,
+    moveImagePathIdentity,
+    syncCollectionImages
+} from '../db/imageRepo';
 import { upsertCollection } from '../db/collectionRepo';
+import { createInvokeImagePathResolver, ResolvedInvokeImagePath } from './pathResolver';
+import { getFilename, normalizePath } from '../../utils/pathUtils';
 
 interface InvokeSyncOptions {
     syncFavorites?: boolean;
@@ -41,6 +50,7 @@ interface CountRow {
 
 interface InvokeImageRow {
     image_name: string;
+    image_subfolder?: string | null;
     metadata_blob: string | null;
     created_at: string;
     updated_at?: string | null;
@@ -51,6 +61,12 @@ interface InvokeImageRow {
     thumbnail_name?: string | null;
     has_workflow?: number | boolean | null;
     is_intermediate?: number | boolean | null;
+}
+
+interface InvokeRepairCandidate {
+    legacyFlatPath: string;
+    targetPath: string;
+    thumbnailPath: string;
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -126,6 +142,7 @@ export const syncImages = async (
     const hasThumbnailName = columns.includes('thumbnail_name');
     const hasHasWorkflow = columns.includes('has_workflow');
     const hasUpdatedAt = columns.includes('updated_at');
+    const hasImageSubfolder = columns.includes('image_subfolder');
 
     const metaCol = hasMetadataJson ? 'metadata_json' : (hasMetadata ? 'metadata' : null);
 
@@ -196,15 +213,268 @@ export const syncImages = async (
     const touchedFacetTypes = new Set<FacetType>();
     let touchedFacetResources = createEmptyTouchedFacetResources();
 
+    onProgress(0, 0, `Scanning ${APP_NAME} library...`);
+    const pathResolver = createInvokeImagePathResolver(imagesRoot, async () =>
+        unwrap(commands.listInvokeaiImages(imagesRoot))
+    );
+
+    const resolveThumbnailPathsForRows = async (
+        rows: InvokeImageRow[],
+        resolvedPaths: ResolvedInvokeImagePath[]
+    ): Promise<string[]> => {
+        const candidatesByRow = rows.map((row, index) =>
+            pathResolver.getThumbnailPathCandidates(
+                hasThumbnailName ? row.thumbnail_name : undefined,
+                resolvedPaths[index]
+            )
+        );
+        const allCandidates = Array.from(new Set(candidatesByRow.flat()));
+        let existingThumbnailPaths: Set<string> | undefined;
+
+        if (allCandidates.length > 0) {
+            try {
+                const missingPaths = await unwrap(commands.verifyImagePaths(allCandidates));
+                const missingSet = new Set(missingPaths.map(path => path.replace(/\\/g, '/')));
+                existingThumbnailPaths = new Set(
+                    allCandidates.filter(path => !missingSet.has(path.replace(/\\/g, '/')))
+                );
+            } catch (error) {
+                console.warn('[InvokeAI Sync] Failed to verify InvokeAI thumbnail paths; using source image fallback.', error);
+                existingThumbnailPaths = new Set();
+            }
+        }
+
+        return resolvedPaths.map((resolvedPath, index) =>
+            pathResolver.resolveThumbnailPath(
+                hasThumbnailName ? rows[index].thumbnail_name : undefined,
+                resolvedPath,
+                existingThumbnailPaths
+            ) || resolvedPath.absolutePath || ''
+        );
+    };
+
+    const repairStaleInvokeImagePaths = async (): Promise<number> => {
+        onProgress(0, 0, 'Repairing existing InvokeAI image paths...');
+        const staleFlatPaths = await getFlatInvokeImageIdsForRoot(imagesRoot);
+        if (staleFlatPaths.length === 0) return 0;
+
+        const stalePathByName = new Map<string, string>();
+        staleFlatPaths.forEach((path) => {
+            const filename = getFilename(path);
+            if (filename) stalePathByName.set(filename.toLowerCase(), path);
+        });
+
+        const repairConditions: string[] = [];
+        if (!options.importIntermediates && hasIsIntermediate) {
+            repairConditions.push('i.is_intermediate = 0');
+        }
+        const REPAIR_NAME_BATCH_SIZE = 500;
+        const REPAIR_MOVE_BATCH_SIZE = 250;
+        let repairedCount = 0;
+        let matchedRows = 0;
+        let relativeRowsScanned = 0;
+        let skippedTargetMissing = 0;
+        let skippedTargetExists = 0;
+        let skippedSourceMissing = 0;
+        let skippedAmbiguous = 0;
+        let skippedUnresolved = 0;
+        const staleNames = Array.from(stalePathByName.keys());
+        const repairSelectFields = `i.image_name${hasImageSubfolder ? ', i.image_subfolder' : ''}${hasThumbnailName ? ', i.thumbnail_name' : ''}`;
+        const normalizedImageNameExpr = "LOWER(REPLACE(i.image_name, '\\', '/'))";
+        const repairRowsByKey = new Map<string, InvokeImageRow>();
+        const matchedStaleNames = new Set<string>();
+        const addRepairRows = (rows: InvokeImageRow[]) => {
+            rows.forEach((row) => {
+                const staleName = getFilename(row.image_name).toLowerCase();
+                if (!stalePathByName.has(staleName)) return;
+                matchedStaleNames.add(staleName);
+
+                const key = [
+                    normalizePath(row.image_name).toLowerCase(),
+                    normalizePath(row.image_subfolder || '').toLowerCase()
+                ].join('|');
+                repairRowsByKey.set(key, row);
+            });
+        };
+
+        for (let offset = 0; offset < staleNames.length; offset += REPAIR_NAME_BATCH_SIZE) {
+            if (signal?.aborted) throw new Error('Aborted');
+
+            const nameChunk = staleNames.slice(offset, offset + REPAIR_NAME_BATCH_SIZE);
+            const placeholders = nameChunk.map(() => '?').join(',');
+            const repairWhereClause = [
+                `${normalizedImageNameExpr} IN (${placeholders})`,
+                ...repairConditions
+            ].join(' AND ');
+            const repairRows = await invokeDb.select<InvokeImageRow[]>(`
+                SELECT ${repairSelectFields}
+                FROM images i
+                WHERE ${repairWhereClause}
+                ORDER BY i.created_at ASC, i.image_name ASC
+            `, nameChunk);
+            addRepairRows(repairRows);
+        }
+
+        if (matchedStaleNames.size < staleNames.length) {
+            const relativeRepairWhereClause = [
+                "instr(REPLACE(i.image_name, '\\', '/'), '/') > 0",
+                ...repairConditions
+            ].join(' AND ');
+            const relativeRepairRows = await invokeDb.select<InvokeImageRow[]>(`
+                SELECT ${repairSelectFields}
+                FROM images i
+                WHERE ${relativeRepairWhereClause}
+                ORDER BY i.created_at ASC, i.image_name ASC
+            `);
+            relativeRowsScanned = relativeRepairRows.length;
+            addRepairRows(relativeRepairRows);
+        }
+
+        const repairCandidates = Array.from(repairRowsByKey.values());
+        matchedRows = repairCandidates.length;
+
+        for (let offset = 0; offset < repairCandidates.length; offset += REPAIR_MOVE_BATCH_SIZE) {
+            if (signal?.aborted) throw new Error('Aborted');
+
+            const repairRows = repairCandidates.slice(offset, offset + REPAIR_MOVE_BATCH_SIZE);
+            if (repairRows.length === 0) continue;
+
+            const resolvedPaths = await Promise.all(
+                repairRows.map(row => pathResolver.resolveImagePath(row.image_name, row.image_subfolder))
+            );
+            const targetPaths = resolvedPaths
+                .map(resolved => resolved.absolutePath)
+                .filter((path): path is string => !!path);
+            const legacyFlatPaths = repairRows.map(row =>
+                stalePathByName.get(getFilename(row.image_name).toLowerCase()) || pathResolver.getLegacyFlatImagePath(row.image_name)
+            );
+            const lookupPaths = Array.from(new Set([
+                ...targetPaths,
+                ...legacyFlatPaths.filter((path): path is string => !!path)
+            ]));
+
+            let sizes: number[] = [];
+            try {
+                sizes = await unwrap(commands.getFileSizesBulk(targetPaths));
+            } catch (error) {
+                console.warn('[InvokeAI Sync] Failed to probe resolved InvokeAI paths during repair.', error);
+                sizes = new Array(targetPaths.length).fill(0);
+            }
+            const existingImagesInBatch = await getImagesByIds(lookupPaths);
+            const existingMap = new Map(existingImagesInBatch.map(img => [img.id, img]));
+            const sizeByPath = new Map(targetPaths.map((path, index) => [path, sizes[index] || 0]));
+            const thumbnailPaths = await resolveThumbnailPathsForRows(repairRows, resolvedPaths);
+            const moves: ImagePathIdentityMove[] = [];
+            const candidatesBySource = new Map<string, InvokeRepairCandidate[]>();
+
+            for (let i = 0; i < repairRows.length; i++) {
+                const resolvedPath = resolvedPaths[i];
+                const targetPath = resolvedPath.absolutePath;
+                const legacyFlatPath = legacyFlatPaths[i];
+                if (resolvedPath.ambiguous) {
+                    skippedAmbiguous++;
+                    continue;
+                }
+                if (!targetPath || !legacyFlatPath) {
+                    skippedUnresolved++;
+                    continue;
+                }
+                if (legacyFlatPath === targetPath) {
+                    skippedUnresolved++;
+                    continue;
+                }
+                if ((sizeByPath.get(targetPath) || 0) <= 0) {
+                    skippedTargetMissing++;
+                    continue;
+                }
+                if (existingMap.has(targetPath)) {
+                    skippedTargetExists++;
+                    continue;
+                }
+                if (!existingMap.has(legacyFlatPath)) {
+                    skippedSourceMissing++;
+                    continue;
+                }
+
+                const thumbnailPath = thumbnailPaths[i] || targetPath;
+                const candidates = candidatesBySource.get(legacyFlatPath) || [];
+                candidates.push({ legacyFlatPath, targetPath, thumbnailPath });
+                candidatesBySource.set(legacyFlatPath, candidates);
+            }
+
+            for (const candidates of candidatesBySource.values()) {
+                const targetPathsForSource = new Set(candidates.map(candidate => candidate.targetPath));
+                if (targetPathsForSource.size > 1) {
+                    skippedAmbiguous += candidates.length;
+                    continue;
+                }
+
+                const candidate = candidates[0];
+                moves.push({
+                    oldId: candidate.legacyFlatPath,
+                    newId: candidate.targetPath,
+                    thumbnailPath: candidate.thumbnailPath,
+                    thumbnailSource: candidate.thumbnailPath === candidate.targetPath ? null : 'invokeai'
+                });
+            }
+
+            if (moves.length > 0) {
+                const moveResult = await moveImagePathIdentities(moves);
+                repairedCount += moveResult.moved;
+                skippedTargetExists += moveResult.skippedTargetExists;
+                skippedSourceMissing += moveResult.skippedSourceMissing;
+
+                for (const move of moves.slice(0, moveResult.moved)) {
+                    const legacyExisting = existingMap.get(move.oldId);
+                    existingMap.delete(move.oldId);
+                    if (legacyExisting) existingMap.set(move.newId, { ...legacyExisting, id: move.newId });
+                }
+            }
+
+            console.info('[InvokeAI Sync] Stale InvokeAI path repair batch complete.', {
+                staleFlatRows: staleFlatPaths.length,
+                matchedRows,
+                relativeRowsScanned,
+                queuedMoves: moves.length,
+                repairedCount,
+                skippedTargetExists,
+                skippedTargetMissing,
+                skippedSourceMissing,
+                skippedAmbiguous,
+                skippedUnresolved
+            });
+            await new Promise(r => setTimeout(r, 0));
+        }
+
+        console.info('[InvokeAI Sync] Stale InvokeAI path repair complete.', {
+            staleFlatRows: staleFlatPaths.length,
+            matchedRows,
+            relativeRowsScanned,
+            repairedCount,
+            skippedTargetExists,
+            skippedTargetMissing,
+            skippedSourceMissing,
+            skippedAmbiguous,
+            skippedUnresolved
+        });
+        return repairedCount;
+    };
+
+    let repairedExistingCount = 0;
+    const shouldRepairExistingPaths = (options.mode ?? 'manual') === 'manual';
+    if (shouldRepairExistingPaths) {
+        repairedExistingCount = await repairStaleInvokeImagePaths();
+    }
+
     if (totalToImport === 0) {
         logSyncInfo('Invoke sync service complete', {
             totalToImport,
             importedCount: 0,
-            updatedCount: 0,
+            updatedCount: repairedExistingCount,
             batchCount: 0,
             totalMs: elapsedMs(syncStartedAt)
         });
-        return { imported: 0, updated: 0, maxTimestamp: options.afterTimestamp || 0, syncedIds, boardMapping: options.syncBoards ? boards : new Map(), touchedFacetTypes: [], touchedFacetResources: createEmptyTouchedFacetResources() };
+        return { imported: 0, updated: repairedExistingCount, maxTimestamp: options.afterTimestamp || 0, syncedIds, boardMapping: options.syncBoards ? boards : new Map(), touchedFacetTypes: [], touchedFacetResources: createEmptyTouchedFacetResources() };
     }
 
     let hasBoardsTable = false;
@@ -227,11 +497,9 @@ export const syncImages = async (
         });
     }
 
-    onProgress(0, 0, `Scanning ${APP_NAME} library...`);
-
     let processed = 0;
     let newImportedCount = 0;
-    let totalUpdated = 0;
+    let totalUpdated = repairedExistingCount;
     const BATCH_SIZE = 500;
     let offset = 0;
     let maxTimestampNum = options.afterTimestamp || 0;
@@ -241,6 +509,7 @@ export const syncImages = async (
     const hasWfCol = hasHasWorkflow ? ', i.has_workflow' : '';
     const updatedCol = hasUpdatedAt ? ', i.updated_at' : '';
     const intermediateCol = hasIsIntermediate ? ', i.is_intermediate' : '';
+    const imageSubfolderCol = hasImageSubfolder ? ', i.image_subfolder' : '';
 
     const createdBoardIds = new Set<string>();
     let batchCount = 0;
@@ -252,7 +521,7 @@ export const syncImages = async (
         const batchIndex = batchCount + 1;
         const metaSelect = metaCol ? `i.${metaCol} as metadata_blob` : "NULL as metadata_blob";
         const query = `
-            SELECT i.image_name, ${metaSelect}, i.created_at, i.width, i.height ${favCol} ${thumbCol} ${hasWfCol} ${updatedCol} ${intermediateCol}
+            SELECT i.image_name, ${metaSelect}, i.created_at, i.width, i.height ${favCol} ${thumbCol} ${hasWfCol} ${updatedCol} ${intermediateCol} ${imageSubfolderCol}
             FROM images i
             ${whereClause}
             ORDER BY i.created_at ASC, ${hasUpdatedAt ? 'i.updated_at ASC' : 'i.image_name ASC'}
@@ -265,10 +534,16 @@ export const syncImages = async (
         if (rows.length === 0) break;
         batchCount++;
 
-        const batchPaths = rows.map((row) => {
-            const rawPath = `${imagesRoot}/outputs/images/${row.image_name}`;
-            return rawPath.replace(/\\/g, '/').replace(/\/+/g, '/');
-        });
+        const resolvedPaths = await Promise.all(rows.map((row) => pathResolver.resolveImagePath(row.image_name, row.image_subfolder)));
+        const thumbnailPaths = await resolveThumbnailPathsForRows(rows, resolvedPaths);
+        const batchPaths = resolvedPaths
+            .map((resolved) => resolved.absolutePath)
+            .filter((path): path is string => !!path);
+        const legacyFlatPaths = rows.map((row) => pathResolver.getLegacyFlatImagePath(row.image_name));
+        const lookupPaths = Array.from(new Set([
+            ...batchPaths,
+            ...legacyFlatPaths.filter((path): path is string => !!path)
+        ]));
 
         let sizes: number[] = [];
         const fileSizeProbeStartedAt = liveWatchNow();
@@ -280,16 +555,25 @@ export const syncImages = async (
         const fileSizeProbeMs = elapsedMs(fileSizeProbeStartedAt);
 
         const existingLookupStartedAt = liveWatchNow();
-        const existingImagesInBatch = await getImagesByIds(batchPaths);
+        const existingImagesInBatch = await getImagesByIds(lookupPaths);
         const existingMap = new Map(existingImagesInBatch.map(img => [img.id, img]));
+        const sizeByPath = new Map(batchPaths.map((path, index) => [path, sizes[index] || 0]));
         const existingLookupMs = elapsedMs(existingLookupStartedAt);
 
         const currentBatch: AIImage[] = [];
         const batchBuildStartedAt = liveWatchNow();
         for (let i = 0; i < rows.length; i++) {
             const row = rows[i];
-            const fullPath = batchPaths[i];
-            const fileSize = sizes[i] || 0;
+            const resolvedPath: ResolvedInvokeImagePath = resolvedPaths[i];
+            if (!resolvedPath.absolutePath) {
+                processed++;
+                continue;
+            }
+
+            const fullPath = resolvedPath.absolutePath;
+            const fileSize = sizeByPath.get(fullPath) || 0;
+            const legacyFlatPath = legacyFlatPaths[i];
+            let pathRepaired = false;
 
             try {
                 const timeRaw = row.created_at.includes('Z') ? row.created_at : row.created_at + ' Z';
@@ -310,7 +594,32 @@ export const syncImages = async (
                 let isPinned = false;
 
                 // Sync protection: If we already have this image, and sync options are OFF, keep the old values
-                const existing = existingMap.get(fullPath);
+                let existing = existingMap.get(fullPath);
+                if (!existing && legacyFlatPath && legacyFlatPath !== fullPath) {
+                    const legacyExisting = existingMap.get(legacyFlatPath);
+                    if (legacyExisting) {
+                        const repairedThumbnailPath = thumbnailPaths[i] || fullPath;
+                        pathRepaired = await moveImagePathIdentity(
+                            legacyFlatPath,
+                            fullPath,
+                            repairedThumbnailPath,
+                            repairedThumbnailPath === fullPath ? null : 'invokeai'
+                        );
+
+                        if (pathRepaired) {
+                            existing = {
+                                ...legacyExisting,
+                                id: fullPath,
+                                url: convertFileSrc(fullPath),
+                                thumbnailUrl: repairedThumbnailPath,
+                                thumbnailSource: repairedThumbnailPath === fullPath ? undefined : 'invokeai',
+                                filename: row.image_name.split(/[\\/]/).pop() ?? row.image_name,
+                                isMissing: false
+                            };
+                            existingMap.set(fullPath, existing);
+                        }
+                    }
+                }
 
                 if (options.syncFavorites && options.starredAs && options.starredAs !== 'none') {
                     const isStarredInInvoke = (hasStarred && (row.starred === 1 || row.starred === true)) ||
@@ -422,14 +731,14 @@ export const syncImages = async (
                 }
 
                 if (!needsUpdate) {
+                    if (pathRepaired) totalUpdated++;
                     processed++;
                     syncedIds.add(row.image_name);
+                    if (resolvedPath.relativePath) syncedIds.add(resolvedPath.relativePath);
                     continue;
                 }
 
-                let thumbnailPath = (hasThumbnailName && row.thumbnail_name)
-                    ? `${imagesRoot}/outputs/images/thumbnails/${row.thumbnail_name}`
-                    : `${imagesRoot}/outputs/images/thumbnails/${row.image_name.replace(/\.[^/.]+$/, "") + ".webp"}`;
+                const thumbnailPath = thumbnailPaths[i] || fullPath;
 
                 // Capture originalState for new images (InvokeAI import-time values)
                 const isStarredInInvoke = (hasStarred && (row.starred === 1 || row.starred === true)) ||
@@ -459,8 +768,8 @@ export const syncImages = async (
                     id: fullPath,
                     url: convertFileSrc(fullPath),
                     thumbnailUrl: thumbnailPath,
-                    thumbnailSource: 'invokeai',
-                    filename: row.image_name,
+                    thumbnailSource: thumbnailPath === fullPath ? undefined : 'invokeai',
+                    filename: row.image_name.split(/[\\/]/).pop() ?? row.image_name,
                     fileSize: fileSize,
                     timestamp: timestamp || Date.now(),
                     width: row.width || 0,
@@ -495,6 +804,7 @@ export const syncImages = async (
 
                 currentBatch.push(newImg);
                 syncedIds.add(row.image_name);
+                if (resolvedPath.relativePath) syncedIds.add(resolvedPath.relativePath);
                 processed++;
             } catch (e) { }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,7 @@ export interface InvokeDbSnapshotState {
   importIntermediates: boolean;
   importOrphans: boolean;
   syncBoardsToCollections: boolean;
+  pathRepairVersion: number;
   files: InvokeDbSnapshotFile[];
 }
 


### PR DESCRIPTION
## Summary
- resolve InvokeAI image paths from image_subfolder and disk fallback instead of assuming flat outputs/images layout
- repair stale flat Ambit image identities, including relationship tables and thumbnail cache/source references
- persist startup snapshot state with the path repair marker and add coverage for manual/startup repair behavior

## Verification
- cargo test move_image_path_identities
- pnpm run typecheck
- git diff --check
- rustfmt --edition 2021 --check src\\db\\commands\\image_commands.rs