### PR TITLE
fix: harden idle background work cleanup

### DIFF
--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -117,6 +117,7 @@ export const ActivityDock: React.FC = () => {
         progress = backgroundHealingProgress;
         label = "Smart Thumbnails";
         isLowPriority = true;
+        supportsCancel = true;
         footerMessage = THUMBNAIL_QUEUE_RUNNING_FOOTER;
     } else if (isRefreshActive) {
         progress = refreshProgress;
@@ -320,6 +321,7 @@ export const ActivityDock: React.FC = () => {
                                             if (isScanningDiscovery) cancelDiscoveryScan();
                                             if (isScanningDuplicates) cancelDuplicateScan();
                                             if (isScanningMissingFiles) cancelMissingScan();
+                                            if (isBackgroundActive) void commands.cancelThumbnailOptimizationJob().catch(console.error);
                                             if (isRefreshActive) cancelRefresh();
                                         }}
                                         className="text-[10px] font-bold text-red-500 hover:text-red-700 dark:hover:text-red-400 bg-red-50 dark:bg-red-900/10 hover:bg-red-100 dark:hover:bg-red-900/30 px-2 py-1 rounded-md transition-colors uppercase tracking-wider"

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -165,7 +165,7 @@ describe('ActivityDock', () => {
         expect(screen.queryByText('Scanning C:/old-folder...')).toBeNull();
     });
 
