### PR TITLE
[codex] Fix optimistic pin cache ordering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,7 @@ export default function App() {
 
     const {
         images, setImages,
+        imagesQueryKey,
         filters, setFilters,
         sortOption, setSortOption,
         totalImages, globalTotal,
@@ -158,6 +159,7 @@ export default function App() {
         selectedIds,
         setSelectedIds,
         lastSelectedId,
+        imagesQueryKey,
         modalManager: modals
     });
 

--- a/src/components/ui/AppContextMenu.tsx
+++ b/src/components/ui/AppContextMenu.tsx
@@ -4,7 +4,6 @@ import { useToast } from '../../hooks/useToast';
 import { isImageMasked } from '../../utils/maskingUtils';
 import { useSettingsStore } from '../../stores/settingsStore';
 import { useCollectionStore } from '../../stores/collectionStore';
-import { useSearchStore } from '../../stores/searchStore';
 import { AIImage, ContextMenuState, FilterState } from '../../types';
 import { useQueryClient } from '@tanstack/react-query';
 import { isBrowserMockMode } from '../../services/runtime';
@@ -43,7 +42,6 @@ export const AppContextMenu: React.FC<AppContextMenuProps> = ({
     const settings = useSettingsStore(s => s.settings);
     const privacyEnabled = useSettingsStore(s => s.privacyEnabled);
     const allCollections = useCollectionStore(s => s.collections);
-    const libraryToggleFavorite = useSearchStore(s => s.toggleFavorite);
     const queryClient = useQueryClient();
 
     const collections = React.useMemo(() => allCollections.filter(c => !c.filters), [allCollections]);
@@ -140,9 +138,7 @@ export const AppContextMenu: React.FC<AppContextMenuProps> = ({
             }}
             onToggleFavorite={() => {
                 if (contextMenu.imageId) {
-                    // Use toggleFavorite from actions if available, else from library
-                    const toggle = actions.toggleFavorite || libraryToggleFavorite;
-                    toggle(contextMenu.imageId);
+                    actions.toggleFavorite(contextMenu.imageId);
                     onClose();
                 }
             }}

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -11,10 +11,11 @@ import { Facets, LibraryStats, ValidFacetNames } from '../services/db/searchRepo
 import {
     checkHiddenContentAvailability,
     rebuildThumbnailFacetCache,
+    updateFavorite,
     updatePinned,
 } from '../services/db/imageRepo';
 import { clearAllCollectionThumbnailCaches } from '../services/db/collectionRepo';
-import { useImagesQuery } from '../hooks/useImagesQuery';
+import { useImagesQuery, type ImagesQueryKey } from '../hooks/useImagesQuery';
 import { useLibraryStatsQuery } from '../hooks/useLibraryStatsQuery';
 import { buildSqlWhereClause } from '../utils/sqlHelpers';
 import { useQueryClient } from '@tanstack/react-query';
@@ -23,9 +24,12 @@ import { unwrap } from '../utils/spectaUtils';
 import { isBrowserMockMode } from '../services/runtime';
 import { shouldPrefetchResultPages } from '../utils/filterState';
 import { useLibraryStore } from '../stores/libraryStore';
+import { patchImageFlagsInQueryCaches, restoreImagesInQueryCaches } from '../utils/imageQueryCache';
+import { applyOptimisticPinOrder } from '../utils/imageOptimisticUpdates';
 
 interface SearchContextType {
     images: AIImage[];
+    imagesQueryKey: ImagesQueryKey;
     setImages: React.Dispatch<React.SetStateAction<AIImage[]>>;
     filters: FilterState;
     setFilters: React.Dispatch<React.SetStateAction<FilterState>>;
@@ -80,9 +84,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         filters, setFilters,
         sortOption, setSortOption,
         // Removed deleted store properties
-        clearAllFilters,
-        toggleFavorite: storeToggleFavorite,
-        togglePin: storeTogglePin
+        clearAllFilters
     } = useSearchStore();
 
     const privacyMaskKeywords = React.useMemo(() => (
@@ -162,7 +164,8 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         hasNextPage,
         isFetchingNextPage,
         isLoading: isQueryLoading,
-        isPlaceholderData
+        isPlaceholderData,
+        queryKey: imagesQueryKey
     } = useImagesQuery({
         filters,
         sortOption,
@@ -263,21 +266,48 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
 
 
 
-    // Legacy support for togglePin (add to store or keep local wrapper calling repo directly?)
+    const toggleFavorite = useCallback(async (id: string) => {
+        const imgs = useSearchStore.getState().images;
+        const img = imgs.find(i => i.id === id);
+        if (!img) return;
+        const newVal = !img.isFavorite;
+
+        try {
+            setImages(imgs.map(i => i.id === id ? { ...i, isFavorite: newVal } : i));
+            patchImageFlagsInQueryCaches(queryClient, [id], { isFavorite: newVal });
+            await updateFavorite(id, newVal);
+        } catch (e) {
+            console.error("Toggle favorite failed", e);
+            setImages(imgs);
+            restoreImagesInQueryCaches(queryClient, imgs);
+        }
+    }, [queryClient, setImages]);
+
     const togglePin = useCallback(async (id: string, isPinned?: boolean) => {
-        // ... implementation from old context, potentially update store images locally
-        // For now keep old impl but update Store images?
-        // Store has setImages.
         const imgs = useSearchStore.getState().images;
         const img = imgs.find(i => i.id === id);
         if (!img) return;
         const newVal = isPinned !== undefined ? isPinned : !img.isPinned;
+        const nextImages = applyOptimisticPinOrder(imgs, [id], newVal, filters.collectionId !== null);
 
         try {
+            setImages(nextImages);
+            patchImageFlagsInQueryCaches(queryClient, [id], { isPinned: newVal }, {
+                previousOrder: imgs,
+                nextOrder: nextImages,
+                reorderQueryKey: imagesQueryKey
+            });
             await updatePinned(id, newVal);
-            setImages(imgs.map(i => i.id === id ? { ...i, isPinned: newVal } : i));
-        } catch (e) { console.error(e); }
-    }, [setImages]);
+        } catch (e) {
+            console.error("Toggle pin failed", e);
+            setImages(imgs);
+            restoreImagesInQueryCaches(queryClient, imgs, {
+                previousOrder: nextImages,
+                nextOrder: imgs,
+                reorderQueryKey: imagesQueryKey
+            });
+        }
+    }, [filters.collectionId, imagesQueryKey, queryClient, setImages]);
 
     // ... Missing: setRecentSearches, loadFacet, availableHiddenContent
     // Store doesn't have recentSearches yet.
@@ -369,6 +399,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     return (
         <SearchContext.Provider value={{
             images,
+            imagesQueryKey,
             setImages,
             filters,
             setFilters,
@@ -397,8 +428,8 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             fetchData,
             recentSearches,
             setRecentSearches,
-            toggleFavorite: storeToggleFavorite,
-            togglePin: storeTogglePin,
+            toggleFavorite,
+            togglePin,
             availableHiddenContent,
             refreshHiddenAvailability,
             isFacetsLoading: isFacetsFetching,

--- a/src/features/filters/components/__tests__/FilterPanel.test.tsx
+++ b/src/features/filters/components/__tests__/FilterPanel.test.tsx
@@ -5,6 +5,7 @@ import type { Collection, FilterState, SmartCollection, SortOption, AssetScope }
 import type { Facets } from '../../../../services/db/searchRepo';
 import type { useCollections } from '../../../../contexts/CollectionContext';
 import type { useSearch } from '../../../../contexts/SearchContext';
+import type { ImagesQueryKey } from '../../../../hooks/useImagesQuery';
 import { FilterPanel } from '../FilterPanel';
 
 type SearchContextValue = ReturnType<typeof useSearch>;
@@ -82,6 +83,7 @@ const emptyFacets = (): Facets => ({
 
 const defaultSearchContext = (overrides: Partial<SearchContextValue> = {}): SearchContextValue => ({
     images: [],
+    imagesQueryKey: ['images', filters, 'date_desc', false, 'blur', [], null] as ImagesQueryKey,
     setImages: vi.fn() as Dispatch<SetStateAction<SearchContextValue['images']>>,
     filters,
     setFilters: vi.fn() as Dispatch<SetStateAction<FilterState>>,

--- a/src/hooks/__tests__/useAppActions.test.tsx
+++ b/src/hooks/__tests__/useAppActions.test.tsx
@@ -1,8 +1,8 @@
 
-import { renderHook, act } from '../../test/testUtils';
+import { renderHook, act, waitFor } from '../../test/testUtils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAppActions } from '../useAppActions';
-import { AppSettings, FilterState } from '../../types';
+import type { ImagesQueryKey } from '../useImagesQuery';
 
 const mockAddToast = vi.fn();
 vi.mock('../useToast', () => ({
@@ -12,12 +12,18 @@ vi.mock('../useToast', () => ({
 }));
 
 const mockSetImages = vi.fn();
-const mockToggleFavorite = vi.fn();
+const mockToggleImageFavorite = vi.fn();
+const mockToggleImagePin = vi.fn();
 const mockRefreshCollections = vi.fn();
+let mockStoreImages = [
+    { id: '1', isFavorite: false, isPinned: false, filename: '1.png', timestamp: 100 },
+    { id: '2', isFavorite: true, isPinned: true, filename: '2.png', timestamp: 200 },
+];
+let mockStoreFilters = { collectionId: 'col1' as string | null };
 
 vi.mock('../../services/db/imageRepo', () => ({
-    toggleImageFavorite: vi.fn(),
-    toggleImagePin: vi.fn(),
+    toggleImageFavorite: (id: string, isFavorite: boolean) => mockToggleImageFavorite(id, isFavorite),
+    toggleImagePin: (id: string, isPinned: boolean) => mockToggleImagePin(id, isPinned),
     toggleImageMask: vi.fn(),
     markAsDeleted: vi.fn(),
     deleteImage: vi.fn(),
@@ -25,13 +31,9 @@ vi.mock('../../services/db/imageRepo', () => ({
 
 vi.mock('../../stores/searchStore', () => ({
     useSearchStore: (selector: any) => selector({
-        images: [
-            { id: '1', isFavorite: false, isPinned: false, filename: '1.png', timestamp: 100 },
-            { id: '2', isFavorite: true, isPinned: true, filename: '2.png', timestamp: 200 },
-        ],
+        images: mockStoreImages,
         setImages: mockSetImages,
-        filters: { collectionId: 'col1' },
-        toggleFavorite: mockToggleFavorite,
+        filters: mockStoreFilters,
     }),
 }));
 
@@ -62,6 +64,7 @@ describe('useAppActions', () => {
         pendingViewerDeleteId: null,
         setPendingViewerDeleteId: vi.fn(),
     };
+    const mockImagesQueryKey = ['images', { collectionId: 'col1' }, 'date_desc', false, 'none', [], null] as unknown as ImagesQueryKey;
 
     const props = {
         viewingImageId: null,
@@ -71,11 +74,17 @@ describe('useAppActions', () => {
         selectedIds: new Set(['1']),
         setSelectedIds: mockSetSelectedIds,
         lastSelectedId: '1',
+        imagesQueryKey: mockImagesQueryKey,
         modalManager: mockModalManager,
     };
 
     beforeEach(() => {
         vi.clearAllMocks();
+        mockStoreImages = [
+            { id: '1', isFavorite: false, isPinned: false, filename: '1.png', timestamp: 100 },
+            { id: '2', isFavorite: true, isPinned: true, filename: '2.png', timestamp: 200 },
+        ];
+        mockStoreFilters = { collectionId: 'col1' };
     });
 
     it('should open delete confirmation modal if settings.confirmDelete is true', () => {
@@ -147,7 +156,8 @@ describe('useAppActions', () => {
             result.current.handleFavoriteImage('1');
         });
 
-        expect(mockToggleFavorite).toHaveBeenCalledWith('1');
+        expect(mockToggleImageFavorite).toHaveBeenCalledWith('1', true);
+        expect(mockSetImages).toHaveBeenCalled();
         expect(mockAddToast).not.toHaveBeenCalled();
     });
 
@@ -158,7 +168,8 @@ describe('useAppActions', () => {
             result.current.handleFavoriteImage('2');
         });
 
-        expect(mockToggleFavorite).toHaveBeenCalledWith('2');
+        expect(mockToggleImageFavorite).toHaveBeenCalledWith('2', false);
+        expect(mockSetImages).toHaveBeenCalled();
         expect(mockAddToast).not.toHaveBeenCalled();
     });
 
@@ -170,6 +181,7 @@ describe('useAppActions', () => {
         });
 
         expect(mockSetImages).toHaveBeenCalled();
+        expect(mockSetImages.mock.calls[0][0].map((img: { id: string }) => img.id)).toEqual(['2', '1']);
         expect(mockRefreshCollections).toHaveBeenCalledWith(true);
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Pinned'), 'info');
     });
@@ -182,7 +194,34 @@ describe('useAppActions', () => {
         });
 
         expect(mockSetImages).toHaveBeenCalled();
+        expect(mockSetImages.mock.calls[0][0].map((img: { id: string }) => img.id)).toEqual(['2', '1']);
         expect(mockAddToast).toHaveBeenCalledWith('Pinned to top', 'info');
+    });
+
+    it('should preserve current order for single-image pins outside collections', async () => {
+        mockStoreFilters = { collectionId: null };
+        const { result } = renderHook(() => useAppActions(props));
+
+        await act(async () => {
+            result.current.handlePinImage('1', true);
+        });
+
+        expect(mockSetImages.mock.calls[0][0].map((img: { id: string }) => img.id)).toEqual(['1', '2']);
+    });
+
+    it('should restore the previous order when pin persistence fails', async () => {
+        mockToggleImagePin.mockRejectedValueOnce(new Error('pin failed'));
+        const { result } = renderHook(() => useAppActions(props));
+
+        await act(async () => {
+            result.current.handlePinImage('1', true);
+        });
+
+        expect(mockSetImages.mock.calls[0][0].map((img: { id: string }) => img.id)).toEqual(['2', '1']);
+        await waitFor(() => {
+            expect(mockSetImages.mock.calls[1][0].map((img: { id: string }) => img.id)).toEqual(['1', '2']);
+            expect(mockAddToast).toHaveBeenCalledWith('Failed to update pinned state', 'error');
+        });
     });
 
     it('should toggle a viewer pin without a success toast', async () => {

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -13,6 +13,9 @@ import {
 } from '../services/db/imageRepo';
 import { backfillParameterColumns } from '../services/db/maintenanceRepo';
 import { useLibraryStore } from '../stores/libraryStore';
+import { patchImageFlagsInQueryCaches, restoreImagesInQueryCaches } from '../utils/imageQueryCache';
+import { applyOptimisticPinOrder } from '../utils/imageOptimisticUpdates';
+import type { ImagesQueryKey } from './useImagesQuery';
 
 interface AppActionFileOps {
     deleteImages: (ids: string[]) => void | Promise<void>;
@@ -36,6 +39,7 @@ interface UseAppActionsProps {
     selectedIds: Set<string>;
     setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
     lastSelectedId: string | null;
+    imagesQueryKey: ImagesQueryKey;
     modalManager: AppActionModalManager; // Renamed from modals
 }
 
@@ -51,6 +55,7 @@ export const useAppActions = ({
     selectedIds,
     setSelectedIds,
     lastSelectedId,
+    imagesQueryKey,
     modalManager: modals // Destructure with alias for minimum logic change
 }: UseAppActionsProps) => {
     const { addToast } = useToast();
@@ -60,7 +65,6 @@ export const useAppActions = ({
     const images = useSearchStore(s => s.images);
     const setImages = useSearchStore(s => s.setImages);
     const filters = useSearchStore(s => s.filters);
-    const toggleFavorite = useSearchStore(s => s.toggleFavorite);
 
     const settings = useSettingsStore(s => s.settings);
     const privacyEnabled = useSettingsStore(s => s.privacyEnabled);
@@ -74,6 +78,7 @@ export const useAppActions = ({
         ids: string[],
         isPinned: boolean,
         previousImages: typeof images,
+        optimisticImages: typeof images,
         errorMessage: string
     ) => {
         try {
@@ -82,9 +87,29 @@ export const useAppActions = ({
         } catch (error) {
             console.error('[Pin] Failed to persist pin state', error);
             setImages(previousImages);
+            restoreImagesInQueryCaches(queryClient, previousImages, {
+                previousOrder: optimisticImages,
+                nextOrder: previousImages,
+                reorderQueryKey: imagesQueryKey
+            });
             addToast(errorMessage, 'error');
         }
-    }, [refreshCollections, setImages, addToast, images]);
+    }, [refreshCollections, setImages, addToast, queryClient, imagesQueryKey]);
+
+    const persistFavoriteChanges = React.useCallback(async (
+        ids: string[],
+        isFavorite: boolean,
+        previousImages: typeof images
+    ) => {
+        try {
+            await Promise.all(ids.map(id => toggleImageFavorite(id, isFavorite)));
+        } catch (error) {
+            console.error('[Favorite] Failed to persist favorite state', error);
+            setImages(previousImages);
+            restoreImagesInQueryCaches(queryClient, previousImages);
+            addToast('Failed to update favorite state', 'error');
+        }
+    }, [addToast, queryClient, setImages]);
 
     const executeDeleteByIds = React.useCallback((ids: string[], targetDeleteId: string | null = null) => {
         fileOps.deleteImages(ids);
@@ -133,11 +158,13 @@ export const useAppActions = ({
 
     const handleBulkFavorite = () => {
         const anyUnfavorite = images.some(img => selectedIds.has(img.id) && !img.isFavorite);
-        setImages(prev => prev.map(img => selectedIds.has(img.id) ? { ...img, isFavorite: anyUnfavorite } : img));
+        const previousImages = images;
+        const ids = Array.from(selectedIds);
 
-        selectedIds.forEach(id => {
-            void toggleImageFavorite(id, anyUnfavorite);
-        });
+        setImages(prev => prev.map(img => selectedIds.has(img.id) ? { ...img, isFavorite: anyUnfavorite } : img));
+        patchImageFlagsInQueryCaches(queryClient, ids, { isFavorite: anyUnfavorite });
+
+        void persistFavoriteChanges(ids, anyUnfavorite, previousImages);
 
         addToast(`${anyUnfavorite ? 'Favorited' : 'Unfavorited'} ${selectedIds.size} images`, 'success');
     };
@@ -147,7 +174,12 @@ export const useAppActions = ({
         if (!img) return;
 
         const newFavorite = !img.isFavorite;
-        void toggleFavorite(id);
+        const previousImages = images;
+
+        setImages(prev => prev.map(item => item.id === id ? { ...item, isFavorite: newFavorite } : item));
+        patchImageFlagsInQueryCaches(queryClient, [id], { isFavorite: newFavorite });
+        void persistFavoriteChanges([id], newFavorite, previousImages);
+
         if (options.showToast) {
             addToast(newFavorite ? "Liked" : "Unliked", newFavorite ? "success" : "info");
         }
@@ -156,24 +188,23 @@ export const useAppActions = ({
     const handleBulkPin = () => {
         const anyUnpinned = images.some(img => selectedIds.has(img.id) && !img.isPinned);
         const previousImages = images;
+        const ids = Array.from(selectedIds);
+        const nextImages = applyOptimisticPinOrder(
+            previousImages,
+            ids,
+            anyUnpinned,
+            !!filters.collectionId
+        );
 
-        setImages(prev => {
-            const updated = prev.map(img => selectedIds.has(img.id) ? { ...img, isPinned: anyUnpinned } : img);
-
-            // Only sort if we are in a collection (where pinned items are forced to top)
-            // In "All Photos", we want to keep chronological order
-            if (filters.collectionId) {
-                return [...updated].sort((a, b) => {
-                    if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
-                    return (b.timestamp || 0) - (a.timestamp || 0);
-                });
-            }
-            return updated;
+        setImages(nextImages);
+        patchImageFlagsInQueryCaches(queryClient, ids, { isPinned: anyUnpinned }, {
+            previousOrder: previousImages,
+            nextOrder: nextImages,
+            reorderQueryKey: imagesQueryKey
         });
 
-        const ids = Array.from(selectedIds);
         addToast(`${anyUnpinned ? 'Pinned' : 'Unpinned'} ${selectedIds.size} images`, 'info');
-        void persistPinChanges(ids, anyUnpinned, previousImages, 'Failed to update pinned images');
+        void persistPinChanges(ids, anyUnpinned, previousImages, nextImages, 'Failed to update pinned images');
         // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
     };
 
@@ -265,23 +296,24 @@ export const useAppActions = ({
 
     const handlePinImage = (id: string, newPinned: boolean, options: SingleImageActionOptions = { showToast: true }) => {
         const previousImages = images;
+        const nextImages = applyOptimisticPinOrder(
+            previousImages,
+            [id],
+            newPinned,
+            !!filters.collectionId
+        );
 
-        setImages(prev => {
-            const updated = prev.map(i => i.id === id ? { ...i, isPinned: newPinned } : i);
-
-            if (filters.collectionId) {
-                return [...updated].sort((a, b) => {
-                    if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
-                    return (b.timestamp || 0) - (a.timestamp || 0);
-                });
-            }
-            return updated;
+        setImages(nextImages);
+        patchImageFlagsInQueryCaches(queryClient, [id], { isPinned: newPinned }, {
+            previousOrder: previousImages,
+            nextOrder: nextImages,
+            reorderQueryKey: imagesQueryKey
         });
 
         if (options.showToast !== false) {
             addToast(newPinned ? "Pinned to top" : "Unpinned", "info");
         }
-        void persistPinChanges([id], newPinned, previousImages, 'Failed to update pinned state');
+        void persistPinChanges([id], newPinned, previousImages, nextImages, 'Failed to update pinned state');
         // await queryClient.invalidateQueries({ queryKey: ['libraryStats'] });
     };
 
@@ -327,7 +359,7 @@ export const useAppActions = ({
         handlePinImage,
         handleShortcutFavorite,
         handleShortcutPin,
-        toggleFavorite,
+        toggleFavorite: handleFavoriteImage,
         runBackfill
     };
 };

--- a/src/hooks/useImagesQuery.ts
+++ b/src/hooks/useImagesQuery.ts
@@ -15,6 +15,16 @@ interface UseImagesQueryProps {
     settingsLoaded?: boolean;
 }
 
+export type ImagesQueryKey = readonly [
+    'images',
+    FilterState,
+    SortOption,
+    boolean,
+    AppSettings['maskingMode'],
+    AppSettings['maskedKeywords'],
+    string | null
+];
+
 export const useImagesQuery = ({
     filters,
     sortOption,
@@ -41,8 +51,18 @@ export const useImagesQuery = ({
         [activeCollection?.filters]
     );
 
-    return useInfiniteQuery({
-        queryKey: ['images', filters, sortOption, privacyEnabled, settings.maskingMode, settings.maskedKeywords, smartFilterHash],
+    const imagesQueryKey = useMemo<ImagesQueryKey>(() => [
+        'images',
+        filters,
+        sortOption,
+        privacyEnabled,
+        settings.maskingMode,
+        settings.maskedKeywords,
+        smartFilterHash
+    ], [filters, sortOption, privacyEnabled, settings.maskingMode, settings.maskedKeywords, smartFilterHash]);
+
+    const query = useInfiniteQuery({
+        queryKey: imagesQueryKey,
         queryFn: async ({ pageParam }) => {
             if (useBrowserMocks) {
                 const cursor = pageParam as PaginationCursor | undefined;
@@ -122,4 +142,6 @@ export const useImagesQuery = ({
         gcTime: 1000 * 60 * 10,
         enabled: settingsLoaded, // Wait for settings to load before fetching to prevent duplicate queries
     });
+
+    return { ...query, queryKey: imagesQueryKey };
 };

--- a/src/utils/__tests__/imageQueryCache.test.ts
+++ b/src/utils/__tests__/imageQueryCache.test.ts
@@ -1,0 +1,207 @@
+import { QueryClient } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import { GeneratorTool, type AIImage } from '../../types';
+import { patchImageFlagsInQueryCaches, restoreImagesInQueryCaches } from '../imageQueryCache';
+
+const image = (id: string, flags: Partial<AIImage> = {}): AIImage => ({
+    id,
+    url: id,
+    thumbnailUrl: id,
+    filename: `${id}.png`,
+    timestamp: 1,
+    width: 100,
+    height: 100,
+    isFavorite: false,
+    isPinned: false,
+    isDeleted: false,
+    isMissing: false,
+    metadata: {
+        tool: GeneratorTool.UNKNOWN,
+        model: 'Unknown',
+        seed: 0,
+        steps: 0,
+        cfg: 0,
+        sampler: 'Unknown',
+        positivePrompt: '',
+        negativePrompt: ''
+    },
+    ...flags
+});
+
+describe('imageQueryCache', () => {
+    it('patches all cached image result pages so optimistic flags survive query re-emissions', () => {
+        const queryClient = new QueryClient();
+        const first = image('1');
+        const second = image('2');
+
+        queryClient.setQueryData(['images', { scope: 'library' }], {
+            pages: [
+                { images: [first], totalCount: 2, globalCount: 2 },
+                { images: [second], totalCount: -1, globalCount: -1 }
+            ],
+            pageParams: [undefined, { id: '1', val: 1 }]
+        });
+
+        patchImageFlagsInQueryCaches(queryClient, ['2'], { isFavorite: true, isPinned: true });
+
+        const data = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(['images', { scope: 'library' }]);
+
+        expect(data?.pages[0].images[0]).toBe(first);
+        expect(data?.pages[1].images[0]).toMatchObject({
+            id: '2',
+            isFavorite: true,
+            isPinned: true
+        });
+    });
+
+    it('reorders the active cached result and preserves original page sizes', () => {
+        const queryClient = new QueryClient();
+        const activeKey = ['images', { scope: 'active' }] as const;
+        const first = image('1', { timestamp: 100 });
+        const second = image('2', { timestamp: 200, isPinned: true });
+        const third = image('3', { timestamp: 50 });
+        const previousOrder = [first, second, third];
+        const nextOrder = [
+            second,
+            { ...first, isPinned: true },
+            third
+        ];
+
+        queryClient.setQueryData(activeKey, {
+            pages: [
+                { images: [first, second], totalCount: 3, globalCount: 3 },
+                { images: [third], totalCount: -1, globalCount: -1 }
+            ],
+            pageParams: [undefined, { id: '2', val: 100 }]
+        });
+
+        patchImageFlagsInQueryCaches(queryClient, ['1'], { isPinned: true }, {
+            previousOrder,
+            nextOrder,
+            reorderQueryKey: activeKey
+        });
+
+        const data = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(activeKey);
+
+        expect(data?.pages.map(page => page.images.map(item => item.id))).toEqual([
+            ['2', '1'],
+            ['3']
+        ]);
+        expect(data?.pages[0].images[1].isPinned).toBe(true);
+    });
+
+    it('patches inactive cached results with the same ids without reordering them', () => {
+        const queryClient = new QueryClient();
+        const activeKey = ['images', { scope: 'active' }] as const;
+        const inactiveKey = ['images', { scope: 'inactive' }] as const;
+        const activeFirst = image('1', { timestamp: 100 });
+        const activeSecond = image('2', { timestamp: 200, isPinned: true });
+        const inactiveFirst = image('1', { timestamp: 100 });
+        const inactiveSecond = image('2', { timestamp: 200, isPinned: true });
+        const previousOrder = [activeFirst, activeSecond];
+        const nextOrder = [
+            activeSecond,
+            { ...activeFirst, isPinned: true }
+        ];
+
+        queryClient.setQueryData(activeKey, {
+            pages: [{ images: [activeFirst, activeSecond], totalCount: 2, globalCount: 2 }],
+            pageParams: [undefined]
+        });
+        queryClient.setQueryData(inactiveKey, {
+            pages: [{ images: [inactiveFirst, inactiveSecond], totalCount: 2, globalCount: 2 }],
+            pageParams: [undefined]
+        });
+
+        patchImageFlagsInQueryCaches(queryClient, ['1'], { isPinned: true }, {
+            previousOrder,
+            nextOrder,
+            reorderQueryKey: activeKey
+        });
+
+        const activeData = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(activeKey);
+        const inactiveData = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(inactiveKey);
+
+        expect(activeData?.pages[0].images.map(item => item.id)).toEqual(['2', '1']);
+        expect(inactiveData?.pages[0].images.map(item => item.id)).toEqual(['1', '2']);
+        expect(inactiveData?.pages[0].images[0].isPinned).toBe(true);
+    });
+
+    it('restores cached images from a previous optimistic snapshot', () => {
+        const queryClient = new QueryClient();
+        const previous = [image('1')];
+
+        queryClient.setQueryData(['images'], {
+            pages: [
+                { images: [image('1', { isFavorite: true })], totalCount: 1, globalCount: 1 }
+            ],
+            pageParams: [undefined]
+        });
+
+        restoreImagesInQueryCaches(queryClient, previous);
+
+        const data = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(['images']);
+
+        expect(data?.pages[0].images[0].isFavorite).toBe(false);
+    });
+
+    it('restores active cached result order after an optimistic reorder fails', () => {
+        const queryClient = new QueryClient();
+        const activeKey = ['images', { scope: 'active' }] as const;
+        const inactiveKey = ['images', { scope: 'inactive' }] as const;
+        const first = image('1', { timestamp: 100 });
+        const second = image('2', { timestamp: 200, isPinned: true });
+        const third = image('3', { timestamp: 50 });
+        const inactiveFirst = image('1', { timestamp: 100, isPinned: true });
+        const inactiveSecond = image('2', { timestamp: 200, isPinned: true });
+        const previousOrder = [first, second, third];
+        const optimisticOrder = [
+            second,
+            { ...first, isPinned: true },
+            third
+        ];
+
+        queryClient.setQueryData(activeKey, {
+            pages: [
+                { images: optimisticOrder.slice(0, 2), totalCount: 3, globalCount: 3 },
+                { images: optimisticOrder.slice(2), totalCount: -1, globalCount: -1 }
+            ],
+            pageParams: [undefined, { id: '1', val: 100 }]
+        });
+        queryClient.setQueryData(inactiveKey, {
+            pages: [{ images: [inactiveFirst, inactiveSecond], totalCount: 2, globalCount: 2 }],
+            pageParams: [undefined]
+        });
+
+        restoreImagesInQueryCaches(queryClient, previousOrder, {
+            previousOrder: optimisticOrder,
+            nextOrder: previousOrder,
+            reorderQueryKey: activeKey
+        });
+
+        const data = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(activeKey);
+        const inactiveData = queryClient.getQueryData<{
+            pages: Array<{ images: AIImage[] }>;
+        }>(inactiveKey);
+
+        expect(data?.pages.map(page => page.images.map(item => item.id))).toEqual([
+            ['1', '2'],
+            ['3']
+        ]);
+        expect(data?.pages[0].images[0].isPinned).toBe(false);
+        expect(inactiveData?.pages[0].images.map(item => item.id)).toEqual(['1', '2']);
+        expect(inactiveData?.pages[0].images[0].isPinned).toBe(false);
+    });
+});

--- a/src/utils/imageOptimisticUpdates.ts
+++ b/src/utils/imageOptimisticUpdates.ts
@@ -1,0 +1,20 @@
+import type { AIImage } from '../types';
+
+export const applyOptimisticPinOrder = (
+    images: readonly AIImage[],
+    ids: Iterable<string>,
+    isPinned: boolean,
+    prioritizePinned: boolean
+): AIImage[] => {
+    const idSet = new Set(ids);
+    const updated = images.map(image => (
+        idSet.has(image.id) ? { ...image, isPinned } : image
+    ));
+
+    if (!prioritizePinned) return updated;
+
+    return [...updated].sort((a, b) => {
+        if (a.isPinned !== b.isPinned) return a.isPinned ? -1 : 1;
+        return (b.timestamp || 0) - (a.timestamp || 0);
+    });
+};

--- a/src/utils/imageQueryCache.ts
+++ b/src/utils/imageQueryCache.ts
@@ -1,0 +1,115 @@
+import type { InfiniteData, QueryClient, QueryKey } from '@tanstack/react-query';
+import type { AIImage } from '../types';
+
+interface ImagesPage {
+    images: AIImage[];
+    totalCount: number;
+    globalCount: number;
+}
+
+type ImagesQueryData = InfiniteData<ImagesPage, unknown>;
+
+interface ImageQueryOrderOptions {
+    previousOrder?: readonly AIImage[];
+    nextOrder?: readonly AIImage[];
+    reorderQueryKey?: QueryKey;
+}
+
+const hasSameImageOrder = (images: readonly AIImage[], order: readonly AIImage[]): boolean => (
+    images.length === order.length && images.every((image, index) => image.id === order[index]?.id)
+);
+
+const pageImagesChanged = (pages: ImagesPage[], nextPages: ImagesPage[]): boolean => (
+    pages.some((page, pageIndex) => (
+        page.images.length !== nextPages[pageIndex]?.images.length
+        || page.images.some((image, imageIndex) => image !== nextPages[pageIndex]?.images[imageIndex])
+    ))
+);
+
+const repartitionImages = (images: readonly AIImage[], pages: ImagesPage[]): ImagesPage[] => {
+    let offset = 0;
+    return pages.map(page => {
+        const pageLength = page.images.length;
+        const nextImages = images.slice(offset, offset + pageLength);
+        offset += pageLength;
+        return { ...page, images: nextImages };
+    });
+};
+
+const queryKeysMatch = (left: QueryKey, right: QueryKey): boolean => (
+    left === right || JSON.stringify(left) === JSON.stringify(right)
+);
+
+const updateImagesQueryData = (
+    data: ImagesQueryData,
+    queryKey: QueryKey,
+    updateImage: (image: AIImage) => AIImage,
+    options: ImageQueryOrderOptions = {}
+): ImagesQueryData => {
+    const originalImages = data.pages.flatMap(page => page.images);
+    const shouldReorder = !!options.reorderQueryKey
+        && !!options.previousOrder
+        && !!options.nextOrder
+        && queryKeysMatch(queryKey, options.reorderQueryKey)
+        && hasSameImageOrder(originalImages, options.previousOrder);
+
+    let changed = false;
+    const pages = data.pages.map(page => {
+        let pageChanged = false;
+        const images = page.images.map(image => {
+            const nextImage = updateImage(image);
+            if (nextImage !== image) pageChanged = true;
+            return nextImage;
+        });
+
+        if (!pageChanged) return page;
+        changed = true;
+        return { ...page, images };
+    });
+
+    if (shouldReorder && options.nextOrder) {
+        const patchedById = new Map(pages.flatMap(page => page.images).map(image => [image.id, image]));
+        const orderedImages = options.nextOrder.map(image => patchedById.get(image.id) ?? image);
+        const orderedPages = repartitionImages(orderedImages, pages);
+        return changed || pageImagesChanged(data.pages, orderedPages)
+            ? { ...data, pages: orderedPages }
+            : data;
+    }
+
+    return changed ? { ...data, pages } : data;
+};
+
+export const updateImagesQueryCaches = (
+    queryClient: QueryClient,
+    updateImage: (image: AIImage) => AIImage,
+    options: ImageQueryOrderOptions = {}
+): void => {
+    queryClient.getQueriesData<ImagesQueryData>({ queryKey: ['images'] }).forEach(([queryKey, data]) => {
+        if (!data) return;
+        const nextData = updateImagesQueryData(data, queryKey, updateImage, options);
+        if (nextData !== data) {
+            queryClient.setQueryData(queryKey, nextData);
+        }
+    });
+};
+
+export const patchImageFlagsInQueryCaches = (
+    queryClient: QueryClient,
+    ids: Iterable<string>,
+    patch: Pick<Partial<AIImage>, 'isFavorite' | 'isPinned'>,
+    options?: ImageQueryOrderOptions
+): void => {
+    const idSet = new Set(ids);
+    updateImagesQueryCaches(queryClient, image => (
+        idSet.has(image.id) ? { ...image, ...patch } : image
+    ), options);
+};
+
+export const restoreImagesInQueryCaches = (
+    queryClient: QueryClient,
+    previousImages: AIImage[],
+    options?: ImageQueryOrderOptions
+): void => {
+    const previousById = new Map(previousImages.map(image => [image.id, image]));
+    updateImagesQueryCaches(queryClient, image => previousById.get(image.id) ?? image, options);
+};


### PR DESCRIPTION
## Summary

- Keep optimistic favorite and pin flag updates synchronized across cached image queries.
- Scope optimistic pin reordering and rollback to the active image query key.
- Add shared optimistic pin ordering and query-cache helpers with focused coverage.

## Why

Switching between grid and timeline could re-sync stale React Query pages over the optimistic Zustand image order. Pin reordering also needed to avoid touching unrelated cached views that happened to contain the same image IDs.

## Validation

- `pnpm vitest run src/utils/__tests__/imageQueryCache.test.ts src/hooks/__tests__/useAppActions.test.tsx`
- `pnpm run typecheck`
- `git diff --check`