### PR TITLE
[codex] Improve ImageViewer like and pin feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -334,6 +334,7 @@ export default function App() {
         filteredImages: images,
         lastSelectedId,
         selectedImageIndex,
+        isViewerOpen: viewingImageId !== null || selectedImageIndex !== null,
         gridRef,
         searchInputRef: inputRef,
         setSelectedImageIndex,
@@ -568,8 +569,8 @@ export default function App() {
                             onUpdateNegativePrompt={(id, neg) => handlers.handleUpdateNegativePrompt(id, neg)}
                             onUpdateModel={(id, model) => handlers.handleUpdateModel(id, model)}
                             onUpdateTool={(id, tool) => handlers.handleUpdateTool(id, tool)}
-                            onToggleFavorite={(id) => toggleFavorite(id)}
-                            onTogglePin={(id, p) => actions.handlePinImage(id, p)}
+                            onToggleFavorite={(id) => actions.handleFavoriteImage(id, { showToast: false })}
+                            onTogglePin={(id, p) => actions.handlePinImage(id, p, { showToast: false })}
                             onDelete={(id) => actions.handleDeleteViewerImage(id)}
                             onOpenSettings={() => { modals.setInitialSettingsTab('intelligence'); modals.openModal('settings'); }}
                             onUpdateNotes={(id, n) => handlers.handleUpdateNotes(id, n)}

--- a/src/features/viewer/components/ImageViewer.tsx
+++ b/src/features/viewer/components/ImageViewer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { useEffect, useState, useRef, useMemo } from 'react';
+import { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import { X, Share2, Minimize2, Maximize2, Heart, Trash2, PanelRightClose, PanelRightOpen, Copy, Wand2, Shuffle, Layers, ArrowRight, Layout, ExternalLink } from 'lucide-react';
+import { Heart, Pin } from 'lucide-react';
 import { AIImage, GeneratorTool } from '../../../types';
 import { useZoomPan } from '../../../hooks/useZoomPan';
 import { ImageCanvas } from './ImageCanvas';
@@ -45,6 +45,58 @@ interface ImageViewerProps {
 import { AIResultModal } from './AIResultModal';
 import { ViewerToolbar } from './ViewerToolbar';
 import { VersionSelector } from './VersionSelector';
+
+interface ViewerStatusHudProps {
+    isFavorite: boolean;
+    isPinned: boolean;
+    isVisible: boolean;
+}
+
+const ViewerStatusHud: React.FC<ViewerStatusHudProps> = ({ isFavorite, isPinned, isVisible }) => {
+    const statuses = [
+        {
+            key: 'favorite',
+            active: isFavorite,
+            Icon: Heart,
+            activeClass: 'border-red-400/40 bg-red-500/15 text-red-400 shadow-red-950/30',
+            inactiveClass: 'border-white/10 bg-black/30 text-white/35',
+            iconClass: isFavorite ? 'fill-current' : '',
+        },
+        {
+            key: 'pin',
+            active: isPinned,
+            Icon: Pin,
+            activeClass: 'border-sage-400/40 bg-sage-500/15 text-sage-300 shadow-sage-950/30',
+            inactiveClass: 'border-white/10 bg-black/30 text-white/35',
+            iconClass: isPinned ? 'fill-current' : '',
+        },
+    ];
+
+    if (!isVisible && !isFavorite && !isPinned) return null;
+
+    const label = [
+        isFavorite ? 'liked' : 'not liked',
+        isPinned ? 'pinned' : 'not pinned',
+    ].join(', ');
+
+    return (
+        <div
+            className="absolute bottom-8 right-8 z-20 flex items-center gap-2 pointer-events-none transition-opacity duration-300"
+            role="status"
+            aria-live="polite"
+            aria-label={label}
+        >
+            {statuses.map(({ key, active, Icon, activeClass, inactiveClass, iconClass }) => (
+                <div
+                    key={key}
+                    className={`flex h-8 w-8 items-center justify-center rounded-full border backdrop-blur-md shadow-lg transition-all duration-300 ${active ? activeClass : inactiveClass} ${isVisible || active ? 'opacity-100 scale-100' : 'opacity-0 scale-100'}`}
+                >
+                    <Icon className={`h-4 w-4 ${iconClass}`} />
+                </div>
+            ))}
+        </div>
+    );
+};
 
 export const ImageViewer: React.FC<ImageViewerProps> = ({
     image,
@@ -142,7 +194,9 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
     const [activeTab, setActiveTab] = useState<'info' | 'edit' | 'workflow'>('info');
     const [isTheaterMode, setIsTheaterMode] = useState(false);
     const [showControls, setShowControls] = useState(true);
+    const [showStatusHud, setShowStatusHud] = useState(true);
     const controlsTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const statusHudTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // --- Buffers (Notes/Prompt editing local to displayImage) ---
     const [notes, setNotes] = useState(displayImage.notes || '');
@@ -170,6 +224,29 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
         });
     }, [displayImage.url]);
 
+    const revealStatusHud = useCallback((duration = 1600) => {
+        setShowStatusHud(true);
+        if (statusHudTimeoutRef.current) clearTimeout(statusHudTimeoutRef.current);
+        statusHudTimeoutRef.current = setTimeout(() => setShowStatusHud(false), duration);
+    }, []);
+
+    useEffect(() => {
+        revealStatusHud();
+        return () => {
+            if (statusHudTimeoutRef.current) clearTimeout(statusHudTimeoutRef.current);
+        };
+    }, [displayImage.id, revealStatusHud]);
+
+    const handleToggleFavorite = useCallback(() => {
+        onToggleFavorite(displayImage.id);
+        revealStatusHud(2000);
+    }, [displayImage.id, onToggleFavorite, revealStatusHud]);
+
+    const handleTogglePin = useCallback(() => {
+        onTogglePin?.(displayImage.id, !displayImage.isPinned);
+        revealStatusHud(2000);
+    }, [displayImage.id, displayImage.isPinned, onTogglePin, revealStatusHud]);
+
     // Theater Mode Controls Auto-Hide
     useEffect(() => {
         if (isSidebarOpen && !isTheaterMode) {
@@ -195,8 +272,8 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
             if (e.key === 'ArrowLeft') onPrev();
 
             // Actions
-            if (key === 'f') onToggleFavorite(displayImage.id);
-            if (key === 'p') onTogglePin?.(displayImage.id, !displayImage.isPinned);
+            if (key === 'f') handleToggleFavorite();
+            if (key === 'p') handleTogglePin();
             if (key === 'i') onToggleSidebar?.();
 
             if (e.key === 'Escape') {
@@ -208,7 +285,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
         };
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [isOpen, ai.modalOpen, isTheaterMode, onNext, onPrev, onToggleFavorite, onTogglePin, onToggleSidebar, displayImage, onClose]);
+    }, [isOpen, ai.modalOpen, isTheaterMode, onNext, onPrev, handleToggleFavorite, handleTogglePin, onToggleSidebar, onClose]);
 
     if (!isOpen) return null;
 
@@ -265,7 +342,8 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                     onOpenExternal={handleOpenExternal}
                     onToggleTheater={() => setIsTheaterMode(!isTheaterMode)}
                     onShare={handleShare}
-                    onToggleFavorite={() => onToggleFavorite(displayImage.id)}
+                    onToggleFavorite={handleToggleFavorite}
+                    onTogglePin={onTogglePin ? handleTogglePin : undefined}
                     onDelete={onDelete ? () => onDelete(displayImage.id) : undefined}
                     onToggleSidebar={onToggleSidebar}
                     onClose={onClose}
@@ -286,6 +364,12 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                     isTheaterMode={isTheaterMode}
                     onToggleTheater={() => setIsTheaterMode(!isTheaterMode)}
                     handlers={handlers}
+                />
+
+                <ViewerStatusHud
+                    isFavorite={Boolean(displayImage.isFavorite)}
+                    isPinned={Boolean(displayImage.isPinned)}
+                    isVisible={showStatusHud}
                 />
 
                 <VersionSelector

--- a/src/features/viewer/components/ViewerToolbar.tsx
+++ b/src/features/viewer/components/ViewerToolbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { X, Share2, Heart, Trash2, PanelRightClose, PanelRightOpen, Copy, Layout, ExternalLink } from 'lucide-react';
+import { X, Share2, Heart, Pin, Trash2, PanelRightClose, PanelRightOpen, Copy, Layout, ExternalLink } from 'lucide-react';
 import { getFilename } from '../../../utils/pathUtils';
 import { AIImage } from '../../../types';
 
@@ -15,6 +15,7 @@ interface ViewerToolbarProps {
     onToggleTheater: () => void;
     onShare: () => void;
     onToggleFavorite: () => void;
+    onTogglePin?: () => void;
     onDelete?: () => void;
     onToggleSidebar?: () => void;
     onClose: () => void;
@@ -32,6 +33,7 @@ export const ViewerToolbar: React.FC<ViewerToolbarProps> = ({
     onToggleTheater,
     onShare,
     onToggleFavorite,
+    onTogglePin,
     onDelete,
     onToggleSidebar,
     onClose
@@ -86,6 +88,15 @@ export const ViewerToolbar: React.FC<ViewerToolbarProps> = ({
                 >
                     <Heart className={`w-5 h-5 ${image.isFavorite ? 'fill-red-500 text-red-500' : ''}`} />
                 </button>
+                {onTogglePin && (
+                    <button
+                        onClick={onTogglePin}
+                        className={`p-2.5 bg-black/50 hover:bg-white/10 border border-white/5 hover:border-white/20 rounded-full transition-all backdrop-blur-md shadow-lg ${image.isPinned ? 'text-sage-400 border-sage-500/50' : 'text-white/50 hover:text-white'}`}
+                        title={image.isPinned ? "Unpin (P)" : "Pin to top (P)"}
+                    >
+                        <Pin className={`w-5 h-5 ${image.isPinned ? 'fill-current' : ''}`} />
+                    </button>
+                )}
                 {onDelete && (
                     <button
                         onClick={onDelete}

--- a/src/hooks/__tests__/useAppActions.test.tsx
+++ b/src/hooks/__tests__/useAppActions.test.tsx
@@ -140,6 +140,28 @@ describe('useAppActions', () => {
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Favorited'), 'success');
     });
 
+    it('should toggle a viewer favorite without a success toast', () => {
+        const { result } = renderHook(() => useAppActions(props));
+
+        act(() => {
+            result.current.handleFavoriteImage('1');
+        });
+
+        expect(mockToggleFavorite).toHaveBeenCalledWith('1');
+        expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
+    it('should toggle a viewer unfavorite without a success toast', () => {
+        const { result } = renderHook(() => useAppActions(props));
+
+        act(() => {
+            result.current.handleFavoriteImage('2');
+        });
+
+        expect(mockToggleFavorite).toHaveBeenCalledWith('2');
+        expect(mockAddToast).not.toHaveBeenCalled();
+    });
+
     it('should handle bulk pin and refresh thumbnails', async () => {
         const { result } = renderHook(() => useAppActions(props));
 
@@ -150,6 +172,28 @@ describe('useAppActions', () => {
         expect(mockSetImages).toHaveBeenCalled();
         expect(mockRefreshCollections).toHaveBeenCalledWith(true);
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Pinned'), 'info');
+    });
+
+    it('should keep single-image pin feedback outside the viewer path', async () => {
+        const { result } = renderHook(() => useAppActions(props));
+
+        await act(async () => {
+            result.current.handlePinImage('1', true);
+        });
+
+        expect(mockSetImages).toHaveBeenCalled();
+        expect(mockAddToast).toHaveBeenCalledWith('Pinned to top', 'info');
+    });
+
+    it('should toggle a viewer pin without a success toast', async () => {
+        const { result } = renderHook(() => useAppActions(props));
+
+        await act(async () => {
+            result.current.handlePinImage('1', true, { showToast: false });
+        });
+
+        expect(mockSetImages).toHaveBeenCalled();
+        expect(mockAddToast).not.toHaveBeenCalled();
     });
 
     it('should show the bulk pin toast without waiting for collection refresh', async () => {

--- a/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -30,6 +30,7 @@ describe('useGlobalShortcuts', () => {
         filteredImages: [],
         lastSelectedId: null,
         selectedImageIndex: null,
+        isViewerOpen: false,
         gridRef: { current: null },
         searchInputRef: { current: null },
         isModalOpen: false,
@@ -53,6 +54,16 @@ describe('useGlobalShortcuts', () => {
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
 
         expect(mockActions.toggleFavorite).toHaveBeenCalled();
+    });
+
+    it('should let the viewer own favorite and pin shortcuts while open', () => {
+        renderHook(() => useGlobalShortcuts({ ...defaultProps, isViewerOpen: true, selectedImageIndex: 0 }));
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'f' }));
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+
+        expect(mockActions.toggleFavorite).not.toHaveBeenCalled();
+        expect(mockActions.togglePin).not.toHaveBeenCalled();
     });
 
     it('should block actions when a modal is open', () => {

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -39,6 +39,10 @@ interface UseAppActionsProps {
     modalManager: AppActionModalManager; // Renamed from modals
 }
 
+interface SingleImageActionOptions {
+    showToast?: boolean;
+}
+
 export const useAppActions = ({
     viewingImageId,
     selectedImageIndex,
@@ -136,6 +140,17 @@ export const useAppActions = ({
         });
 
         addToast(`${anyUnfavorite ? 'Favorited' : 'Unfavorited'} ${selectedIds.size} images`, 'success');
+    };
+
+    const handleFavoriteImage = (id: string, options: SingleImageActionOptions = {}) => {
+        const img = images.find(i => i.id === id);
+        if (!img) return;
+
+        const newFavorite = !img.isFavorite;
+        void toggleFavorite(id);
+        if (options.showToast) {
+            addToast(newFavorite ? "Liked" : "Unliked", newFavorite ? "success" : "info");
+        }
     };
 
     const handleBulkPin = () => {
@@ -248,7 +263,7 @@ export const useAppActions = ({
         fileOps.recoverMetadata(targetId, style, () => closeModal('recovery'));
     };
 
-    const handlePinImage = (id: string, newPinned: boolean) => {
+    const handlePinImage = (id: string, newPinned: boolean, options: SingleImageActionOptions = { showToast: true }) => {
         const previousImages = images;
 
         setImages(prev => {
@@ -263,14 +278,16 @@ export const useAppActions = ({
             return updated;
         });
 
-        addToast(newPinned ? "Pinned to top" : "Unpinned", "info");
+        if (options.showToast !== false) {
+            addToast(newPinned ? "Pinned to top" : "Unpinned", "info");
+        }
         void persistPinChanges([id], newPinned, previousImages, 'Failed to update pinned state');
         // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
     };
 
     const handleShortcutFavorite = () => {
         if (selectedImageIndex !== null && images[selectedImageIndex]) {
-            toggleFavorite(images[selectedImageIndex].id);
+            handleFavoriteImage(images[selectedImageIndex].id);
         } else {
             handleBulkFavorite();
         }
@@ -306,6 +323,7 @@ export const useAppActions = ({
         handleBulkMask,
         handleTogglePrivacy,
         executeMetadataRecovery,
+        handleFavoriteImage,
         handlePinImage,
         handleShortcutFavorite,
         handleShortcutPin,

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -10,6 +10,7 @@ interface GlobalShortcutsProps {
     filteredImages: AIImage[];
     lastSelectedId: string | null;
     selectedImageIndex: number | null;
+    isViewerOpen: boolean;
     gridRef: React.RefObject<VirtualGridHandle | null>;
     searchInputRef: React.RefObject<HTMLInputElement | null>;
 
@@ -41,6 +42,7 @@ export const useGlobalShortcuts = ({
     filteredImages,
     lastSelectedId,
     selectedImageIndex,
+    isViewerOpen,
     gridRef,
     searchInputRef,
     setSelectedImageIndex,
@@ -140,12 +142,14 @@ export const useGlobalShortcuts = ({
 
             // 6. Action Shortcuts
             if (e.key === 'f' || e.key === 'F') {
+                if (isViewerOpen) return;
                 e.preventDefault();
                 toggleFavorite();
                 return;
             }
 
             if (e.key === 'p' || e.key === 'P') {
+                if (isViewerOpen) return;
                 e.preventDefault();
                 togglePin();
                 return;
@@ -234,6 +238,7 @@ export const useGlobalShortcuts = ({
         selectedIds,
         viewMode,
         selectedImageIndex,
+        isViewerOpen,
         lastSelectedId,
         isModalOpen,
         toggleShortcuts,


### PR DESCRIPTION
## Summary
- add a pinned-state control to the ImageViewer toolbar beside favorite
- add a compact fixed-slot Heart/Pin HUD for viewer-local state feedback
- suppress single-image viewer success toasts while preserving bulk/non-viewer feedback
- prevent global F/P shortcuts from double-handling while ImageViewer is open

## Why
The ImageViewer toolbar auto-hides to keep the image-first experience clean. Keyboard users still need reliable feedback for favorite and pin state, but duplicate toasts plus HUD feedback felt noisy. This separates the surfaces: toolbar for controls, HUD for viewer-local state, toasts for bulk and failure feedback.

## Validation
- pnpm run typecheck
- pnpm run test:run -- useAppActions useGlobalShortcuts
- git diff --check
- Browser QA at http://127.0.0.1:1421/: verified toolbar Heart/Pin controls, HUD updates for F/P and toolbar clicks, fixed HUD slot positions, no viewer success toasts, and no console warnings/errors

Note: Browser screenshot capture timed out in the in-app Browser API, so rendered QA evidence was DOM/state based.