### PR TITLE
[codex] Fix collection thumbnail startup performance

### DIFF
--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -13,6 +13,7 @@ import {
     rebuildThumbnailFacetCache,
     updatePinned,
 } from '../services/db/imageRepo';
+import { clearAllCollectionThumbnailCaches } from '../services/db/collectionRepo';
 import { useImagesQuery } from '../hooks/useImagesQuery';
 import { useLibraryStatsQuery } from '../hooks/useLibraryStatsQuery';
 import { buildSqlWhereClause } from '../utils/sqlHelpers';
@@ -126,6 +127,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                 console.info(`[Startup] Privacy mask refresh completed in ${Math.round(performance.now() - refreshStartedAt)}ms (changed: ${result.changed}, updated: ${result.updated})`);
                 if (result.changed || result.updated > 0) {
                     const rebuildStartedAt = performance.now();
+                    await clearAllCollectionThumbnailCaches();
                     await rebuildThumbnailFacetCache();
                     console.info(`[Startup] Thumbnail facet privacy refresh completed in ${Math.round(performance.now() - rebuildStartedAt)}ms`);
                     useLibraryStore.getState().incrementFacetCacheVersion();

--- a/src/hooks/useThumbnailOps.ts
+++ b/src/hooks/useThumbnailOps.ts
@@ -10,7 +10,7 @@ import { regenerateThumbnailsForImages } from '../services/thumbnailService';
 interface UseThumbnailOpsProps {
     images: AIImage[];
     setImages: React.Dispatch<React.SetStateAction<AIImage[]>>;
-    refreshCollectionThumbnails: () => Promise<void>;
+    refreshCollectionThumbnails: (debounced?: boolean, force?: boolean) => Promise<void>;
 }
 
 export const useThumbnailOps = ({
@@ -72,7 +72,7 @@ export const useThumbnailOps = ({
                     ? `Cancelled after optimizing ${updates.length} thumbnails.`
                     : `Successfully optimized ${updates.length} of ${candidates.length} thumbnails.`;
                 addToast(msg, "success");
-                await refreshCollectionThumbnails();
+                await refreshCollectionThumbnails(false, true);
             }
         } catch (e) {
             console.error("Regeneration error", e);

--- a/src/services/db/__tests__/collectionRepo.test.ts
+++ b/src/services/db/__tests__/collectionRepo.test.ts
@@ -101,6 +101,36 @@ describe('collectionRepo filter normalization', () => {
         expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_is_sensitive INTEGER');
         expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_cached_at INTEGER');
     });
+
+    it('clears dynamic thumbnail cache after resetting a custom thumbnail', async () => {
+        const { setCollectionCustomThumbnail } = await import('../collectionRepo');
+
+        await setCollectionCustomThumbnail('c1', null);
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            'UPDATE collections SET custom_thumbnail = ?, updated_at = ? WHERE id = ?',
+            [null, expect.any(Number), 'c1']
+        );
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_thumbnail_path = NULL'),
+            ['c1']
+        );
+    });
+
+    it('keeps dynamic thumbnail cache when setting a custom thumbnail', async () => {
+        const { setCollectionCustomThumbnail } = await import('../collectionRepo');
+
+        await setCollectionCustomThumbnail('c1', 'img-custom');
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            'UPDATE collections SET custom_thumbnail = ?, updated_at = ? WHERE id = ?',
+            ['img-custom', expect.any(Number), 'c1']
+        );
+        expect(dbMocks.execute).not.toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_thumbnail_path = NULL'),
+            expect.anything()
+        );
+    });
 });
 
 describe('collectionRepo thumbnail hydration', () => {
@@ -119,7 +149,7 @@ describe('collectionRepo thumbnail hydration', () => {
                 return [makeCollectionRow({ name: 'Custom', custom_thumbnail: 'img1' })];
             }
             if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 1 }];
-            if (query.includes('c.id as collection_id')) {
+            if (query.includes('ranked_thumbnails')) {
                 return [{
                     collection_id: 'c1',
                     dynamic_thumb: 'C:/images/full.png',
@@ -172,12 +202,12 @@ describe('collectionRepo thumbnail hydration', () => {
             imageIds: []
         }));
         expect(collections[0].thumbnail).toBeUndefined();
-        expect(queries.join('\n')).not.toContain('c.id as collection_id');
+        expect(queries.join('\n')).not.toContain('ranked_thumbnails');
         expect(queries.join('\n')).not.toContain('WHERE id IN');
         expect(queries.join('\n')).not.toContain('WHERE path IN');
     });
 
-    it('maps cached dynamic thumbnails without running thumbnail hydration queries', async () => {
+    it('maps cached dynamic thumbnails without running thumbnail hydration queries when thumbnails are included', async () => {
         const queries: string[] = [];
         dbMocks.select.mockImplementation(async (query: string) => {
             queries.push(query);
@@ -186,16 +216,15 @@ describe('collectionRepo thumbnail hydration', () => {
                     name: 'Cached',
                     dynamic_thumbnail_path: 'C:/thumbs/cached.webp',
                     dynamic_safe_thumbnail_path: 'C:/thumbs/cached-safe.webp',
-                    dynamic_thumbnail_is_sensitive: 1,
-                    filter_state: JSON.stringify({ dateRange: 'today' })
+                    dynamic_thumbnail_is_sensitive: 1
                 })];
             }
-            if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 0 }];
+            if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 3 }];
             return [];
         });
 
         const { getAllCollectionsWithStats } = await import('../collectionRepo');