-    it('renders running smart thumbnail progress without repeated checked counts', () => {
+    it('renders running smart thumbnail progress with cancel controls and without repeated checked counts', () => {
         useLibraryStore.setState({
             isBackgroundHealingActive: true,
             backgroundHealingProgress: {
@@ -184,7 +184,7 @@ describe('ActivityDock', () => {
         expect(screen.queryByText('340 / 340')).toBeNull();
         expect(screen.queryByText('0%')).toBeNull();
         expect(screen.queryByText('100%')).toBeNull();
-        expect(screen.queryByText('Cancel')).toBeNull();
+        expect(screen.getByText('Cancel')).toBeTruthy();
     });
 
     it('renders completed smart thumbnail progress without generic count or percent chrome', () => {

--- a/src/features/settings/components/DevTab.tsx
+++ b/src/features/settings/components/DevTab.tsx
@@ -8,11 +8,11 @@ import { useLibraryContext } from '../../../hooks/useLibraryContext';
 import { useSettingsStore } from '../../../stores/settingsStore';
 import { commands } from '../../../bindings';
 import { invoke } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
 import { useToast } from '../../../hooks/useToast';
 import { useLibraryStore } from '../../../stores/libraryStore';
 import { AI_PROMPTS, AIPromptKey } from '../../../constants/aiPrompts';
 import { cn } from '../../../utils/cn';
+import { listenWithCleanup } from '../../../utils/tauriListener';
 import type { LogLevel } from '../../../types';
 
 type DevTabId = 'prompts' | 'tools';
@@ -82,18 +82,16 @@ export const DevTab: React.FC = () => {
 
     // Event listener for reset progress
     React.useEffect(() => {
-        let unlisten: (() => void) | undefined;
-
-        const setupListener = async () => {
-            unlisten = await listen<string>('reset-progress', (event) => {
+        const resetProgressListener = listenWithCleanup<string>(
+            'reset-progress',
+            (event) => {
                 addToast(event.payload, 'info');
-            });
-        };
-
-        setupListener();
+            },
+            'Database reset progress'
+        );
 
         return () => {
-            if (unlisten) unlisten();
+            resetProgressListener.cleanup();
         };
     }, [addToast]);
 

--- a/src/hooks/__tests__/useThumbnailQueue.test.ts
+++ b/src/hooks/__tests__/useThumbnailQueue.test.ts
@@ -90,8 +90,21 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).toContain('thumbnailOptimizationRetrySignal');
         expect(content).toContain('retryAfterCurrentRunRef');
         expect(content).toContain('postRunRetrySignal');
-        expect(content).toContain('scheduleIdleCallback(() => {');
-        expect(content).toContain('runQueue();');
+        expect(content).toContain("scheduleIdleCallback('retry'");
+        expect(content).toContain('void runQueue();');
+    });
+
+    it('should cancel pending idle starts on disable and unmount', async () => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
+        const content = await fs.readFile(hookPath, 'utf-8');
+
+        expect(content).toContain('scheduledIdleCancelRef');
+        expect(content).toContain('cancelScheduledIdleCallback();');
+        expect(content).toContain("scheduleIdleCallback('auto-start'");
+        expect(content).toContain("scheduleIdleCallback('resume'");
+        expect(content).toContain('mountedRef.current = false');
     });
 
     it('should pause only for high-priority blocking work', async () => {

--- a/src/hooks/useMetadataRefresh.ts
+++ b/src/hooks/useMetadataRefresh.ts
@@ -6,11 +6,11 @@
  */
 
 import { useEffect, useCallback } from 'react';
-import { listen } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { useLibraryStore } from '../stores/libraryStore';
 import { useToast } from './useToast';
 import { isBrowserMockMode } from '../services/runtime';
+import { listenWithCleanup } from '../utils/tauriListener';
 
 interface RefreshProgress {
     current: number;
@@ -39,35 +39,43 @@ export function useMetadataRefresh() {
     useEffect(() => {
         if (browserMockMode) return;
 
-        const unlistenProgress = listen<RefreshProgress>('refresh-progress', (event) => {
-            setRefreshProgress({
-                current: event.payload.current,
-                total: event.payload.total,
-                message: event.payload.message,
-            });
-        });
+        const progressListener = listenWithCleanup<RefreshProgress>(
+            'refresh-progress',
+            (event) => {
+                setRefreshProgress({
+                    current: event.payload.current,
+                    total: event.payload.total,
+                    message: event.payload.message,
+                });
+            },
+            'Metadata refresh progress'
+        );
 
-        const unlistenComplete = listen<RefreshResult>('refresh-complete', (event) => {
-            const { processed, updated, errors, wasCancelled } = event.payload;
+        const completeListener = listenWithCleanup<RefreshResult>(
+            'refresh-complete',
+            (event) => {
+                const { processed, updated, errors, wasCancelled } = event.payload;
 
-            setIsRefreshingMetadata(false);
-            setRefreshProgress(null);
+                setIsRefreshingMetadata(false);
+                setRefreshProgress(null);
 
-            if (wasCancelled) {
-                addToast(`Refresh cancelled: ${processed.toLocaleString()} processed before stop`, 'info');
-            } else if (processed > 0) {
-                addToast(
-                    `Refresh complete: ${updated.toLocaleString()} updated, ${errors} errors`,
-                    errors > 0 ? 'warning' : 'success'
-                );
-            }
+                if (wasCancelled) {
+                    addToast(`Refresh cancelled: ${processed.toLocaleString()} processed before stop`, 'info');
+                } else if (processed > 0) {
+                    addToast(
+                        `Refresh complete: ${updated.toLocaleString()} updated, ${errors} errors`,
+                        errors > 0 ? 'warning' : 'success'
+                    );
+                }
 
-            console.log(`[Refresh] Complete: ${processed} processed, ${updated} updated, ${errors} errors`);
-        });
+                console.log(`[Refresh] Complete: ${processed} processed, ${updated} updated, ${errors} errors`);
+            },
+            'Metadata refresh complete'
+        );
 
         return () => {
-            unlistenProgress.then(f => f());
-            unlistenComplete.then(f => f());
+            progressListener.cleanup();
+            completeListener.cleanup();
         };
     }, [setIsRefreshingMetadata, setRefreshProgress, addToast, browserMockMode]);
 

--- a/src/hooks/useProgressListeners.ts
+++ b/src/hooks/useProgressListeners.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
-import { listen } from '@tauri-apps/api/event';
 import { useLibraryStore, type SyncProgress } from '../stores/libraryStore';
 import { isBrowserMockMode } from '../services/runtime';
+import { listenWithCleanup } from '../utils/tauriListener';
 
 export function useProgressListeners() {
     const {
@@ -14,38 +14,42 @@ export function useProgressListeners() {
     useEffect(() => {
         if (isBrowserMockMode()) return;
 
-        let unlistenModel: () => void;
-        let unlistenDiscovery: () => void;
-        let unlistenDuplicateScan: () => void;
-
-        const setupListeners = async () => {
-            unlistenModel = await listen<SyncProgress>('model_resolution_progress', (event) => {
+        const modelListener = listenWithCleanup<SyncProgress>(
+            'model_resolution_progress',
+            (event) => {
                 const progress = event.payload;
                 setModelResolutionProgress(progress);
 
                 // Auto-clear when complete if backend doesn't call back for setIsResolvingModels(false)
                 // However, typical pattern is that the command finishing handles the boolean.
                 // We keep the progress state for the UI to show "100%" or the last message.
-            });
+            },
+            'Model resolution progress'
+        );
 
-            unlistenDiscovery = await listen<SyncProgress>('discovery_scan_progress', (event) => {
+        const discoveryListener = listenWithCleanup<SyncProgress>(
+            'discovery_scan_progress',
+            (event) => {
                 const progress = event.payload;
                 setDiscoveryScanProgress(progress);
-            });
+            },
+            'Model discovery progress'
+        );
 
-            unlistenDuplicateScan = await listen<SyncProgress>('file_hash_backfill_progress', (event) => {
+        const duplicateScanListener = listenWithCleanup<SyncProgress>(
+            'file_hash_backfill_progress',
+            (event) => {
                 const progress = event.payload;
                 setIsScanningDuplicates(true);
                 setDuplicateScanProgress(progress);
-            });
-        };
-
-        setupListeners();
+            },
+            'Duplicate hash backfill progress'
+        );
 
         return () => {
-            if (unlistenModel) unlistenModel();
-            if (unlistenDiscovery) unlistenDiscovery();
-            if (unlistenDuplicateScan) unlistenDuplicateScan();
+            modelListener.cleanup();
+            discoveryListener.cleanup();
+            duplicateScanListener.cleanup();
         };
     }, []);
 }

--- a/src/hooks/useStacking.ts
+++ b/src/hooks/useStacking.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { AIImage } from '../types';
 import MetadataWorker from '../workers/metadata.worker.ts?worker';
+import { startBackgroundDiagnostic } from '../utils/backgroundDiagnostics';
 
 export interface StackGroup {
     id: string;
@@ -33,10 +34,13 @@ export const useStacking = (images: AIImage[]) => {
 
     // Debounce ref
     const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const activeWorkerCleanupRef = useRef<(() => void) | null>(null);
     const lastImagesRef = useRef<number>(0);
 
     useEffect(() => {
         if (images.length === 0) {
+            activeWorkerCleanupRef.current?.();
+            activeWorkerCleanupRef.current = null;
             setSuggestedStacks([]);
             setIsCalculating(false);
             return;
@@ -48,11 +52,24 @@ export const useStacking = (images: AIImage[]) => {
         lastImagesRef.current = currentSig;
 
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
+        activeWorkerCleanupRef.current?.();
+        activeWorkerCleanupRef.current = null;
 
         setIsCalculating(true);
         timeoutRef.current = setTimeout(() => {
             const worker = getWorker();
             const requestId = `stack_${Date.now()}`;
+            const diagnostic = startBackgroundDiagnostic('worker', 'Stack suggestion analysis', {
+                requestId,
+                imageCount: images.length
+            });
+            let finished = false;
+
+            const finish = (status: 'finished' | 'cancelled' | 'failed') => {
+                if (finished) return;
+                finished = true;
+                diagnostic.finish(status);
+            };
 
             const handler = (e: MessageEvent) => {
                 if (e.data.requestId === requestId) {
@@ -61,9 +78,19 @@ export const useStacking = (images: AIImage[]) => {
                     }
                     setIsCalculating(false);
                     worker.removeEventListener('message', handler);
+                    if (activeWorkerCleanupRef.current === cleanupWorkerListener) {
+                        activeWorkerCleanupRef.current = null;
+                    }
+                    finish(e.data.error ? 'failed' : 'finished');
                 }
             };
 
+            const cleanupWorkerListener = () => {
+                worker.removeEventListener('message', handler);
+                finish('cancelled');
+            };
+
+            activeWorkerCleanupRef.current = cleanupWorkerListener;
             worker.addEventListener('message', handler);
 
             // Send lightweight payload
@@ -90,6 +117,8 @@ export const useStacking = (images: AIImage[]) => {
 
         return () => {
             if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            activeWorkerCleanupRef.current?.();
+            activeWorkerCleanupRef.current = null;
         };
     }, [images]);
 

--- a/src/hooks/useThumbnailQueue.ts
+++ b/src/hooks/useThumbnailQueue.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react';
 import { useIsFetching, useQueryClient } from '@tanstack/react-query';
-import { listen } from '@tauri-apps/api/event';
 import {
     commands,
     type ThumbnailOptimizationProfile,
@@ -17,6 +16,8 @@ import {
 } from './thumbnailQueueProgress';
 import { rebuildThumbnailFacetCache } from '../services/db/imageRepo';
 import { getThumbnailDir } from '../services/thumbnailService';
+import { startBackgroundDiagnostic, type BackgroundDiagnosticHandle } from '../utils/backgroundDiagnostics';
+import { listenWithCleanup } from '../utils/tauriListener';
 
 const STARTUP_DELAY_MS = 30000;
 const RESUME_DELAY_MS = 5000;
@@ -65,6 +66,9 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
     const restartRequestedRef = useRef(false);
     const retryAfterCurrentRunRef = useRef(false);
     const isImageQueryFetchingRef = useRef(false);
+    const mountedRef = useRef(true);
+    const scheduledIdleCancelRef = useRef<(() => void) | null>(null);
+    const jobDiagnosticRef = useRef<BackgroundDiagnosticHandle | null>(null);
     const browserMockMode = isBrowserMockMode();
     const [resumeSignal, setResumeSignal] = useState(0);
     const [postRunRetrySignal, setPostRunRetrySignal] = useState(0);
@@ -119,23 +123,82 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             || store.isRefreshingMetadata;
     }, []);
 
-    const scheduleIdleCallback = useCallback((callback: () => void, delay: number = 0) => {
-        const schedule = () => {
-            if ('requestIdleCallback' in window) {
-                (window as typeof window & { requestIdleCallback: (cb: () => void, options?: { timeout: number }) => number })
-                    .requestIdleCallback(callback, { timeout: 2000 });
-            } else {
-                setTimeout(callback, 50);
+    const cancelScheduledIdleCallback = useCallback(() => {
+        scheduledIdleCancelRef.current?.();
+        scheduledIdleCancelRef.current = null;
+    }, []);
+
+    const scheduleIdleCallback = useCallback((label: string, callback: () => void, delay: number = 0) => {
+        cancelScheduledIdleCallback();
+
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
+        let idleId: number | null = null;
+        let finished = false;
+        const diagnostic = startBackgroundDiagnostic('timer', `Smart Thumbnail ${label}`, { delayMs: delay });
+
+        const finish = (status: 'finished' | 'cancelled') => {
+            if (finished) return;
+            finished = true;
+            diagnostic.finish(status);
+        };
+
+        const clearScheduledHandles = () => {
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }
+            if (idleId !== null) {
+                window.cancelIdleCallback?.(idleId);
+                idleId = null;
             }
         };
 
+        const fire = () => {
+            clearScheduledHandles();
+
+            if (!mountedRef.current) {
+                finish('cancelled');
+                return;
+            }
+
+            if (scheduledIdleCancelRef.current === cancel) {
+                scheduledIdleCancelRef.current = null;
+            }
+            finish('finished');
+            callback();
+        };
+
+        const schedule = () => {
+            if (!mountedRef.current) {
+                finish('cancelled');
+                return;
+            }
+
+            if (typeof window.requestIdleCallback === 'function') {
+                idleId = window.requestIdleCallback(fire, { timeout: 2000 });
+            } else {
+                timeoutId = setTimeout(fire, 50);
+            }
+        };
+
+        const cancel = () => {
+            clearScheduledHandles();
+            if (scheduledIdleCancelRef.current === cancel) {
+                scheduledIdleCancelRef.current = null;
+            }
+            finish('cancelled');
+        };
+
+        scheduledIdleCancelRef.current = cancel;
+
         if (delay > 0) {
-            setTimeout(schedule, delay);
-            return;
+            timeoutId = setTimeout(schedule, delay);
+        } else {
+            schedule();
         }
 
-        schedule();
-    }, []);
+        return cancel;
+    }, [cancelScheduledIdleCallback]);
 
     const setBackendThrottled = useCallback((throttled: boolean) => {
         if (browserMockMode) return;
@@ -173,6 +236,14 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
     const handleCompletion = useCallback(async (result: ThumbnailOptimizationResult) => {
         if (completionHandledRef.current) return;
         completionHandledRef.current = true;
+        jobDiagnosticRef.current?.finish(result.wasCancelled ? 'cancelled' : 'finished', {
+            checked: result.checked,
+            optimized: result.optimized,
+            failed: result.failed,
+            skipped: result.skipped,
+            durationMs: result.durationMs
+        });
+        jobDiagnosticRef.current = null;
         const completedConfig = runningConfigRef.current;
         isRunningRef.current = false;
         runningConfigRef.current = null;
@@ -223,7 +294,7 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
 
         await sleep(COMPLETE_VISIBLE_MS);
 
-        if (!completionHandledRef.current || isRunningRef.current || useLibraryStore.getState().backgroundHealingPaused) {
+        if (!mountedRef.current || !completionHandledRef.current || isRunningRef.current || useLibraryStore.getState().backgroundHealingPaused) {
             return;
         }
 
@@ -249,11 +320,19 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
     useEffect(() => {
         if (browserMockMode) return;
 
-        const unlistenProgress = listen<ThumbnailOptimizationProgress>(
+        const progressListener = listenWithCleanup<ThumbnailOptimizationProgress>(
             'thumbnail-optimization-progress',
             (event) => {
                 if (cancelRequestedRef.current) return;
 
+                jobDiagnosticRef.current?.update({
+                    checked: event.payload.checked,
+                    optimized: event.payload.optimized,
+                    failed: event.payload.failed,
+                    skipped: event.payload.skipped,
+                    phase: event.payload.phase,
+                    isThrottled: event.payload.isThrottled
+                });
                 setBackgroundHealingActive(true);
                 setBackgroundHealingPaused(false);
                 setBackgroundHealingProgress({
@@ -283,19 +362,21 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
                 if (event.payload.checked > 0) {
                     console.debug('[ThumbnailQueue] Backend progress', event.payload);
                 }
-            }
+            },
+            'Thumbnail optimization progress'
         );
 
-        const unlistenComplete = listen<ThumbnailOptimizationResult>(
+        const completeListener = listenWithCleanup<ThumbnailOptimizationResult>(
             'thumbnail-optimization-complete',
             (event) => {
                 void handleCompletion(event.payload);
-            }
+            },
+            'Thumbnail optimization complete'
         );
 
         return () => {
-            unlistenProgress.then(unlisten => unlisten());
-            unlistenComplete.then(unlisten => unlisten());
+            progressListener.cleanup();
+            completeListener.cleanup();
         };
     }, [
         browserMockMode,
@@ -309,6 +390,7 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
     const cancelBackendJob = useCallback(async (clearDock: boolean) => {
         if (browserMockMode) return;
 
+        cancelScheduledIdleCallback();
         cancelRequestedRef.current = true;
 
         try {
@@ -323,6 +405,8 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             runningConfigRef.current = null;
             lastThrottleRef.current = null;
             restartRequestedRef.current = false;
+            jobDiagnosticRef.current?.finish('cancelled', { clearDock });
+            jobDiagnosticRef.current = null;
             setBackgroundHealingActive(false);
             setBackgroundHealingPaused(false);
             setBackgroundHealingProgress(null);
@@ -330,6 +414,7 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
         }
     }, [
         browserMockMode,
+        cancelScheduledIdleCallback,
         setBackgroundHealingActive,
         setBackgroundHealingDetails,
         setBackgroundHealingPaused,
@@ -338,6 +423,7 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
 
     const runQueue = useCallback(async () => {
         if (browserMockMode) return;
+        if (!mountedRef.current) return;
 
         const settings = useSettingsStore.getState().settings;
         if (!settings.enableAutoThumbnailHealing) return;
@@ -395,6 +481,12 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             includeUpgradeable: optimizerConfig.includeUpgradeable,
             profile: optimizerConfig.profile
         });
+        jobDiagnosticRef.current?.finish('cancelled', { reason: 'superseded' });
+        jobDiagnosticRef.current = startBackgroundDiagnostic('job', 'Smart Thumbnail optimization', {
+            includeUpgradeable: optimizerConfig.includeUpgradeable,
+            profile: optimizerConfig.profile,
+            throttledAtStart: shouldStartThrottled
+        });
 
         try {
             const jobPromise = unwrap(commands.startThumbnailOptimizationJob({
@@ -409,10 +501,23 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             cancelRequestedRef.current = false;
             await handleCompletion(result);
         } catch (error) {
-            if (cancelRequestedRef.current) return;
+            if (cancelRequestedRef.current) {
+                isRunningRef.current = false;
+                runningConfigRef.current = null;
+                lastThrottleRef.current = null;
+                jobDiagnosticRef.current?.finish('cancelled', {
+                    error: error instanceof Error ? error.message : String(error)
+                });
+                jobDiagnosticRef.current = null;
+                return;
+            }
 
             console.error('[ThumbnailQueue] Backend thumbnail optimization failed', error);
             addToast?.(`Smart thumbnail optimization failed: ${String(error)}`, 'error');
+            jobDiagnosticRef.current?.finish('failed', {
+                error: error instanceof Error ? error.message : String(error)
+            });
+            jobDiagnosticRef.current = null;
             completionHandledRef.current = true;
             isRunningRef.current = false;
             runningConfigRef.current = null;
@@ -451,14 +556,18 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
 
         if (enableAutoThumbnailHealing) {
             if (!isRunningRef.current && !shouldPauseForActivity() && !useLibraryStore.getState().backgroundHealingPaused) {
-                scheduleIdleCallback(() => runQueue());
+                scheduleIdleCallback('auto-start', () => {
+                    void runQueue();
+                });
             }
             return;
         }
 
+        cancelScheduledIdleCallback();
         void cancelBackendJob(true);
     }, [
         browserMockMode,
+        cancelScheduledIdleCallback,
         cancelBackendJob,
         enableAutoThumbnailHealing,
         enforceHighQualityThumbnails,
@@ -552,8 +661,8 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             return;
         }
 
-        scheduleIdleCallback(() => {
-            runQueue();
+        scheduleIdleCallback('retry', () => {
+            void runQueue();
         });
     }, [
         browserMockMode,
@@ -575,13 +684,9 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             console.log('[ThumbnailQueue] Resuming after blocking activity...');
             setBackgroundHealingPaused(false);
 
-            const resumeTimer = setTimeout(() => {
-                scheduleIdleCallback(() => {
-                    runQueue();
-                });
+            return scheduleIdleCallback('resume', () => {
+                void runQueue();
             }, RESUME_DELAY_MS);
-
-            return () => clearTimeout(resumeTimer);
         }
     }, [
         browserMockMode,
@@ -595,12 +700,21 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
 
     useEffect(() => {
         return () => {
+            mountedRef.current = false;
+            cancelScheduledIdleCallback();
             if (isRunningRef.current) {
                 void commands.cancelThumbnailOptimizationJob().catch(console.error);
             }
+            jobDiagnosticRef.current?.finish('cancelled', { reason: 'unmount' });
+            jobDiagnosticRef.current = null;
             setBackgroundHealingActive(false);
             setBackgroundHealingProgress(null);
             setBackgroundHealingDetails(null);
         };
-    }, [setBackgroundHealingActive, setBackgroundHealingDetails, setBackgroundHealingProgress]);
+    }, [
+        cancelScheduledIdleCallback,
+        setBackgroundHealingActive,
+        setBackgroundHealingDetails,
+        setBackgroundHealingProgress
+    ]);
 }

--- a/src/services/WatcherService.ts
+++ b/src/services/WatcherService.ts
@@ -1,8 +1,10 @@
 import { commands } from '../bindings';
 import { unwrap } from '../utils/spectaUtils';
-import { listen, UnlistenFn } from '@tauri-apps/api/event';
+import { UnlistenFn } from '@tauri-apps/api/event';
 import { AppSettings } from '../types';
 import { isBrowserMockMode } from './runtime';
+import { startBackgroundDiagnostic, type BackgroundDiagnosticHandle } from '../utils/backgroundDiagnostics';
+import { listenWithCleanup } from '../utils/tauriListener';
 
 type WatcherCallback = (paths?: string[]) => void;
 
@@ -10,6 +12,8 @@ export class WatcherService {
     private unlistenFn: UnlistenFn | null = null;
     private isWatching = false;
     private lastPaths: string[] = [];
+    private generation = 0;
+    private diagnostic: BackgroundDiagnosticHandle | null = null;
 
     async startWatching(paths: string[], onChangeEvent: WatcherCallback) {
         if (isBrowserMockMode()) {
@@ -27,22 +31,54 @@ export class WatcherService {
 
         if (paths.length === 0) return;
 
+        const startGeneration = ++this.generation;
+
         try {
             // Start the native rust watcher which handles multiple paths
             await unwrap(commands.startNativeFolderWatcher(paths));
+            if (startGeneration !== this.generation) {
+                await unwrap(commands.startNativeFolderWatcher([]));
+                return;
+            }
+
             console.log(`[WatcherService] Native watcher started for ${paths.length} paths`);
 
             this.isWatching = true;
             this.lastPaths = [...paths];
+            this.diagnostic = startBackgroundDiagnostic('job', 'Native folder watcher', {
+                pathCount: paths.length,
+                paths
+            });
 
             // Listen for the debounced event from Rust
-            this.unlistenFn = await listen<string[]>('folder-change-event', (event) => {
-                console.log(`[WatcherService] Folder change detected with ${event.payload?.length || 0} paths`);
-                onChangeEvent(event.payload);
-            });
+            const listener = listenWithCleanup<string[]>(
+                'folder-change-event',
+                (event) => {
+                    const pathCount = event.payload?.length || 0;
+                    console.log(`[WatcherService] Folder change detected with ${pathCount} paths`);
+                    this.diagnostic?.update({ lastEventAt: Date.now(), lastPathCount: pathCount });
+                    onChangeEvent(event.payload);
+                },
+                'Native folder watcher events'
+            );
+            this.unlistenFn = listener.cleanup;
+
+            const listenerReady = await listener.ready;
+            if (startGeneration !== this.generation) {
+                listener.cleanup();
+                return;
+            }
+
+            if (!listenerReady) {
+                await this.stopWatching();
+            }
 
         } catch (err) {
             console.error(`[WatcherService] Failed to start native watcher:`, err);
+            this.diagnostic?.finish('failed', { error: err instanceof Error ? err.message : String(err) });
+            this.diagnostic = null;
+            this.isWatching = false;
+            this.lastPaths = [];
             // Optionally throw here so the UI can display a Toast, or just leave `isWatching = false` 
             // so we can try again later.
         }
@@ -55,14 +91,20 @@ export class WatcherService {
             return;
         }
 
-        if (!this.unlistenFn && !this.isWatching) return;
+        const hadActiveWatcher = Boolean(this.unlistenFn) || this.isWatching;
+        this.generation++;
+
+        if (!hadActiveWatcher) return;
 
         this.isWatching = false;
+        this.lastPaths = [];
 
         if (this.unlistenFn) {
             this.unlistenFn();
             this.unlistenFn = null;
         }
+        this.diagnostic?.finish('cancelled');
+        this.diagnostic = null;
 
         try {
             // Send empty list to stop the rust watcher

--- a/src/services/__tests__/WatcherService.test.ts
+++ b/src/services/__tests__/WatcherService.test.ts
@@ -1,0 +1,42 @@
+import { listen } from '@tauri-apps/api/event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { commands } from '../../bindings';
+import { WatcherService } from '../WatcherService';
+
+vi.mock('../../bindings', () => ({
+    commands: {
+        startNativeFolderWatcher: vi.fn()
+    }
+}));
+
+const mockedStartNativeFolderWatcher = vi.mocked(commands.startNativeFolderWatcher);
+const mockedListen = vi.mocked(listen);
+
+describe('WatcherService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockedListen.mockResolvedValue(() => undefined);
+    });
+
+    it('invalidates a pending native watcher start when stop is requested before startup settles', async () => {
+        let resolveStart!: () => void;
+        mockedStartNativeFolderWatcher
+            .mockReturnValueOnce(new Promise((resolve) => {
+                resolveStart = () => resolve({ status: 'ok', data: null });
+            }))
+            .mockResolvedValue({ status: 'ok', data: null });
+
+        const service = new WatcherService();
+        const startPromise = service.startWatching(['C:/watch'], vi.fn());
+
+        await Promise.resolve();
+        await service.stopWatching();
+
+        resolveStart();
+        await startPromise;
+
+        expect(mockedStartNativeFolderWatcher).toHaveBeenNthCalledWith(1, ['C:/watch']);
+        expect(mockedStartNativeFolderWatcher).toHaveBeenNthCalledWith(2, []);
+        expect(mockedListen).not.toHaveBeenCalled();
+    });
+});

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -2,7 +2,6 @@
 import { parseImageFile, scanImageNative, scanImagesBulk } from './metadataParser';
 import { getExistingMetadata, insertImage, insertImagesBatch, rebuildFacetCache } from './db/imageRepo';
 import { convertFileSrc } from '@tauri-apps/api/core';
-import { listen } from '@tauri-apps/api/event';
 import { commands, type ThumbnailScanResult } from '../bindings';
 import { unwrap } from '../utils/spectaUtils';
 import { normalizePath } from '../utils/pathUtils';
@@ -24,6 +23,7 @@ import {
     liveWatchNow,
     TargetedLiveSyncPerfContext,
 } from '../utils/liveWatchPerf';
+import { listenWithCleanup } from '../utils/tauriListener';
 
 /**
  * Queries the database for paths that already exist.
@@ -292,16 +292,22 @@ async function processFileEntries(
             const batchStartedAt = liveWatchNow();
             const nativeProgressRunId = createNativeProgressRunId();
             // Setup listener for native progress stream for silky smooth UI loading bars
-            unlisten = await listen<NativeImportProgressPayload>('import_progress', (e) => {
-                if (e.payload.progressRunId !== nativeProgressRunId) {
-                    return;
-                }
+            const progressListener = listenWithCleanup<NativeImportProgressPayload>(
+                'import_progress',
+                (e) => {
+                    if (e.payload.progressRunId !== nativeProgressRunId) {
+                        return;
+                    }
 
-                if (onProgress) {
-                    const absCurrent = Math.min(i + e.payload.current, totalToProcess);
-                    onProgress(absCurrent, totalToProcess, e.payload.message);
-                }
-            });
+                    if (onProgress) {
+                        const absCurrent = Math.min(i + e.payload.current, totalToProcess);
+                        onProgress(absCurrent, totalToProcess, e.payload.message);
+                    }
+                },
+                'Native import progress'
+            );
+            unlisten = progressListener.cleanup;
+            await progressListener.ready;
 
             // true for extractWorkflow (always want full metadata)
             const scanStartedAt = liveWatchNow();

--- a/src/services/metadataParser.ts
+++ b/src/services/metadataParser.ts
@@ -8,6 +8,7 @@ import {
     infoLiveWatchPerf,
     liveWatchNow,
 } from '../utils/liveWatchPerf';
+import { startBackgroundDiagnostic } from '../utils/backgroundDiagnostics';
 
 // Initializing the worker
 // Using ?worker&inline might be needed depending on Vite config, 
@@ -59,31 +60,65 @@ const parseInWorker = (chunks: unknown, filename: string, path?: string, default
 
         // Let's implement a simple Request ID system.
         const requestId = Math.random().toString(36).substring(7);
-        let timeoutId: ReturnType<typeof setTimeout>;
+        let timeoutId: ReturnType<typeof setTimeout> | null = null;
+        let settled = false;
+        const diagnostic = startBackgroundDiagnostic('worker', 'Metadata parse', {
+            requestId,
+            filename,
+            path
+        });
+
+        const cleanup = () => {
+            worker.removeEventListener('message', handler);
+            if (timeoutId !== null) {
+                clearTimeout(timeoutId);
+                timeoutId = null;
+            }
+        };
+
+        const settle = (
+            status: 'finished' | 'failed',
+            action: () => void,
+            detail?: Record<string, unknown>
+        ) => {
+            if (settled) return;
+            settled = true;
+            cleanup();
+            diagnostic.finish(status, detail);
+            action();
+        };
 
         const handler = (e: MessageEvent) => {
             const data = e.data as WorkerParseResponse;
             if (data.requestId === requestId) {
-                worker.removeEventListener('message', handler);
-                clearTimeout(timeoutId);
-                if (data.error) reject(new Error(data.error));
-                else resolve({
+                if (data.error) {
+                    settle('failed', () => reject(new Error(data.error)), { error: data.error });
+                    return;
+                }
+
+                settle('finished', () => resolve({
                     metadata: data.metadata ?? {},
                     extra: data.extra ?? {},
                     isIntermediate: data.isIntermediate
-                });
+                }));
             }
         };
 
         const payload = toWorkerInput(chunks);
         worker.addEventListener('message', handler);
-        worker.postMessage({ chunks: payload.chunks, buffer: payload.buffer, filename, requestId, path, defaultTool });
 
         // Timeout safety
         timeoutId = setTimeout(() => {
-            worker.removeEventListener('message', handler);
-            reject(new Error("Worker timed out"));
+            settle('failed', () => reject(new Error("Worker timed out")), { error: 'Worker timed out' });
         }, 5000);
+
+        try {
+            worker.postMessage({ chunks: payload.chunks, buffer: payload.buffer, filename, requestId, path, defaultTool });
+        } catch (error) {
+            settle('failed', () => reject(error), {
+                error: error instanceof Error ? error.message : String(error)
+            });
+        }
     });
 };
 

--- a/src/utils/__tests__/tauriListener.test.ts
+++ b/src/utils/__tests__/tauriListener.test.ts
@@ -1,0 +1,41 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listenWithCleanup } from '../tauriListener';
+
+const mockedListen = vi.mocked(listen);
+
+describe('listenWithCleanup', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('unlistens when cleanup runs before Tauri listener registration resolves', async () => {
+        let resolveListen!: (unlisten: UnlistenFn) => void;
+        const unlisten = vi.fn();
+        mockedListen.mockReturnValueOnce(new Promise<UnlistenFn>((resolve) => {
+            resolveListen = resolve;
+        }));
+
+        const managed = listenWithCleanup('background-event', vi.fn());
+        managed.cleanup();
+
+        resolveListen(unlisten);
+        const ready = await managed.ready;
+
+        expect(ready).toBe(false);
+        expect(unlisten).toHaveBeenCalledTimes(1);
+    });
+
+    it('unlistens an already registered listener exactly once', async () => {
+        const unlisten = vi.fn();
+        mockedListen.mockResolvedValueOnce(unlisten);
+
+        const managed = listenWithCleanup('background-event', vi.fn());
+        const ready = await managed.ready;
+        managed.cleanup();
+        managed.cleanup();
+
+        expect(ready).toBe(true);
+        expect(unlisten).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/utils/backgroundDiagnostics.ts
+++ b/src/utils/backgroundDiagnostics.ts
@@ -1,0 +1,129 @@
+export type BackgroundDiagnosticKind = 'job' | 'listener' | 'timer' | 'worker';
+export type BackgroundDiagnosticStatus = 'active' | 'finished' | 'cancelled' | 'failed';
+
+export interface BackgroundDiagnosticEntry {
+    id: string;
+    kind: BackgroundDiagnosticKind;
+    label: string;
+    startedAt: number;
+    updatedAt: number;
+    endedAt?: number;
+    status: BackgroundDiagnosticStatus;
+    detail?: Record<string, unknown>;
+}
+
+export interface BackgroundDiagnosticSnapshot {
+    active: BackgroundDiagnosticEntry[];
+    history: BackgroundDiagnosticEntry[];
+}
+
+export interface BackgroundDiagnosticHandle {
+    id: string;
+    update: (detail?: Record<string, unknown>) => void;
+    finish: (status?: Exclude<BackgroundDiagnosticStatus, 'active'>, detail?: Record<string, unknown>) => void;
+}
+
+interface AmbitDiagnosticsWindow extends Window {
+    ambitDiagnostics?: {
+        background?: {
+            snapshot: () => BackgroundDiagnosticSnapshot;
+        };
+    };
+}
+
+const HISTORY_LIMIT = 100;
+
+let sequence = 0;
+const activeEntries = new Map<string, BackgroundDiagnosticEntry>();
+const historyEntries: BackgroundDiagnosticEntry[] = [];
+
+const cloneEntry = (entry: BackgroundDiagnosticEntry): BackgroundDiagnosticEntry => ({
+    ...entry,
+    detail: entry.detail ? { ...entry.detail } : undefined
+});
+
+const createSnapshot = (): BackgroundDiagnosticSnapshot => ({
+    active: Array.from(activeEntries.values()).map(cloneEntry),
+    history: historyEntries.map(cloneEntry)
+});
+
+const isEnabled = (): boolean =>
+    typeof window !== 'undefined' && Boolean(import.meta.env.DEV);
+
+const ensureInstalled = () => {
+    if (!isEnabled()) return;
+
+    const target = window as AmbitDiagnosticsWindow;
+    target.ambitDiagnostics = target.ambitDiagnostics ?? {};
+    target.ambitDiagnostics.background = {
+        snapshot: createSnapshot
+    };
+};
+
+const recordHistory = (entry: BackgroundDiagnosticEntry) => {
+    historyEntries.unshift(cloneEntry(entry));
+    if (historyEntries.length > HISTORY_LIMIT) {
+        historyEntries.length = HISTORY_LIMIT;
+    }
+};
+
+export const startBackgroundDiagnostic = (
+    kind: BackgroundDiagnosticKind,
+    label: string,
+    detail?: Record<string, unknown>
+): BackgroundDiagnosticHandle => {
+    if (!isEnabled()) {
+        return {
+            id: '',
+            update: () => undefined,
+            finish: () => undefined
+        };
+    }
+
+    ensureInstalled();
+
+    const now = Date.now();
+    const id = `${kind}:${label}:${now}:${sequence++}`;
+    const entry: BackgroundDiagnosticEntry = {
+        id,
+        kind,
+        label,
+        startedAt: now,
+        updatedAt: now,
+        status: 'active',
+        detail
+    };
+    activeEntries.set(id, entry);
+
+    return {
+        id,
+        update: (nextDetail) => {
+            const current = activeEntries.get(id);
+            if (!current) return;
+
+            current.updatedAt = Date.now();
+            current.detail = {
+                ...(current.detail ?? {}),
+                ...(nextDetail ?? {})
+            };
+        },
+        finish: (status = 'finished', finalDetail) => {
+            const current = activeEntries.get(id);
+            if (!current) return;
+
+            activeEntries.delete(id);
+            const endedAt = Date.now();
+            const completed: BackgroundDiagnosticEntry = {
+                ...current,
+                updatedAt: endedAt,
+                endedAt,
+                status,
+                detail: {
+                    ...(current.detail ?? {}),
+                    ...(finalDetail ?? {})
+                }
+            };
+            recordHistory(completed);
+        }
+    };
+};

--- a/src/utils/tauriListener.ts
+++ b/src/utils/tauriListener.ts
@@ -1,0 +1,56 @@
+import { listen, type Event, type UnlistenFn } from '@tauri-apps/api/event';
+import { startBackgroundDiagnostic } from './backgroundDiagnostics';
+
+interface ManagedTauriListener {
+    cleanup: UnlistenFn;
+    ready: Promise<boolean>;
+}
+
+const formatError = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+
+export const listenWithCleanup = <T>(
+    eventName: string,
+    handler: (event: Event<T>) => void,
+    label = eventName
+): ManagedTauriListener => {
+    let disposed = false;
+    let unlisten: UnlistenFn | null = null;
+    let finished = false;
+    const diagnostic = startBackgroundDiagnostic('listener', label, { eventName });
+
+    const finishDiagnostic = (status: 'finished' | 'cancelled' | 'failed', detail?: Record<string, unknown>) => {
+        if (finished) return;
+        finished = true;
+        diagnostic.finish(status, detail);
+    };
+
+    const ready = listen<T>(eventName, handler)
+        .then((nextUnlisten) => {
+            if (disposed) {
+                nextUnlisten();
+                finishDiagnostic('cancelled', { disposedBeforeReady: true });
+                return false;
+            }
+
+            unlisten = nextUnlisten;
+            diagnostic.update({ listening: true });
+            return true;
+        })
+        .catch((error: unknown) => {
+            console.error(`[TauriListener] Failed to listen for ${eventName}`, error);
+            finishDiagnostic('failed', { error: formatError(error) });
+            return false;
+        });
+
+    const cleanup = () => {
+        disposed = true;
+        if (!unlisten) return;
+
+        unlisten();
+        unlisten = null;
+        finishDiagnostic('cancelled');
+    };
+
+    return { cleanup, ready };
+};


### PR DESCRIPTION
## Summary
- add dev-only background diagnostics for active jobs, timers, listeners, and worker requests
- harden Smart Thumbnail scheduling/cancellation so stale idle callbacks cannot start work after disable or unmount
- centralize Tauri listener cleanup and apply it to watcher, progress, import, metadata refresh, and dev reset listeners
- clean up metadata/stacking worker listeners and make Smart Thumbnail background work cancellable from Activity Dock

## Validation
- `git diff --check`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm exec vitest run src/hooks/__tests__/useThumbnailQueue.test.ts src/utils/__tests__/tauriListener.test.ts src/components/ui/__tests__/ActivityDock.test.tsx src/hooks/__tests__/useStacking.test.ts src/services/__tests__/WatcherService.test.ts src/contexts/__tests__/LibraryIntegration.test.tsx`

Note: the targeted Vitest command needs to run outside the sandbox on this Windows setup because Vite/Rolldown hits `spawn EPERM` inside the sandbox.