### PR TITLE
feat: persist gallery layout mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,6 @@ export default function App() {
 
     // --- Interaction State ---
     const [viewMode, setViewMode] = useState<ViewMode>('grid');
-    const [layoutMode, setLayoutMode] = useState<LayoutMode>('masonry');
     const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(true);
     const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
     const [viewingImageId, setViewingImageId] = useState<string | null>(null);
@@ -97,6 +96,7 @@ export default function App() {
     // const setRecentSearches = useSearchStore(s => s.setRecentSearches);
 
     const isLoaded = isSettingsLoaded && isCollectionsLoaded;
+    const layoutMode = settings.libraryLayoutMode ?? 'masonry';
     const updater = useAppUpdater({
         addToast,
         autoCheckEnabled: settings.autoCheckForUpdates !== false,
@@ -238,6 +238,10 @@ export default function App() {
         setViewMode(newMode);
         clearSelection();
     }, [viewMode, clearSelection]);
+
+    const setLayoutMode = useCallback((mode: LayoutMode) => {
+        setSettings(prev => ({ ...prev, libraryLayoutMode: mode }));
+    }, [setSettings]);
 
     const handleLayoutChange = useCallback((c: number, h: number) => {
         setGridLayout(prev => {

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -66,7 +66,7 @@ interface AppLayoutProps {
     changeViewMode: (mode: ViewMode) => void;
     searchProps: React.ComponentProps<typeof AppHeader>['searchProps'];
     layoutMode: LayoutMode;
-    setLayoutMode: React.Dispatch<React.SetStateAction<LayoutMode>>;
+    setLayoutMode: (mode: LayoutMode) => void;
     sortOption: SortOption;
     setSortOption: (opt: SortOption) => void;
     totalImages: number;

--- a/src/features/library/components/__tests__/ViewControls.test.tsx
+++ b/src/features/library/components/__tests__/ViewControls.test.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ViewControls } from '../ViewControls';
+
+const setFilters = vi.fn();
+const setSortOption = vi.fn();
+
+vi.mock('../../../../contexts/SearchContext', () => ({
+    useSearch: () => ({
+        availableHiddenContent: { hasIntermediates: false, hasGrids: false },
+        filters: { showIntermediates: false, showGrids: false },
+        setFilters,
+        sortOption: 'date_desc',
+        setSortOption
+    })
+}));
+
+const renderViewControls = (setLayoutMode = vi.fn()) => {
+    render(
+        <ViewControls
+            showLayoutSwitcher
+            layoutMode="masonry"
+            setLayoutMode={setLayoutMode}
+            showSlideshowButton={false}
+            onSlideshow={vi.fn()}
+            sortOption="date_desc"
+            setSortOption={vi.fn()}
+            thumbnailSize={200}
+            setThumbnailSize={vi.fn()}
+            displayedCount={10}
+            totalCount={10}
+            scopeName="Library"
+        />
+    );
+    return setLayoutMode;
+};
+
+describe('ViewControls', () => {
+    it('selects the requested gallery layout mode', () => {
+        const setLayoutMode = renderViewControls();
+
+        fireEvent.click(screen.getByTitle('Justified Layout'));
+
+        expect(setLayoutMode).toHaveBeenCalledWith('justified');
+    });
+});

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -37,6 +37,7 @@ describe('SettingsStore', () => {
                 maskedKeywords: ['nsfw', 'blood', 'gore'],
                 maskingMode: 'blur',
                 enableAI: false,
+                libraryLayoutMode: 'masonry',
                 hideImportModal: false
             }
         });
@@ -67,6 +68,22 @@ describe('SettingsStore', () => {
 
         expect(useSettingsStore.getState().settings.enableAutoThumbnailHealing).toBe(true);
         expect(useSettingsStore.getState().settings.enforceHighQualityThumbnails).toBe(false);
+    });
+
+    it('should default gallery layout mode to masonry', async () => {
+        (appRepository.load as any).mockResolvedValue({ settings: {} });
+
+        await useSettingsStore.getState().initialize();
+
+        expect(useSettingsStore.getState().settings.libraryLayoutMode).toBe('masonry');
+    });
+
+    it('should preserve persisted gallery layout mode on initialize', async () => {
+        (appRepository.load as any).mockResolvedValue({ settings: { libraryLayoutMode: 'justified' } });
+
+        await useSettingsStore.getState().initialize();
+
+        expect(useSettingsStore.getState().settings.libraryLayoutMode).toBe('justified');
     });
 
     it('should migrate legacy API key from library.json to keyring', async () => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -37,6 +37,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     syncBoardsToCollections: false,
     importOrphans: true,
     starredAs: 'favorite',
+    libraryLayoutMode: 'masonry',
     resourceViewModes: {},
     hideImportModal: false,
     enableAutoThumbnailHealing: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,7 @@ export interface AppSettings {
   importOrphans?: boolean; // New: Option to scan for files not in DB
   invokeDbSnapshot?: InvokeDbSnapshotState; // Internal: last known InvokeAI DB/WAL/SHM file snapshot for startup no-op skips
   starredAs?: 'favorite' | 'pin' | 'both' | 'none'; // New: Map starred images to favorites, pins, or both
+  libraryLayoutMode?: LayoutMode; // Persisted gallery layout preference
   libraryShowGrids?: boolean; // Persisted view preference
   libraryShowIntermediates?: boolean; // Persisted view preference
   resourceFolders?: string[]; // New: Folders to scan for resources (models/loras)


### PR DESCRIPTION
## Summary

- Persist the main gallery layout choice globally in app settings
- Default missing legacy settings to masonry
- Add focused tests for default/persisted settings and the layout control callback

## Why

Users who prefer grid or justified layout should not have to switch away from the default masonry layout after every app restart.

## Validation

- `pnpm run test:run -- settingsStore ViewControls`
- `pnpm run typecheck`
- `pnpm run lint`