-        const collections = await getAllCollectionsWithStats({ includeThumbnails: false });
+        const collections = await getAllCollectionsWithStats();
 
         expect(collections[0]).toEqual(expect.objectContaining({
             thumbnail: 'asset://C:/thumbs/cached.webp',
@@ -203,7 +232,8 @@ describe('collectionRepo thumbnail hydration', () => {
             thumbnailIsSensitive: true,
             thumbnailSourceKind: 'dynamic'
         }));
-        expect(queries.join('\n')).not.toContain('c.id as collection_id');
+        expect(queries.join('\n')).not.toContain('ranked_thumbnails');
+        expect(dbMocks.execute).not.toHaveBeenCalled();
     });
 
     it('keeps cached smart thumbnails during full collection reloads until smart hydration runs', async () => {
@@ -235,7 +265,7 @@ describe('collectionRepo thumbnail hydration', () => {
             thumbnailIsSensitive: false,
             thumbnailSourceKind: 'dynamic'
         }));
-        expect(queries.join('\n')).not.toContain('c.id as collection_id');
+        expect(queries.join('\n')).not.toContain('ranked_thumbnails');
         expect(dbMocks.execute).not.toHaveBeenCalled();
     });
 
@@ -268,7 +298,7 @@ describe('collectionRepo thumbnail hydration', () => {
                 return [makeCollectionRow({ custom_thumbnail: 'C:/images/source.png' })];
             }
             if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 1 }];
-            if (query.includes('c.id as collection_id')) {
+            if (query.includes('ranked_thumbnails')) {
                 return [{ collection_id: 'c1', dynamic_thumb: null, dynamic_privacy: null, safe_thumb: null }];
             }
             if (query.includes('WHERE id IN')) return [];
@@ -297,7 +327,7 @@ describe('collectionRepo thumbnail hydration', () => {
                 return [makeCollectionRow({ custom_thumbnail: 'https://example.com/thumb.webp' })];
             }
             if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 1 }];
