### PR TITLE
[codex] Fix timeline click index after pin reordering

### DIFF
--- a/src/features/library/components/TimelineView.tsx
+++ b/src/features/library/components/TimelineView.tsx
@@ -48,6 +48,13 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
 }) => {
     const privacyEnabled = useSettingsStore(s => s.privacyEnabled);
     const { groups } = useTimeline(images, sortOption);
+    const timelineSourceIndexes = React.useMemo(() => {
+        const sourceIndexById = new Map(images.map((image, index) => [image.id, index]));
+
+        return groups.flatMap(group =>
+            group.images.map(image => sourceIndexById.get(image.id) ?? -1)
+        );
+    }, [groups, images]);
     const containerRef = useRef<HTMLDivElement>(null);
     const stickyHeaderRef = useRef<HTMLDivElement>(null);
 
@@ -74,11 +81,21 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
         activeHeaderIdRef
     } = useTimelineLayout({ groups, width, thumbnailSize, scrollTop });
 
+    const handleTimelineRangeSelection = React.useCallback((selectedIndexes: number[], isAdditive: boolean) => {
+        if (!onRangeSelection) return;
+
+        const sourceIndexes = selectedIndexes
+            .map(index => timelineSourceIndexes[index])
+            .filter((index): index is number => index !== undefined && index >= 0);
+
+        onRangeSelection(sourceIndexes, isAdditive);
+    }, [onRangeSelection, timelineSourceIndexes]);
+
     // Selection Hook
     const { dragBox, handleMouseDown } = useTimelineSelection({
         containerRef,
         layoutItems: visibleItems, // We can use visible items or all items, visible is enough for overlap check if we search correctly
-        onRangeSelection,
+        onRangeSelection: handleTimelineRangeSelection,
         onBackgroundClick
     });
 
@@ -171,7 +188,7 @@ export const TimelineView: React.FC<TimelineViewProps> = ({
                                                         console.error('[TimelineView] Failed to set drag data:', err);
                                                     }
                                                 }}
-                                                onClick={(e) => onImageClick(e, subItem.image.id, subItem.globalIndex)}
+                                                onClick={(e) => onImageClick(e, subItem.image.id, timelineSourceIndexes[subItem.globalIndex] ?? subItem.globalIndex)}
                                                 onToggleSelection={(e) => onSelectionToggle(e, subItem.image.id)}
                                                 onToggleFavorite={(e) => onToggleFavorite(e, subItem.image.id)}
                                                 onTogglePin={onTogglePin ? (e) => onTogglePin(e, subItem.image.id) : undefined}

--- a/src/features/library/components/__tests__/TimelineView.test.tsx
+++ b/src/features/library/components/__tests__/TimelineView.test.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TimelineView } from '../TimelineView';
+import { AIImage, GeneratorTool } from '../../../../types';
+
+vi.mock('../ImageCard', () => ({
+    ImageCard: ({ image, onClick }: { image: AIImage; onClick: (event: React.MouseEvent) => void }) => (
+        <button type="button" data-testid={`timeline-card-${image.id}`} onClick={onClick}>
+            {image.id}
+        </button>
+    )
+}));
+
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+let resizeObserverInstance: ResizeObserver | null = null;
+
+const emitResize = (target: Element, width: number) => {
+    if (!resizeObserverCallback || !resizeObserverInstance) {
+        throw new Error('ResizeObserver mock has not been initialized');
+    }
+
+    resizeObserverCallback([{
+        target,
+        contentRect: {
+            x: 0,
+            y: 0,
+            width,
+            height: 600,
+            top: 0,
+            right: width,
+            bottom: 600,
+            left: 0,
+            toJSON: () => ({})
+        }
+    } as ResizeObserverEntry], resizeObserverInstance);
+};
+
+const createImage = (id: string, timestamp: number, isPinned = false): AIImage => ({
+    id,
+    url: `file:///${id}.png`,
+    thumbnailUrl: `file:///${id}-thumb.png`,
+    filename: `${id}.png`,
+    timestamp,
+    width: 100,
+    height: 100,
+    isFavorite: false,
+    isPinned,
+    metadata: {
+        tool: GeneratorTool.UNKNOWN,
+        model: 'Unknown',
+        seed: 1,
+        steps: 20,
+        cfg: 7,
+        sampler: 'Euler',
+        positivePrompt: '',
+        negativePrompt: ''
+    }
+});
+
+describe('TimelineView', () => {
+    beforeEach(() => {
+        resizeObserverCallback = null;
+        resizeObserverInstance = null;
+        vi.stubGlobal('ResizeObserver', class ResizeObserver {
+            constructor(callback: ResizeObserverCallback) {
+                resizeObserverCallback = callback;
+                resizeObserverInstance = this as unknown as ResizeObserver;
+            }
+
+            observe(target: Element) {
+                emitResize(target, 600);
+            }
+
+            unobserve() {
+                return undefined;
+            }
+
+            disconnect() {
+                return undefined;
+            }
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.unstubAllGlobals();
+    });
+
+    it('opens the clicked image using its source index when pins reorder the timeline', async () => {
+        const onImageClick = vi.fn();
+        const images = [
+            createImage('regular-first', new Date(2020, 0, 1, 11, 0, 0).getTime(), false),
+            createImage('pinned-second', new Date(2020, 0, 1, 10, 0, 0).getTime(), true)
+        ];
+
+        render(
+            <TimelineView
+                images={images}
+                selectedIds={new Set()}
+                sortOption="date_desc"
+                onImageClick={onImageClick}
+                onSelectionToggle={() => undefined}
+                onToggleFavorite={() => undefined}
+                onContextMenu={() => undefined}
+                maskedKeywords={[]}
+            />
+        );
+
+        await waitFor(() => expect(screen.getByTestId('timeline-card-pinned-second')).toBeTruthy());
+
+        fireEvent.click(screen.getByTestId('timeline-card-pinned-second'));
+
+        expect(onImageClick).toHaveBeenCalledWith(expect.anything(), 'pinned-second', 1);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes timeline image opening when pinned items reorder the timeline display differently from the source image array.

## Root Cause

Timeline cards used a display-order index after grouping and pin sorting, while the viewer resolved that index against the original `images` array. When a pinned image moved ahead visually, clicking it could open a different image at the same numeric source index.

## Changes

- Translate timeline display indexes back to source `images` indexes before passing clicks to shared viewer state.
- Apply the same translation for timeline box-selection indexes.
- Add a regression test covering a pinned image that is visually first but second in the source array.

## Validation

- `pnpm exec vitest run src/features/library/components/__tests__/TimelineView.test.tsx`
- `pnpm run typecheck`
- `pnpm exec eslint src/features/library/components/TimelineView.tsx`