-            if (query.includes('c.id as collection_id')) {
+            if (query.includes('ranked_thumbnails')) {
                 return [{ collection_id: 'c1', dynamic_thumb: 'C:/thumbs/dynamic.webp', dynamic_privacy: 1, safe_thumb: null }];
             }
             if (query.includes('WHERE id IN') || query.includes('WHERE path IN')) return [];
@@ -318,7 +348,7 @@ describe('collectionRepo thumbnail hydration', () => {
         dbMocks.select.mockImplementation(async (query: string) => {
             if (query.includes('SELECT * FROM collections')) return [makeCollectionRow()];
             if (query.includes('COUNT(*) as count')) return [{ collection_id: 'c1', count: 2 }];
-            if (query.includes('c.id as collection_id')) {
+            if (query.includes('ranked_thumbnails')) {
                 dynamicQuery = query;
                 return [{
                     collection_id: 'c1',
@@ -337,13 +367,15 @@ describe('collectionRepo thumbnail hydration', () => {
         expect(collections[0].safeThumbnail).toBe('asset://C:/thumbs/safe.webp');
         expect(collections[0].thumbnailIsSensitive).toBe(true);
         expect(collections[0].thumbnailSourceKind).toBe('dynamic');
+        expect(dynamicQuery).toContain('WITH ranked_thumbnails');
         expect(dynamicQuery.match(/ORDER BY i\.is_pinned DESC, i\.timestamp DESC/g)?.length).toBeGreaterThanOrEqual(2);
-        expect(dynamicQuery).toContain('AND i.privacy_hidden = 0');
+        expect(dynamicQuery).toContain('privacy_hidden = 0 AND privacy_rank = 1');
+        expect(dynamicQuery).not.toContain('SELECT i.thumbnail_path');
     });
 
     it('writes raw dynamic thumbnail paths to the collection cache after static hydration', async () => {
         dbMocks.select.mockImplementation(async (query: string) => {
-            if (query.includes('c.id as collection_id')) {
+            if (query.includes('ranked_thumbnails')) {
                 return [{
                     collection_id: 'c1',
                     dynamic_thumb: 'C:/thumbs/unsafe.webp',
@@ -372,7 +404,7 @@ describe('collectionRepo thumbnail hydration', () => {
 
     it('clears the dynamic thumbnail cache when static hydration finds no thumbnail', async () => {
         dbMocks.select.mockImplementation(async (query: string) => {
-            if (query.includes('c.id as collection_id')) {
+            if (query.includes('ranked_thumbnails')) {
                 return [{
                     collection_id: 'c1',
                     dynamic_thumb: null,

--- a/src/services/db/collectionRepo.ts
+++ b/src/services/db/collectionRepo.ts
@@ -93,6 +93,10 @@ interface CollectionThumbnailInput {
     custom_thumbnail?: string | null;
 }
 
+interface CollectionMembershipRow {
+    collection_id: string;
+}
+
 interface CollectionSchemaColumn {
     name: string;
 }
@@ -194,56 +198,115 @@ const writeDynamicThumbnailCache = async (
     }
 };
 
+const clearDynamicThumbnailCacheForCollections = async (
+    db: Awaited<ReturnType<typeof getDb>>,
+    collectionIds: string[]
+) => {
+    const uniqueIds = [...new Set(collectionIds.filter(Boolean))];
+    if (uniqueIds.length === 0) return;
+
+    for (const idBatch of chunk(uniqueIds, 900)) {
+        const placeholders = idBatch.map(() => '?').join(',');
+        await db.execute(
+            `UPDATE collections
+             SET dynamic_thumbnail_path = NULL,
+                 dynamic_safe_thumbnail_path = NULL,
+                 dynamic_thumbnail_is_sensitive = NULL,
+                 dynamic_thumbnail_cached_at = NULL
+             WHERE id IN (${placeholders})
+               AND (custom_thumbnail IS NULL OR custom_thumbnail = '')`,
+            idBatch
+        );
+    }
+};
+
+export const clearCollectionThumbnailCacheForCollections = async (collectionIds: string[]) => {
+    if (isBrowserMockMode() || collectionIds.length === 0) return;
+
+    const db = await getDb();
+    await clearDynamicThumbnailCacheForCollections(db, collectionIds);
+};
+
+export const clearCollectionThumbnailCacheForImages = async (imageIds: string[]) => {
+    if (isBrowserMockMode() || imageIds.length === 0) return;
+
+    const db = await getDb();
+    const normalizedIds = [...new Set(imageIds.map(normalizePath).filter(Boolean))];
+    const collectionIds: string[] = [];
+    for (const idBatch of chunk(normalizedIds, 900)) {
+        const placeholders = idBatch.map(() => '?').join(',');
+        const rows = await db.select<CollectionMembershipRow[]>(
+            `SELECT DISTINCT collection_id
+             FROM collection_images
+             WHERE image_id IN (${placeholders})`,
+            idBatch
+        );
+        if (Array.isArray(rows)) {
+            collectionIds.push(...rows.map(row => row.collection_id));
+        }
+    }
+
+    await clearDynamicThumbnailCacheForCollections(db, collectionIds);
+};
+
+export const clearAllCollectionThumbnailCaches = async () => {
+    if (isBrowserMockMode()) return;
+
+    const db = await getDb();
+    await db.execute(
+        `UPDATE collections
+         SET dynamic_thumbnail_path = NULL,
+             dynamic_safe_thumbnail_path = NULL,
+             dynamic_thumbnail_is_sensitive = NULL,
+             dynamic_thumbnail_cached_at = NULL
+         WHERE custom_thumbnail IS NULL OR custom_thumbnail = ''`
+    );
+};
+
 const buildCollectionThumbnailSummaries = async (
     db: Awaited<ReturnType<typeof getDb>>,
     collections: CollectionThumbnailInput[]
 ): Promise<CollectionThumbnailBuildResult> => {
     if (collections.length === 0) return { summaries: {}, cacheUpdates: [] };
 
-    const ids = [...new Set(collections.map((collection) => collection.id).filter(Boolean))];
+    const ids = [...new Set(
+        collections
+            .filter((collection) => !collection.custom_thumbnail)
+            .map((collection) => collection.id)
+            .filter(Boolean)
+    )];
     const thumbnailRows: CollectionThumbnailRow[] = [];
 
     for (const idBatch of chunk(ids, 900)) {
         const placeholders = idBatch.map(() => '?').join(',');
         const rows = await db.select<CollectionThumbnailRow[]>(`
+            WITH ranked_thumbnails AS (
+                SELECT
+                    ci.collection_id,
+                    i.thumbnail_path,
+                    i.privacy_hidden,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY ci.collection_id
+                        ORDER BY i.is_pinned DESC, i.timestamp DESC
+                    ) as dynamic_rank,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY ci.collection_id, i.privacy_hidden
+                        ORDER BY i.is_pinned DESC, i.timestamp DESC
+                    ) as privacy_rank
+                FROM collection_images ci
+                INNER JOIN images i ON ci.image_id = i.id
+                WHERE ci.collection_id IN (${placeholders})
+                    AND i.is_deleted = 0
+                    AND i.thumbnail_path IS NOT NULL
+                    AND i.thumbnail_path != ''
+            )
             SELECT
-                c.id as collection_id,
-                (
-                    SELECT i.thumbnail_path
-                    FROM collection_images cii
-                    INNER JOIN images i ON cii.image_id = i.id
-                    WHERE cii.collection_id = c.id
-                        AND i.is_deleted = 0
-                        AND i.thumbnail_path IS NOT NULL
-                        AND i.thumbnail_path != ''
-                    ORDER BY i.is_pinned DESC, i.timestamp DESC
-                    LIMIT 1
-                ) as dynamic_thumb,
-                (
-                    SELECT i.privacy_hidden
-                    FROM collection_images cii
-                    INNER JOIN images i ON cii.image_id = i.id
-                    WHERE cii.collection_id = c.id
-                        AND i.is_deleted = 0
-                        AND i.thumbnail_path IS NOT NULL
-                        AND i.thumbnail_path != ''
-                    ORDER BY i.is_pinned DESC, i.timestamp DESC
-                    LIMIT 1
-                ) as dynamic_privacy,
-                (
-                    SELECT i.thumbnail_path
-                    FROM collection_images cii
-                    INNER JOIN images i ON cii.image_id = i.id
-                    WHERE cii.collection_id = c.id
-                        AND i.is_deleted = 0
-                        AND i.privacy_hidden = 0
-                        AND i.thumbnail_path IS NOT NULL
-                        AND i.thumbnail_path != ''
-                    ORDER BY i.is_pinned DESC, i.timestamp DESC
-                    LIMIT 1
-                ) as safe_thumb
-            FROM collections c
-            WHERE c.id IN (${placeholders})
+                collection_id,
+                MAX(CASE WHEN dynamic_rank = 1 THEN thumbnail_path END) as dynamic_thumb,
+                MAX(CASE WHEN dynamic_rank = 1 THEN privacy_hidden END) as dynamic_privacy,
+                MAX(CASE WHEN privacy_hidden = 0 AND privacy_rank = 1 THEN thumbnail_path END) as safe_thumb
+            FROM ranked_thumbnails
+            GROUP BY collection_id
         `, idBatch);
 
         thumbnailRows.push(...rows);
@@ -441,6 +504,9 @@ export const setCollectionCustomThumbnail = async (collectionId: string, imageId
             'UPDATE collections SET custom_thumbnail = ?, updated_at = ? WHERE id = ?',
             [imageId, Date.now(), collectionId]
         );
+        if (imageId === null) {
+            await clearDynamicThumbnailCacheForCollections(db, [collectionId]);
+        }
     });
 };
 
@@ -471,6 +537,7 @@ export const addImagesToCollection = async (collectionId: string, imageIds: stri
         }
         // Update collection timestamp
         await db.execute('UPDATE collections SET updated_at = ? WHERE id = ?', [now, collectionId]);
+        await clearDynamicThumbnailCacheForCollections(db, [collectionId]);
     });
 };
 
@@ -488,6 +555,7 @@ export const removeImagesFromCollection = async (collectionId: string, imageIds:
     );
     // Update collection timestamp
     await db.execute('UPDATE collections SET updated_at = ? WHERE id = ?', [Date.now(), collectionId]);
+    await clearDynamicThumbnailCacheForCollections(db, [collectionId]);
 };
 
 export const getAllCollectionsWithStats = async (options: CollectionStatsOptions = {}): Promise<Collection[]> => {
@@ -531,7 +599,13 @@ export const getAllCollectionsWithStats = async (options: CollectionStatsOptions
     if (includeThumbnails) {
         const thumbnailStartedAt = nowMs();
         const thumbnailInputs = mappedCollections
-            .filter(collection => !collection.filters || !!collection.customThumbnail)
+            .filter(collection => {
+                if (collection.customThumbnail) return true;
+                if (collection.filters || collection.thumbnail) return false;
+
+                const imageCount = collection.count ?? collection.imageIds.length;
+                return imageCount > 0;
+            })
             .map(collection => ({
                 id: collection.id,
                 custom_thumbnail: collection.customThumbnail ?? null

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -15,6 +15,11 @@ import {
 import { isBrowserMockMode } from '../runtime';
 import { getBrowserMockImages, updateBrowserMockImage } from '../browserMockData';
 import { clearLibraryStatsCache } from './searchRepo';
+import {
+    clearAllCollectionThumbnailCaches,
+    clearCollectionThumbnailCacheForCollections,
+    clearCollectionThumbnailCacheForImages,
+} from './collectionRepo';
 import { scanImageNative } from '../metadataParser';
 
 type PersistableImageRecord = {
@@ -157,6 +162,7 @@ const persistImageRecords = async (
         cleanupCandidates: defaultVisibleIds.length,
         cleanupMs: elapsedMs(cleanupStartedAt)
     });
+    await clearCollectionThumbnailCacheForImages(records.map(record => record.id));
 };
 
 const clearFacetRelatedStatsCache = async () => {
@@ -223,6 +229,7 @@ export const insertImage = async (image: AIImage) => {
                 'INSERT OR IGNORE INTO collection_images (collection_id, image_id) VALUES (?, ?)',
                 [image.boardId, record.id]
             );
+            await clearCollectionThumbnailCacheForCollections([image.boardId]);
         }
     });
 };
@@ -434,6 +441,11 @@ export const syncCollectionImages = async (ids?: string[]) => {
         }
 
         await db.execute(query, params);
+        if (ids && ids.length > 0) {
+            await clearCollectionThumbnailCacheForImages(ids);
+        } else {
+            await clearAllCollectionThumbnailCaches();
+        }
         console.log('[DB] Bulk collection sync complete.');
     });
 };
@@ -752,6 +764,7 @@ export const toggleImagePin = async (id: string, isPinned: boolean) => {
     const db = await getDb();
     const normalizedId = normalizePath(id);
     await db.execute('UPDATE images SET is_pinned = $1 WHERE id = $2', [isPinned ? 1 : 0, normalizedId]);
+    await clearCollectionThumbnailCacheForImages([normalizedId]);
     // Note: Asset thumbnails update via facet cache rebuild, not on individual pins.
 };
 
@@ -779,6 +792,7 @@ export const toggleImageMask = async (id: string, userMasked: boolean | null) =>
     if (userMasked === false) value = 0;
 
     await db.execute('UPDATE images SET user_masked = $1 WHERE id = $2', [value, normalizedId]);
+    await clearCollectionThumbnailCacheForImages([normalizedId]);
 };
 
 export const toggleImageIntermediate = async (id: string, isIntermediate: boolean) => {
@@ -810,6 +824,7 @@ export const deleteImage = async (id: string) => {
 
     const db = await getDb();
     const normalizedId = normalizePath(id);
+    await clearCollectionThumbnailCacheForImages([normalizedId]);
     await db.execute('DELETE FROM collection_images WHERE image_id = $1', [normalizedId]);
     await db.execute('DELETE FROM image_loras WHERE image_id = $1', [normalizedId]);
     await db.execute('DELETE FROM image_embeddings WHERE image_id = $1', [normalizedId]);
@@ -909,6 +924,7 @@ export const removeImagesFromLibrary = async (ids: string[]) => {
         }
 
         console.info('[Repo] removeImagesFromLibrary: cleaning related tables', { count: normalizedIds.length });
+        await clearCollectionThumbnailCacheForImages(normalizedIds);
         for (const chunk of chunkItems(normalizedIds)) {
             const placeholders = chunk.map(() => '?').join(',');
             await db.execute(`DELETE FROM collection_images WHERE image_id IN (${placeholders})`, chunk);
@@ -952,6 +968,7 @@ export const restoreRemovedImages = async (ids: string[]) => {
             totalMs: elapsedMs(restoreStartedAt)
         });
 
+        const restoredCollectionIds: string[] = [];
         for (const row of rows) {
             if (!row.collection_ids_json) continue;
 
@@ -964,12 +981,14 @@ export const restoreRemovedImages = async (ids: string[]) => {
                          WHERE EXISTS (SELECT 1 FROM collections WHERE id = ?)`,
                         [collectionId, row.id, collectionId]
                     );
+                    restoredCollectionIds.push(collectionId);
                 }
             } catch (error) {
                 console.warn('[DB] Failed to restore collection membership for removed image', row.id, error);
             }
         }
 
+        await clearCollectionThumbnailCacheForCollections(restoredCollectionIds);
         await removeTombstones(db, normalizedIds);
     });
 };
@@ -1088,6 +1107,7 @@ export const markAsDeleted = async (ids: string[], deleted: boolean) => {
     const db = await getDb();
     const placeholders = normalizedIds.map(() => '?').join(',');
     await db.execute(`UPDATE images SET is_deleted = ? WHERE id IN (${placeholders})`, [deleted ? 1 : 0, ...normalizedIds]);
+    await clearCollectionThumbnailCacheForImages(normalizedIds);
 };
 
 export const updateImageWorkflow = async (id: string, workflowJson: string): Promise<void> => {
@@ -1163,6 +1183,7 @@ export const updatePinned = async (id: string, isPinned: boolean) => {
     const db = await getDb();
     const normalizedId = normalizePath(id);
     await db.execute('UPDATE images SET is_pinned = ? WHERE id = ?', [isPinned ? 1 : 0, normalizedId]);
+    await clearCollectionThumbnailCacheForImages([normalizedId]);
 };
 export const updateImagesBoard = async (ids: string[], boardId: string | null) => {
     if (ids.length === 0) return;
@@ -1187,6 +1208,7 @@ export const updateImagesBoard = async (ids: string[], boardId: string | null) =
         // but since board_id was 1:N, we should probably remove it from any 'invoke' source collections?
         // Actually, a simpler approach is to use the dedicated collection removal tools for manual changes.
     }
+    await clearCollectionThumbnailCacheForImages(normalizedIds);
 };
 
 /**
@@ -1249,6 +1271,9 @@ export const clearAllThumbnailPaths = async (): Promise<number> => {
                     'UPDATE images SET thumbnail_path = NULL, micro_thumbnail = NULL, thumbnail_source = NULL, thumbnail_version = 0, thumbnail_failure_count = 0, thumbnail_last_error = NULL, thumbnail_last_attempt_at = NULL WHERE thumbnail_path IS NOT NULL AND thumbnail_path != ""'
                 );
                 console.log('[DB] Cleared thumbnail paths:', result.rowsAffected);
+                if (result.rowsAffected > 0) {
+                    await clearAllCollectionThumbnailCaches();
+                }
                 return result.rowsAffected;
             } catch (e: unknown) {
                 const errorMsg = e instanceof Error ? e.message : String(e);
@@ -1283,6 +1308,7 @@ export const updateThumbnailPath = async (id: string, thumbnailPath: string): Pr
         'UPDATE images SET thumbnail_path = ?, thumbnail_source = ?, thumbnail_version = 1, thumbnail_failure_count = 0, thumbnail_last_error = NULL, thumbnail_last_attempt_at = NULL WHERE id = ?',
         [normalizedThumb, 'ambit', normalizedId]
     );
+    await clearCollectionThumbnailCacheForImages([normalizedId]);
 };
 
 /**
@@ -1359,6 +1385,7 @@ export const updateThumbnailPathsBatch = async (updates: {
     if (failCount > 0) {
         console.warn(`[DB] ${failCount} thumbnail updates failed`);
     }
+    await clearCollectionThumbnailCacheForImages(updates.map(update => update.id));
 };
 
 

--- a/src/stores/__tests__/collectionStore.test.ts
+++ b/src/stores/__tests__/collectionStore.test.ts
@@ -807,6 +807,112 @@ describe('collectionStore smart count refresh', () => {
         }));
     });
 
+    it('skips cached dynamic collection thumbnails during refresh', async () => {
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    makeStaticCollection({
+                        id: 'cached-static',
+                        count: 4,
+                        thumbnail: 'asset://cached.webp',
+                        safeThumbnail: 'asset://cached-safe.webp',
+                        thumbnailIsSensitive: true,
+                        thumbnailSourceKind: 'dynamic'
+                    })
+                ],
+                isLoaded: true
+            });
+        });
+
+        await useCollectionStore.getState().refreshCollectionThumbnails();
+
+        expect(mockGetCollectionThumbnailSummaries).not.toHaveBeenCalled();
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({});
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            thumbnail: 'asset://cached.webp',
+            safeThumbnail: 'asset://cached-safe.webp',
+            thumbnailIsSensitive: true,
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('can force refresh cached dynamic thumbnails after thumbnail mutations', async () => {
+        mockGetCollectionThumbnailSummaries.mockResolvedValue({
+            'cached-static': {
+                thumbnail: 'asset://fresh.webp',
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    makeStaticCollection({
+                        id: 'cached-static',
+                        count: 4,
+                        thumbnail: 'asset://cached.webp',
+                        thumbnailSourceKind: 'dynamic'
+                    })
+                ],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshCollectionThumbnails(false, true);
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({
+            'cached-static': true
+        });
+        await refreshPromise;
+
+        expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'cached-static' })
+        ]);
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            thumbnail: 'asset://fresh.webp',
+            thumbnailSourceKind: 'dynamic'
+        }));
+    });
+
+    it('refreshes custom thumbnails even when a display thumbnail already exists', async () => {
+        mockGetCollectionThumbnailSummaries.mockResolvedValue({
+            'custom-static': {
+                thumbnail: 'asset://custom-fresh.webp',
+                thumbnailSourceKind: 'customImage'
+            }
+        });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    makeStaticCollection({
+                        id: 'custom-static',
+                        count: 0,
+                        customThumbnail: 'img-custom',
+                        thumbnail: 'asset://custom-stale.webp',
+                        thumbnailSourceKind: 'customImage'
+                    })
+                ],
+                isLoaded: true
+            });
+        });
+
+        const refreshPromise = useCollectionStore.getState().refreshCollectionThumbnails();
+
+        expect(useCollectionStore.getState().thumbnailHydrationPendingIds).toEqual({
+            'custom-static': true
+        });
+        await refreshPromise;
+
+        expect(mockGetCollectionThumbnailSummaries).toHaveBeenCalledWith([
+            expect.objectContaining({ id: 'custom-static', customThumbnail: 'img-custom' })
+        ]);
+        expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            thumbnail: 'asset://custom-fresh.webp',
+            thumbnailSourceKind: 'customImage'
+        }));
+    });
+
     it('hydrates Invoke board collection thumbnails from derived summaries', async () => {
         mockGetCollectionThumbnailSummaries.mockResolvedValue({
             'invoke-board-1': {
@@ -908,6 +1014,17 @@ describe('collectionStore smart count refresh', () => {
                         source: 'ambit',
                         count: 1,
                         imageIds: []
+                    },
+                    {
+                        id: 'cached-static',
+                        name: 'Cached Static',
+                        createdAt: 3,
+                        updatedAt: 3,
+                        source: 'ambit',
+                        count: 1,
+                        imageIds: [],
+                        thumbnail: 'asset://cached.webp',
+                        thumbnailSourceKind: 'dynamic'
                     }
                 ],
                 isLoaded: true

--- a/src/stores/collectionStore.ts
+++ b/src/stores/collectionStore.ts
@@ -39,12 +39,20 @@ const chunk = <T,>(items: T[], size: number): T[][] => {
     return chunks;
 };
 
-const shouldShowThumbnailHydrationPending = (collection: Collection): boolean => {
-    if (collection.filters || collection.thumbnail) return false;
+const shouldShowThumbnailHydrationPending = (collection: Collection, force = false): boolean => {
+    if (collection.filters) return false;
+    if (collection.customThumbnail) return true;
 
     const imageCount = collection.count ?? collection.imageIds.length;
-    return imageCount > 0 || !!collection.customThumbnail;
+    if (force) return imageCount > 0;
+    if (collection.thumbnail) return false;
+
+    return imageCount > 0;
 };
+
+const shouldHydrateCollectionThumbnail = (collection: Collection, force = false): boolean => (
+    shouldShowThumbnailHydrationPending(collection, force)
+);
 
 const sortForThumbnailHydration = (collections: Collection[]): Collection[] => (
     [...collections].sort((a, b) => {
@@ -53,10 +61,10 @@ const sortForThumbnailHydration = (collections: Collection[]): Collection[] => (
     })
 );
 
-const buildPendingThumbnailMap = (collections: Collection[]): Record<string, true> => (
+const buildPendingThumbnailMap = (collections: Collection[], force = false): Record<string, true> => (
     Object.fromEntries(
         collections
-            .filter(shouldShowThumbnailHydrationPending)
+            .filter(collection => shouldShowThumbnailHydrationPending(collection, force))
             .map(collection => [collection.id, true] as const)
     )
 );
@@ -81,7 +89,7 @@ interface CollectionState {
     // Actions
     initialize: () => Promise<void>;
     refreshCollections: (debounced?: boolean) => Promise<void>;
-    refreshCollectionThumbnails: (debounced?: boolean) => Promise<void>;
+    refreshCollectionThumbnails: (debounced?: boolean, force?: boolean) => Promise<void>;
     refreshSmartCounts: (input?: RefreshSmartCountsInput) => Promise<void>;
     setCollections: (collections: Collection[] | ((prev: Collection[]) => Collection[])) => void;
 }
@@ -127,14 +135,14 @@ export const useCollectionStore = create<CollectionState>()(
                 }
             },
 
-            refreshCollectionThumbnails: async (debounced = false) => {
+            refreshCollectionThumbnails: async (debounced = false, force = false) => {
                 const run = async () => {
                     const runId = ++thumbnailRefreshRunId;
                     try {
                         const currentCollections = sortForThumbnailHydration(
-                            get().collections.filter(collection => !collection.filters)
+                            get().collections.filter(collection => shouldHydrateCollectionThumbnail(collection, force))
                         );
-                        set({ thumbnailHydrationPendingIds: buildPendingThumbnailMap(currentCollections) });
+                        set({ thumbnailHydrationPendingIds: buildPendingThumbnailMap(currentCollections, force) });
 
                         if (currentCollections.length === 0) return;
 


### PR DESCRIPTION
## Summary
- reuse cached collection thumbnail fields during normal startup hydration
- replace repeated dynamic cover subqueries with one ranked collection thumbnail query
- clear collection thumbnail cache when cover-affecting image or collection state changes
- preserve custom thumbnail behavior and clear stale dynamic cache when resetting custom thumbnails

## Why
Startup was repeatedly spending tens of seconds computing collection covers for large libraries, even when cached dynamic thumbnail fields already existed. This keeps startup predictable while preserving pinned-first, newest-next, deleted-excluded, and privacy-safe cover behavior.

## Validation
- `pnpm run test:run -- src/services/db/__tests__/collectionRepo.test.ts src/stores/__tests__/collectionStore.test.ts src/services/db/__tests__/imageRepo.test.ts`
- `pnpm run test:run -- src/services/db/__tests__/collectionRepo.test.ts`
- `pnpm run typecheck`
- `git diff --check`

Manual large-library timing still needs confirmation in Ambit.