### PR TITLE
fix: stabilize live watch sync feedback

### DIFF
--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Loader2, X, Info, Sparkles, Minus, Fingerprint, Search } from 'lucide-react';
-import { useLibraryStore, type SyncProgress } from '../../stores/libraryStore';
+import {
+    useLibraryStore,
+    type LiveWatchSessionSource,
+    type LiveWatchSessionState,
+    type SyncProgress
+} from '../../stores/libraryStore';
 import { commands } from '../../bindings';
 import {
     THUMBNAIL_QUEUE_COMPLETE_FOOTER,
@@ -10,6 +15,20 @@ import {
 } from '../../hooks/thumbnailQueueProgress';
 
 const ELAPSED_VISIBLE_AFTER_MS = 5000;
+const LIVE_WATCH_DOCK_REVEAL_MS = 2500;
+const LIVE_WATCH_DOCK_MIN_VISIBLE_MS = 2200;
+const LIVE_WATCH_DOCK_CLOSE_GRACE_MS = 1500;
+const LIVE_WATCH_ACTIVE_MESSAGE = 'Updating your library...';
+const LIVE_WATCH_SOURCE_CHIP_CLASS = 'inline-flex h-5 w-[4.75rem] shrink-0 items-center justify-center rounded-md bg-sage-500/10 px-1.5 text-[10px] font-black uppercase tracking-wider text-sage-600 dark:text-sage-300';
+
+interface LiveWatchPresentation {
+    mode: 'hidden' | 'expanded-active';
+    message: string;
+    sourceLabel: 'InvokeAI' | 'Folders' | 'Mixed' | null;
+    presentationKey: string | null;
+    isActiveWork: boolean;
+    isExpanded: boolean;
+}
 
 const formatElapsed = (elapsedMs: number): string | null => {
     if (elapsedMs < ELAPSED_VISIBLE_AFTER_MS) {
@@ -31,6 +50,106 @@ const splitDetailItems = (detail?: string): string[] => (
         ? detail.split('|').map(item => item.trim()).filter(Boolean)
         : []
 );
+
+const getLiveWatchSourceLabel = (source: LiveWatchSessionSource | null): LiveWatchPresentation['sourceLabel'] => {
+    if (source === 'invoke') return 'InvokeAI';
+    if (source === 'generic') return 'Folders';
+    if (source === 'mixed') return 'Mixed';
+    return null;
+};
+
+const isLiveWatchDockWorkPhase = (session: LiveWatchSessionState): boolean => (
+    session.phase === 'syncing' || session.phase === 'importing'
+);
+
+const useLiveWatchPresentation = (
+    session: LiveWatchSessionState,
+    isLiveWatchActive: boolean,
+    dismissedPresentationKey: string | null
+): LiveWatchPresentation => {
+    const isActiveWork = isLiveWatchActive && isLiveWatchDockWorkPhase(session);
+    const [presentation, setPresentation] = React.useState<{
+        key: string | null;
+        visible: boolean;
+        revealedAt: number | null;
+    }>({
+        key: null,
+        visible: false,
+        revealedAt: null
+    });
+
+    React.useEffect(() => {
+        if (!isLiveWatchActive) {
+            setPresentation({ key: null, visible: false, revealedAt: null });
+            return;
+        }
+
+        if (!isActiveWork) {
+            if (!presentation.visible) {
+                setPresentation(prev => (
+                    prev.key === null ? prev : { key: null, visible: false, revealedAt: null }
+                ));
+                return;
+            }
+
+            const now = Date.now();
+            const revealedAt = presentation.revealedAt ?? now;
+            const minVisibleRemainingMs = Math.max(0, LIVE_WATCH_DOCK_MIN_VISIBLE_MS - (now - revealedAt));
+            const closeDelayMs = Math.max(LIVE_WATCH_DOCK_CLOSE_GRACE_MS, minVisibleRemainingMs);
+            const timer = window.setTimeout(() => {
+                setPresentation({ key: null, visible: false, revealedAt: null });
+            }, closeDelayMs);
+            return () => window.clearTimeout(timer);
+        }
+
+        const presentationKey = presentation.key ?? `${session.source ?? 'watch'}:${Date.now()}`;
+
+        if (!presentation.key) {
+            setPresentation({ key: presentationKey, visible: false, revealedAt: null });
+            return;
+        }
+
+        if (presentationKey === dismissedPresentationKey) {
+            if (presentation.visible) {
+                setPresentation(prev => ({ ...prev, visible: false, revealedAt: null }));
+            }
+            return;
+        }
+
+        if (presentation.visible) {
+            return;
+        }
+
+        const timer = window.setTimeout(() => {
+            setPresentation(prev => (
+                prev.key === presentationKey && presentationKey !== dismissedPresentationKey
+                    ? { key: presentationKey, visible: true, revealedAt: Date.now() }
+                    : prev
+            ));
+        }, LIVE_WATCH_DOCK_REVEAL_MS);
+        return () => window.clearTimeout(timer);
+    }, [
+        dismissedPresentationKey,
+        isActiveWork,
+        isLiveWatchActive,
+        presentation.key,
+        presentation.revealedAt,
+        presentation.visible,
+        session.source
+    ]);
+
+    const sourceLabel = getLiveWatchSourceLabel(session.source);
+    const mode: LiveWatchPresentation['mode'] = presentation.visible ? 'expanded-active' : 'hidden';
+
+    return {
+        mode,
+        message: LIVE_WATCH_ACTIVE_MESSAGE,
+        sourceLabel,
+        presentationKey: presentation.key,
+        isActiveWork: isActiveWork && presentation.visible,
+        isExpanded: mode === 'expanded-active'
+    };
+};
 
 export const ActivityDock: React.FC = () => {
     const {
@@ -59,6 +178,7 @@ export const ActivityDock: React.FC = () => {
         cancelSync,
         cancelRefresh
     } = useLibraryStore();
+    const [dismissedLiveWatchPresentationKey, setDismissedLiveWatchPresentationKey] = React.useState<string | null>(null);
 
     const isManualSyncing = syncStatus === 'syncing';
 
@@ -69,10 +189,11 @@ export const ActivityDock: React.FC = () => {
     const isRefreshActive = isRefreshingMetadata && !isHighPriorityActive && !isBackgroundActive;
 
     const isLiveWatchActive = liveWatchSession.active && !isHighPriorityActive && !isBackgroundActive && !isRefreshActive;
-    const isLiveWatchSummary = isLiveWatchActive && liveWatchSession.phase === 'summary';
-    const isLiveWatchTone = isLiveWatchActive;
+    const liveWatchPresentation = useLiveWatchPresentation(liveWatchSession, isLiveWatchActive, dismissedLiveWatchPresentationKey);
+    const isLiveWatchVisible = isLiveWatchActive && liveWatchPresentation.mode !== 'hidden';
+    const isLiveWatchTone = isLiveWatchVisible;
 
-    const active = isHighPriorityActive || isBackgroundActive || isRefreshActive || isLiveWatchActive;
+    const active = isHighPriorityActive || isBackgroundActive || isRefreshActive || isLiveWatchVisible;
 
     let progress: SyncProgress | null = null;
     let label = "";
@@ -123,13 +244,13 @@ export const ActivityDock: React.FC = () => {
         label = "Refreshing Metadata";
         isLowPriority = false;
         supportsCancel = true;
-    } else if (isLiveWatchActive) {
+    } else if (isLiveWatchVisible) {
         progress = liveWatchSession.progress || {
             current: 0,
             total: 0,
             message: liveWatchSession.message
         };
-        label = "Live Watch";
+        label = 'Live Watch';
         isLowPriority = true;
         footerMessage = 'Live Watch stays active in the background.';
     }
@@ -142,7 +263,8 @@ export const ActivityDock: React.FC = () => {
     const total = progress?.total ?? 0;
     const mode = progress?.mode;
     const isCompleteProgress = mode === 'complete';
-    const showIndeterminateProgress = mode === 'indeterminate' || (total === 0 && active && !isCompleteProgress && (!isLiveWatchActive || !isLiveWatchSummary));
+    const showIndeterminateProgress = liveWatchPresentation.isActiveWork || mode === 'indeterminate' || (total === 0 && active && !isCompleteProgress && !isLiveWatchVisible);
+    const showProgressBar = !isLiveWatchVisible || liveWatchPresentation.isExpanded;
 
     const [elapsedNow, setElapsedNow] = React.useState(() => Date.now());
 
@@ -156,9 +278,11 @@ export const ActivityDock: React.FC = () => {
         return () => window.clearInterval(interval);
     }, [active, progress?.startedAt, showIndeterminateProgress]);
 
-    const message = progress?.message || progress?.phase || (isLiveWatchActive ? liveWatchSession.message || '' : '');
-    const percent = isLiveWatchSummary || isCompleteProgress ? 100 : total > 0 ? Math.round((current / total) * 100) : 0;
-    const showCounts = total > 0 && !isLiveWatchActive && !isBackgroundActive && !showIndeterminateProgress && !isCompleteProgress;
+    const message = isLiveWatchVisible
+        ? liveWatchPresentation.message
+        : (progress?.message || progress?.phase || '');
+    const percent = isLiveWatchVisible ? 0 : isCompleteProgress ? 100 : total > 0 ? Math.round((current / total) * 100) : 0;
+    const showCounts = total > 0 && !isLiveWatchVisible && !isBackgroundActive && !showIndeterminateProgress && !isCompleteProgress;
     const smartThumbnailHasFailures = isBackgroundActive && message.includes('need attention');
     const smartThumbnailIsComplete = isBackgroundActive && total > 0 && current >= total;
     const visibleFooterMessage = smartThumbnailHasFailures
@@ -167,12 +291,24 @@ export const ActivityDock: React.FC = () => {
     const elapsedLabel = progress?.startedAt && active && showIndeterminateProgress && !isCompleteProgress
         ? formatElapsed(elapsedNow - progress.startedAt)
         : null;
-    const secondaryDetails = [
-        ...splitDetailItems(progress?.detail),
-        elapsedLabel
-    ].filter((item): item is string => Boolean(item));
+    const secondaryDetails = isLiveWatchVisible
+        ? []
+        : [
+            ...splitDetailItems(progress?.detail),
+            elapsedLabel
+        ].filter((item): item is string => Boolean(item));
     const hasMultipleSecondaryDetails = secondaryDetails.length > 1;
-    const accentClasses = isLiveWatchTone || isLowPriority
+    const shouldUseSparkles = isLiveWatchTone || isLowPriority;
+    const shouldPulseSparkles = isLowPriority && !isLiveWatchTone;
+    const accentClasses = isLiveWatchTone
+        ? {
+            iconText: 'text-sage-600 dark:text-sage-400',
+            iconBg: 'bg-sage-500/10 text-sage-600 dark:text-sage-400',
+            fill: 'bg-sage-500 shadow-[0_0_12px_rgba(139,174,124,0.32)]',
+            pillHover: 'hover:shadow-[0_0_15px_rgba(139,174,124,0.2)]',
+            percentText: 'text-sage-600 dark:text-sage-400'
+        }
+        : isLowPriority
         ? {
             iconText: 'text-violet-600 dark:text-violet-400',
             iconBg: 'bg-violet-500/10 text-violet-600 dark:text-violet-400',
@@ -188,7 +324,16 @@ export const ActivityDock: React.FC = () => {
             percentText: 'text-sage-600 dark:text-sage-400'
         };
 
-    const shouldShow = active && !isActivityDockDismissed;
+    const dismissDock = React.useCallback(() => {
+        if (isLiveWatchVisible) {
+            setDismissedLiveWatchPresentationKey(liveWatchPresentation.presentationKey);
+            return;
+        }
+
+        setIsActivityDockDismissed(true);
+    }, [isLiveWatchVisible, liveWatchPresentation.presentationKey, setIsActivityDockDismissed]);
+
+    const shouldShow = active && (isLiveWatchVisible || !isActivityDockDismissed);
 
     return (
         <AnimatePresence>
@@ -209,11 +354,11 @@ export const ActivityDock: React.FC = () => {
                             title="Click to expand details"
                         >
                             <motion.div layout="position" className={accentClasses.iconText}>
-                                {isLiveWatchTone || isLowPriority ? <Sparkles className="w-5 h-5 animate-pulse" /> : <Loader2 className="w-5 h-5 animate-spin" />}
+                                {shouldUseSparkles ? <Sparkles className={`w-5 h-5 ${shouldPulseSparkles ? 'animate-pulse' : ''}`} /> : <Loader2 className="w-5 h-5 animate-spin" />}
                             </motion.div>
                             <motion.div layout="position" className="w-12 h-1 bg-gray-200 dark:bg-zinc-700 rounded-full overflow-hidden mr-1">
                                 <div
-                                    className={`h-full ${isLiveWatchTone || isLowPriority ? 'bg-violet-500' : 'bg-sage-500'}`}
+                                    className={`h-full ${isLiveWatchTone || !isLowPriority ? 'bg-sage-500' : 'bg-violet-500'}`}
                                     style={{ width: `${percent}%` }}
                                 />
                             </motion.div>
@@ -226,13 +371,28 @@ export const ActivityDock: React.FC = () => {
                             <div className="flex items-center justify-between gap-4">
                                 <div className="flex items-center gap-3">
                                     <motion.div layout="position" className={`p-2 rounded-lg ${accentClasses.iconBg}`}>
-                                        {isScanningDuplicates ? <Fingerprint className="w-4 h-4" /> : isScanningMissingFiles ? <Search className="w-4 h-4" /> : isLiveWatchTone || isLowPriority ? <Sparkles className="w-4 h-4" /> : <Loader2 className="w-4 h-4 animate-spin" />}
+                                        {isScanningDuplicates ? <Fingerprint className="w-4 h-4" /> : isScanningMissingFiles ? <Search className="w-4 h-4" /> : shouldUseSparkles ? <Sparkles className={`w-4 h-4 ${shouldPulseSparkles ? 'animate-pulse' : ''}`} /> : <Loader2 className="w-4 h-4 animate-spin" />}
                                     </motion.div>
                                     <motion.div layout="position">
-                                        <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-500 italic opacity-80 leading-none mb-1">Background Activity</h4>
+                                        <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-500 italic opacity-80 leading-none mb-1">{isLiveWatchVisible ? 'Live Watch' : 'Background Activity'}</h4>
                                         <p className="text-sm font-bold text-gray-900 dark:text-white flex items-center gap-2">
-                                            {label}
-                                            {showCounts && <span className="text-xs font-medium text-gray-400 font-mono tracking-tight">{current.toLocaleString()} / {total.toLocaleString()}</span>}
+                                            {isLiveWatchVisible ? (
+                                                liveWatchPresentation.sourceLabel && (
+                                                    <span className={LIVE_WATCH_SOURCE_CHIP_CLASS}>
+                                                        {liveWatchPresentation.sourceLabel}
+                                                    </span>
+                                                )
+                                            ) : (
+                                                <>
+                                                    {label}
+                                                    {showCounts && <span className="text-xs font-medium text-gray-400 font-mono tracking-tight">{current.toLocaleString()} / {total.toLocaleString()}</span>}
+                                                </>
+                                            )}
+                                            {isLiveWatchVisible && !liveWatchPresentation.sourceLabel && (
+                                                <span className={LIVE_WATCH_SOURCE_CHIP_CLASS}>
+                                                    Watch
+                                                </span>
+                                            )}
                                         </p>
                                     </motion.div>
                                 </div>
@@ -245,7 +405,7 @@ export const ActivityDock: React.FC = () => {
                                         <Minus className="w-3.5 h-3.5" />
                                     </button>
                                     <button
-                                        onClick={() => setIsActivityDockDismissed(true)}
+                                        onClick={dismissDock}
                                         className="p-1.5 hover:bg-black/5 dark:hover:bg-white/5 rounded-lg text-gray-400 hover:text-gray-900 dark:hover:text-white transition-all hover:scale-105 active:scale-95"
                                         title="Dismiss"
                                     >
@@ -255,22 +415,24 @@ export const ActivityDock: React.FC = () => {
                             </div>
 
                             <motion.div layout="position" className="space-y-1.5">
-                                <div className="w-full h-2 bg-gray-100 dark:bg-black/40 rounded-full overflow-hidden relative">
-                                    <motion.div
-                                        initial={{ width: 0 }}
-                                        animate={{ width: `${percent}%` }}
-                                        transition={{ duration: 0.5, ease: "easeOut" }}
-                                        className={`h-full ${accentClasses.fill}`}
-                                    />
-                                    {showIndeterminateProgress && (
+                                {showProgressBar && (
+                                    <div data-testid="activity-dock-progress-rail" className="w-full h-2 bg-gray-100 dark:bg-black/40 rounded-full overflow-hidden relative">
                                         <motion.div
-                                            initial={{ x: "-100%" }}
-                                            animate={{ x: "200%" }}
-                                            transition={{ repeat: Infinity, duration: 1.5, ease: "linear" }}
-                                            className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent w-full"
+                                            initial={{ width: 0 }}
+                                            animate={{ width: `${percent}%` }}
+                                            transition={{ duration: 0.5, ease: "easeOut" }}
+                                            className={`h-full ${accentClasses.fill}`}
                                         />
-                                    )}
-                                </div>
+                                        {showIndeterminateProgress && (
+                                            <motion.div
+                                                initial={{ x: "-100%" }}
+                                                animate={{ x: "200%" }}
+                                                transition={{ repeat: Infinity, duration: 1.5, ease: "linear" }}
+                                                className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent w-full"
+                                            />
+                                        )}
+                                    </div>
+                                )}
                                 <div className="flex justify-between items-center px-0.5">
                                     <p className="text-[11px] font-medium text-gray-500 dark:text-gray-400 truncate flex-1 pr-4 h-4 leading-4">
                                         {message || "Starting work..."}

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -73,31 +73,27 @@ export const AppHeader = React.memo(({
 
     const isManualSyncing = syncStatus === 'syncing';
     const isLiveWatchActive = liveWatchSession.active;
-    const isLiveWatchSummary = isLiveWatchActive && liveWatchSession.phase === 'summary';
+    const isLiveWatchWorkActive = isLiveWatchActive && (liveWatchSession.phase === 'syncing' || liveWatchSession.phase === 'importing');
     const isNonLiveTaskActive = isImporting || isManualSyncing || isResolvingModels || isScanningDiscovery;
-    const isHighPriority = isNonLiveTaskActive || isLiveWatchActive;
-    const active = isHighPriority || isBackgroundHealingActive;
+    const active = isNonLiveTaskActive || isBackgroundHealingActive;
 
     const progress = (isImporting && importProgress)
         ? importProgress
         : (isManualSyncing
             ? syncProgress
-            : (isLiveWatchActive
-                ? (liveWatchSession.progress || {
-                    current: isLiveWatchSummary ? 1 : 0,
-                    total: isLiveWatchSummary ? 1 : 0,
-                    message: liveWatchSession.message
-                })
-                : (isResolvingModels
-                    ? modelResolutionProgress
-                    : (isScanningDiscovery ? discoveryScanProgress : (isBackgroundHealingActive ? backgroundHealingProgress : null)))));
+            : (isResolvingModels
+                ? modelResolutionProgress
+                : (isScanningDiscovery ? discoveryScanProgress : (isBackgroundHealingActive ? backgroundHealingProgress : null))));
 
     // Determine color
-    const isBackgroundOnly = isBackgroundHealingActive && !isHighPriority;
-    const progressColorInfo = isLiveWatchActive || isBackgroundOnly
+    const isBackgroundOnly = isBackgroundHealingActive && !isNonLiveTaskActive;
+    const progressColorInfo = isBackgroundOnly
         ? { bar: 'bg-violet-500', shadow: 'shadow-[0_0_10px_rgba(139,92,246,0.3)]', bg: 'bg-violet-500/10' }
         : { bar: 'bg-sage-500', shadow: 'shadow-[0_0_10px_rgba(110,121,107,0.5)]', bg: 'bg-sage-500/10' };
     const shouldHighlightImport = isNonLiveTaskActive || isBackgroundHealingActive;
+    const liveWatchButtonClass = isLiveWatching
+        ? `bg-sage-500/10 border-sage-500/30 text-sage-600 shadow-sm shadow-sage-500/10 hover:border-red-500/30 hover:text-red-500 dark:bg-sage-500/15 dark:border-sage-400/30 dark:text-sage-300 ${isLiveWatchWorkActive ? 'ring-1 ring-sage-500/20' : ''}`
+        : 'bg-gray-100 dark:bg-zinc-800/50 border-gray-200 dark:border-white/10 text-gray-400 hover:text-sage-600 hover:border-sage-500/30 dark:hover:text-sage-300';
 
     // Determine visibility of middle controls
     const showLayoutSwitcher = viewMode === 'grid';
@@ -109,7 +105,7 @@ export const AppHeader = React.memo(({
                 {/* Background clip layer for elements that need rounding (like progress bar) */}
                 <div className="absolute inset-0 rounded-2xl overflow-hidden pointer-events-none">
                     {active && (
-                        <div className={`absolute top-0 left-0 right-0 h-1 ${progressColorInfo.bg} overflow-hidden`}>
+                        <div data-testid="app-header-progress-rail" className={`absolute top-0 left-0 right-0 h-1 ${progressColorInfo.bg} overflow-hidden`}>
                             <div
                                 className={`h-full ${progressColorInfo.bar} ${progressColorInfo.shadow} transition-all duration-300 ease-out`}
                                 style={{
@@ -154,8 +150,8 @@ export const AppHeader = React.memo(({
                                 }
                                 setIsLiveWatching(!isLiveWatching);
                             }}
-                            className={`p-2 rounded-xl transition-all border relative group ${isLiveWatching ? 'bg-red-500 text-white border-red-600 shadow-md shadow-red-500/20 animate-pulse' : 'bg-gray-100 dark:bg-zinc-800/50 border-gray-200 dark:border-white/10 text-gray-400 hover:text-red-500'}`}
-                            title={isLiveWatching ? "Live Sync Active – Watching for new images in monitored folders" : "Enable Live Sync – Automatically detect and import new images from your generator output folders"}
+                            className={`p-2 rounded-xl transition-all border relative group ${liveWatchButtonClass}`}
+                            title={isLiveWatching ? "Live Watch enabled - Watching monitored folders" : "Enable Live Watch - Automatically detect and import new images from generator output folders"}
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="w-4 h-4"><path d="M22 12h-4l-3 9L9 3l-3 9H2" /></svg>
                         </button>

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -1,6 +1,6 @@
 ﻿import * as React from 'react';
 import { act, fireEvent, render, screen } from '../../../test/testUtils';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ActivityDock } from '../ActivityDock';
 import { createInitialLiveWatchSessionState, useLibraryStore } from '../../../stores/libraryStore';
 
@@ -51,6 +51,10 @@ describe('ActivityDock', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         resetLibraryStore();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it('renders the manual syncing card with cancel controls', () => {
@@ -349,51 +353,430 @@ describe('ActivityDock', () => {
         expect(screen.queryByText('100%')).toBeNull();
     });
 
-    it('renders a unified Live Watch card without cancel controls during active live work', () => {
+    it('keeps Live Watch watching phase out of the dock', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'watching',
+            message: 'Checking InvokeAI for completed images...'
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+        expect(screen.queryByText('Checking InvokeAI for completed images...')).toBeNull();
+        expect(screen.queryByTestId('activity-dock-progress-rail')).toBeNull();
+    });
+
+    it('keeps quick InvokeAI live sync hidden when it settles before the reveal delay', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
         useLibraryStore.getState().startLiveWatchSession('invoke', {
             phase: 'syncing',
-            message: 'Preparing live InvokeAI sync...',
+            message: 'Syncing completed InvokeAI images...',
+            progress: { current: 0, total: 0, message: undefined }
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            vi.advanceTimersByTime(2499);
+        });
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'summary',
+                message: 'Watching for new images...',
+                progress: null
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+        expect(screen.queryByText('Updating your library...')).toBeNull();
+        expect(screen.queryByText('Watching for new images...')).toBeNull();
+    });
+
+    it('keeps zero-result and image-result summaries out of the dock', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...'
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'summary',
+                message: 'Watching for new images...',
+                progress: null
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+        expect(screen.queryByText('Watching for new images...')).toBeNull();
+
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'syncing',
+                message: 'Syncing completed InvokeAI images...'
+            });
+            useLibraryStore.getState().reportLiveImagesReceived(2, { source: 'invoke' });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+        expect(screen.queryByText('2 images added this session.')).toBeNull();
+        expect(screen.queryByTestId('live-watch-compact-result')).toBeNull();
+        expect(screen.queryByTestId('activity-dock-progress-rail')).toBeNull();
+        expect(screen.queryByText('100%')).toBeNull();
+    });
+
+    it('reveals sustained InvokeAI Live Watch sync with stable user-facing copy', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...',
             progress: { current: 0, total: 0, message: undefined }
         });
 
         const { container } = render(<ActivityDock />);
+
+        act(() => {
+            vi.advanceTimersByTime(2499);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+
         const card = container.querySelector('[layoutid="dock-content"]');
-        const progressFill = container.querySelector('.bg-violet-400');
 
         expect(screen.getByText('Live Watch')).toBeTruthy();
-        expect(screen.getByText('Preparing live InvokeAI sync...')).toBeTruthy();
+        expect(screen.getByText('InvokeAI')).toBeTruthy();
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
         expect(screen.queryByText('Syncing')).toBeNull();
+        expect(screen.queryByText('Checking')).toBeNull();
+        expect(screen.queryByText('Importing')).toBeNull();
+        expect(screen.queryByText('Syncing completed InvokeAI images...')).toBeNull();
+        expect(screen.queryByText('Background Activity')).toBeNull();
         expect(screen.queryByText('Cancel')).toBeNull();
         expect(screen.queryByText('0 / 0')).toBeNull();
         expect(card?.className).toContain('w-[min(400px,calc(100vw-2rem))]');
-        expect(progressFill).toBeTruthy();
-        expect(container.querySelector('.text-sage-600')).toBeNull();
+        expect(screen.getByTestId('activity-dock-progress-rail')).toBeTruthy();
+        expect(container.querySelector('.bg-gradient-to-r')).toBeTruthy();
+        expect(container.querySelector('.bg-sage-500')).toBeTruthy();
+        expect(container.querySelector('.text-sage-600')).toBeTruthy();
+        expect(container.innerHTML).not.toContain('signal');
+        expect(container.querySelector('.bg-violet-400')).toBeNull();
+        expect(container.innerHTML).not.toContain('amethyst');
     });
 
-    it('keeps the same Live Watch card through summary updates', () => {
+    it('reveals sustained folder Live Watch import and keeps source context stable', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
         const { container } = render(<ActivityDock />);
 
         act(() => {
             useLibraryStore.getState().startLiveWatchSession('generic', {
                 phase: 'importing',
-                message: 'Importing live images...',
-                progress: { current: 1, total: 2, message: undefined }
+                message: 'Importing new images...',
+                progress: { current: 1, total: 3, message: undefined }
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(2500);
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+        expect(screen.getByText('Folders')).toBeTruthy();
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
+
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'syncing',
+                message: 'Syncing completed InvokeAI images...',
+                progress: { current: 0, total: 0, message: undefined }
+            });
+        });
+
+        expect(screen.getByText('Mixed')).toBeTruthy();
+        expect(screen.queryByText('Folders')).toBeNull();
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
+        expect(container.querySelector('.bg-sage-500')).toBeTruthy();
+        expect(container.innerHTML).not.toContain('signal');
+        expect(container.innerHTML).not.toContain('violet');
+        expect(container.innerHTML).not.toContain('amethyst');
+    });
+
+    it('keeps visible Live Watch copy stable across active sync and import phase changes', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...'
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            vi.advanceTimersByTime(2500);
+        });
+
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'syncing',
+                message: 'Syncing completed InvokeAI images...',
+                progress: { current: 0, total: 0, message: undefined }
+            });
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'importing',
+                message: 'Importing new images...',
+                progress: { current: 1, total: 3, message: undefined }
             });
         });
 
         expect(screen.getByText('Live Watch')).toBeTruthy();
-        expect(screen.getByText('Importing live images...')).toBeTruthy();
+        expect(screen.getByText('InvokeAI')).toBeTruthy();
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
+        expect(screen.queryByText('Checking InvokeAI for completed images...')).toBeNull();
+        expect(screen.queryByText('Syncing completed InvokeAI images...')).toBeNull();
+        expect(screen.queryByText('Importing new images...')).toBeNull();
+        expect(screen.queryByText('Syncing')).toBeNull();
+        expect(screen.queryByText('Importing')).toBeNull();
+    });
+
+    it('keeps Live Watch visible through close grace after sustained work settles', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...'
+        });
+
+        render(<ActivityDock />);
 
         act(() => {
-            useLibraryStore.getState().reportLiveImagesReceived(2, { source: 'generic' });
+            vi.advanceTimersByTime(2500);
         });
 
         expect(screen.getByText('Live Watch')).toBeTruthy();
-        expect(screen.getByText('2 images received this session. Watching for more...')).toBeTruthy();
-        expect(screen.queryByText('Syncing')).toBeNull();
-        expect(screen.queryByText('Cancel')).toBeNull();
-        expect(screen.getByText('Live Watch stays active in the background.')).toBeTruthy();
-        expect(container.querySelector('.bg-violet-400')).toBeTruthy();
-        expect(container.querySelector('.bg-gradient-to-r')).toBeNull();
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
+
+        act(() => {
+            vi.advanceTimersByTime(2200);
+        });
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'summary',
+                message: 'Watching for new images...',
+                progress: null
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(1499);
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+    });
+
+    it('respects the minimum visible time when sustained work settles immediately after reveal', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...',
+            progress: { current: 0, total: 0, message: undefined }
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            vi.advanceTimersByTime(2500);
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'summary',
+                message: 'Watching for new images...',
+                progress: null
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(2199);
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+    });
+
+    it('keeps dismissed Live Watch hidden for the current presentation but allows a later sustained batch', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...'
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            vi.advanceTimersByTime(2500);
+        });
+
+        fireEvent.click(screen.getByTitle('Dismiss'));
+        expect(screen.queryByText('Live Watch')).toBeNull();
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'syncing',
+                message: 'Still syncing...',
+                progress: { current: 1, total: 2, message: undefined }
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(5000);
+        });
+
+        expect(screen.queryByText('Live Watch')).toBeNull();
+
+        act(() => {
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'summary',
+                message: 'Watching for new images...',
+                progress: null
+            });
+        });
+
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'syncing',
+                message: 'Syncing completed InvokeAI images...'
+            });
+        });
+
+        act(() => {
+            vi.advanceTimersByTime(2500);
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+        expect(screen.getByText('Updating your library...')).toBeTruthy();
+    });
+
+    it('lets higher-priority work replace visible Live Watch immediately', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'syncing',
+            message: 'Syncing completed InvokeAI images...'
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            vi.advanceTimersByTime(2500);
+        });
+
+        expect(screen.getByText('Live Watch')).toBeTruthy();
+
+        act(() => {
+            useLibraryStore.setState({
+                isImporting: true,
+                importProgress: {
+                    current: 1,
+                    total: 2,
+                    message: 'Importing selected files...'
+                }
+            });
+        });
+
+        expect(screen.getByText('Background Activity')).toBeTruthy();
+        expect(screen.getByText('Importing selected files...')).toBeTruthy();
+        expect(screen.queryByText('InvokeAI')).toBeNull();
+        expect(screen.queryByText('Updating your library...')).toBeNull();
+    });
+
+    it('keeps higher-priority work in control while Live Watch watching remains ambient', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+        useLibraryStore.getState().startLiveWatchSession('invoke', {
+            phase: 'watching',
+            message: 'Checking InvokeAI for completed images...'
+        });
+
+        render(<ActivityDock />);
+
+        act(() => {
+            useLibraryStore.setState({
+                isImporting: true,
+                importProgress: {
+                    current: 1,
+                    total: 2,
+                    message: 'Importing selected files...'
+                }
+            });
+        });
+
+        expect(screen.getByText('Background Activity')).toBeTruthy();
+        expect(screen.getByText('Importing selected files...')).toBeTruthy();
+        expect(screen.queryByText('InvokeAI')).toBeNull();
+        expect(screen.queryByText('Updating your library...')).toBeNull();
     });
 });

--- a/src/components/ui/__tests__/AppHeader.test.tsx
+++ b/src/components/ui/__tests__/AppHeader.test.tsx
@@ -91,19 +91,65 @@ describe('AppHeader', () => {
         resetLibraryStore();
     });
 
-    it('uses the purple header strip and leaves the import button neutral during live watch', () => {
+    it('uses calm Live Watch enabled styling without constant header activity', () => {
+        useLibraryStore.getState().setIsLiveWatching(true);
+
+        const { container } = render(<AppHeader {...defaultProps} />);
+        const liveWatchButton = screen.getByTitle(/Live Watch enabled/);
+        const importButton = screen.getByTitle(/Import images\./);
+
+        expect(liveWatchButton.className).toContain('bg-sage-500/10');
+        expect(liveWatchButton.className).toContain('text-sage-600');
+        expect(liveWatchButton.className).not.toContain('signal');
+        expect(liveWatchButton.className).not.toContain('violet');
+        expect(liveWatchButton.className).not.toContain('amethyst');
+        expect(liveWatchButton.className).not.toContain('bg-red-500');
+        expect(liveWatchButton.className).not.toContain('animate-pulse');
+        expect(importButton.className).not.toContain('bg-sage-500/20');
+        expect(screen.queryByTestId('app-header-progress-rail')).toBeNull();
+        expect(container.querySelector('.bg-violet-500')).toBeNull();
+    });
+
+    it('keeps Live Watch work out of the header progress rail while adding only a calm button ring', () => {
+        useLibraryStore.getState().setIsLiveWatching(true);
         useLibraryStore.getState().startLiveWatchSession('invoke', {
             phase: 'syncing',
-            message: 'Preparing live InvokeAI sync...',
+            message: 'Syncing completed InvokeAI images...',
             progress: { current: 0, total: 0, message: undefined }
         });
 
         const { container } = render(<AppHeader {...defaultProps} />);
         const importButton = screen.getByTitle(/Import images\./);
+        const liveWatchButton = screen.getByTitle(/Live Watch enabled/);
 
-        expect(container.querySelector('.bg-violet-500')).toBeTruthy();
+        expect(screen.queryByTestId('app-header-progress-rail')).toBeNull();
+        expect(container.querySelector('.bg-violet-500')).toBeNull();
+        expect(liveWatchButton.className).toContain('ring-sage-500/20');
+        expect(liveWatchButton.className).not.toContain('animate-pulse');
+        expect(liveWatchButton.className).not.toContain('signal');
+        expect(liveWatchButton.className).not.toContain('violet');
+        expect(liveWatchButton.className).not.toContain('amethyst');
+        expect(liveWatchButton.className).not.toContain('bg-red-500');
         expect(importButton.className).not.toContain('bg-sage-500/20');
         expect(importButton.className).toContain('bg-gray-100');
+    });
+
+    it('also keeps Live Watch importing work out of the header progress rail', () => {
+        useLibraryStore.getState().setIsLiveWatching(true);
+        useLibraryStore.getState().startLiveWatchSession('generic', {
+            phase: 'importing',
+            message: 'Importing new images...',
+            progress: { current: 1, total: 3, message: undefined }
+        });
+
+        render(<AppHeader {...defaultProps} />);
+        const importButton = screen.getByTitle(/Import images\./);
+        const liveWatchButton = screen.getByTitle(/Live Watch enabled/);
+
+        expect(screen.queryByTestId('app-header-progress-rail')).toBeNull();
+        expect(liveWatchButton.className).toContain('ring-sage-500/20');
+        expect(liveWatchButton.className).not.toContain('signal');
+        expect(importButton.className).not.toContain('bg-sage-500/20');
     });
 
     it('keeps manual sync on the existing non-live-watch styling', () => {
@@ -115,8 +161,32 @@ describe('AppHeader', () => {
         const { container } = render(<AppHeader {...defaultProps} />);
         const importButton = screen.getByTitle(/Import images\./);
 
+        expect(screen.getByTestId('app-header-progress-rail')).toBeTruthy();
         expect(container.querySelector('.bg-sage-500')).toBeTruthy();
         expect(importButton.className).toContain('bg-sage-500/20');
+    });
+
+    it('keeps import and discovery scans on the header progress rail', () => {
+        useLibraryStore.setState({
+            isImporting: true,
+            importProgress: { current: 1, total: 4, message: 'Importing...' }
+        });
+
+        const { rerender } = render(<AppHeader {...defaultProps} />);
+
+        expect(screen.getByTestId('app-header-progress-rail')).toBeTruthy();
+        expect(screen.getByTitle(/Import images\./).className).toContain('bg-sage-500/20');
+
+        useLibraryStore.setState({
+            isImporting: false,
+            importProgress: null,
+            isScanningDiscovery: true,
+            discoveryScanProgress: { current: 0, total: 0, message: 'Scanning resources...', mode: 'indeterminate' }
+        });
+        rerender(<AppHeader {...defaultProps} />);
+
+        expect(screen.getByTestId('app-header-progress-rail')).toBeTruthy();
+        expect(screen.getByTitle(/Import images\./).className).toContain('bg-sage-500/20');
     });
 
     it('opens the import flow from the header import button', () => {

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -198,8 +198,8 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             ? options.importIntermediates
             : settingsRef.current.importIntermediates;
         const shouldImportOrphans = options.importOrphans !== undefined
-            ? options.importOrphans
-            : settingsRef.current.importOrphans;
+            ? options.importOrphans === true
+            : options.mode === 'manual' && settingsRef.current.importOrphans === true;
         const effectiveSnapshotConfig = {
             lastSyncedAt: effectiveTimestamp,
             importIntermediates: effectiveImportIntermediates,
@@ -265,7 +265,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             setSyncProgress({ current: 0, total: 0, message: undefined });
             startLiveWatchSession('invoke', {
                 phase: 'syncing',
-                message: 'Preparing live InvokeAI sync...',
+                message: 'Syncing completed InvokeAI images...',
                 progress: { current: 0, total: 0, message: undefined }
             });
             debugLiveWatchPerf('Invoke sync started', {
@@ -283,7 +283,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
         const ctrl = new AbortController();
         setSyncAbortController(ctrl);
         const persistInvokeSnapshot = async (lastSyncedAt: number | null | undefined) => {
-            if (!settingsRef.current.invokeAiPath || options.mode === 'live' || shouldImportOrphans !== false) return;
+            if (!settingsRef.current.invokeAiPath || options.mode === 'live' || shouldImportOrphans) return;
 
             try {
                 const snapshot = await readInvokeDbSnapshotState(
@@ -319,7 +319,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         updateLiveWatchSession({
                             source: 'invoke',
                             phase: 'syncing',
-                            message: msg || 'Synchronizing InvokeAI images...',
+                            message: msg || 'Syncing completed InvokeAI images...',
                             progress: { current: c, total: t, message: undefined }
                         });
                     } else {
@@ -372,9 +372,8 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
 
             // Orphan scanning
             let orphansImported = 0;
-            const shouldImportOrphans = options.importOrphans !== undefined ? options.importOrphans : settingsRef.current.importOrphans;
 
-            if (options.mode !== 'live' && shouldImportOrphans !== false) {
+            if (options.mode !== 'live' && shouldImportOrphans) {
                 orphansImported = await scanForOrphans(
                     settingsRef.current.invokeAiPath!,
                     syncedIds,
@@ -461,7 +460,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                                 totalProcessed,
                                 touchedFacetTypes,
                                 touchedFacetResources,
-                                orphanScanEnabled: shouldImportOrphans !== false,
+                                orphanScanEnabled: shouldImportOrphans,
                                 onRefreshApplied: () => useLibraryStore.getState().incrementFacetCacheVersion()
                             });
                         } else {
@@ -514,7 +513,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                             totalProcessed,
                             touchedFacetTypes,
                             touchedFacetResources,
-                            orphanScanEnabled: shouldImportOrphans !== false,
+                            orphanScanEnabled: shouldImportOrphans,
                             onRefreshApplied: () => useLibraryStore.getState().incrementFacetCacheVersion()
                         });
                     }
@@ -619,7 +618,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 const targetedSyncStartedAt = liveWatchNow();
                 startLiveWatchSession('generic', {
                     phase: 'importing',
-                    message: 'Preparing live import...',
+                    message: 'Importing new images...',
                     progress: { current: 0, total: nextBatch.length, message: undefined }
                 });
 
@@ -640,7 +639,7 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                             updateLiveWatchSession({
                                 source: 'generic',
                                 phase: 'importing',
-                                message: message || 'Importing live images...',
+                                message: message || 'Importing new images...',
                                 progress: { current, total, message: undefined }
                             });
                         },

--- a/src/contexts/WatcherContext.tsx
+++ b/src/contexts/WatcherContext.tsx
@@ -86,7 +86,7 @@ const mergeInvokePerfContext = (
 
 export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected?: (scope?: MetadataRefreshScope) => void | Promise<void> }> = ({ children, onNewImageDetected }) => {
     const { settings, isLoaded } = useSettings();
-    const { startInvokeSync, startTargetedLiveSync } = useSync();
+    const { startInvokeSync, startTargetedLiveSync, syncStatus } = useSync();
 
     // Zustand State
     const isLiveWatching = useLibraryStore(s => s.isLiveWatching);
@@ -123,15 +123,16 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
     const invokePathConfig = settings.invokeAiPath;
 
     // Stable ref for callbacks to avoid restarting watcher on every render
-    const callbacksRef = useRef({ onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync });
+    const callbacksRef = useRef({ onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync, syncStatus });
     const invokeSyncTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const pendingGenericPathsRef = useRef<Set<string>>(new Set());
     const pendingGenericPerfRef = useRef<TargetedLiveSyncPerfContext | null>(null);
     const pendingInvokePerfRef = useRef<InvokeLiveWatchPerfContext | null>(null);
     const genericLiveDrainPromiseRef = useRef<Promise<void> | null>(null);
+    const invokeActivationCatchupRootRef = useRef<string | null>(null);
 
     useEffect(() => {
-        callbacksRef.current = { onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync };
+        callbacksRef.current = { onNewImageDetected, refreshMaintenanceCounts, startInvokeSync, settings, startTargetedLiveSync, syncStatus };
     });
 
     const drainGenericLiveChanges = useCallback(async (paths: string[]) => {
@@ -198,6 +199,9 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
 
     useEffect(() => {
         if (!isLoaded) return;
+        if (!isLiveWatching) {
+            invokeActivationCatchupRootRef.current = null;
+        }
 
         const initWatcher = async () => {
             if (!isLiveWatching) {
@@ -207,6 +211,7 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
 
             const currentSettings = callbacksRef.current.settings;
             const pathsToWatch: string[] = [];
+            const activeInvokeRoot = normalizeInvokeRoot(currentSettings.invokeAiPath);
 
             if (currentSettings.monitoredFolders) {
                 currentSettings.monitoredFolders.forEach(f => {
@@ -214,9 +219,10 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
                 });
             }
 
-            if (currentSettings.invokeAiPath) {
-                const root = normalizeInvokeRoot(currentSettings.invokeAiPath);
-                if (root) pathsToWatch.push(`${root}/databases`);
+            if (activeInvokeRoot) {
+                pathsToWatch.push(`${activeInvokeRoot}/databases`);
+            } else {
+                invokeActivationCatchupRootRef.current = null;
             }
 
             if (pathsToWatch.length === 0) {
@@ -264,7 +270,7 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
                 if (genericPaths.length > 0) {
                     startLiveWatchSession('generic', {
                         phase: 'watching',
-                        message: 'Detected new files. Preparing live import...'
+                        message: 'Checking monitored folders...'
                     });
                     pendingGenericPerfRef.current = mergeTargetedPerfContext(
                         pendingGenericPerfRef.current,
@@ -287,7 +293,7 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
                 if (invokePaths.length > 0 && cb.settings.invokeAiPath) {
                     startLiveWatchSession('invoke', {
                         phase: 'watching',
-                        message: 'Detected InvokeAI activity. Waiting for completed images...'
+                        message: 'Checking InvokeAI for completed images...'
                     });
                     pendingInvokePerfRef.current = mergeInvokePerfContext(
                         pendingInvokePerfRef.current,
@@ -352,6 +358,27 @@ export const WatcherProvider: React.FC<{ children: ReactNode; onNewImageDetected
                 watchedPathCount: pathsToWatch.length,
                 invokeDebounceMs: INVOKE_LIVE_DEBOUNCE_MS
             });
+
+            if (activeInvokeRoot) {
+                const activationKey = activeInvokeRoot.toLowerCase();
+                const cb = callbacksRef.current;
+
+                if (invokeActivationCatchupRootRef.current !== activationKey) {
+                    invokeActivationCatchupRootRef.current = activationKey;
+
+                    if (cb.syncStatus === 'syncing') {
+                        debugLiveWatchPerf('Invoke activation catch-up skipped', {
+                            reason: 'sync-already-active',
+                            root: activeInvokeRoot
+                        });
+                    } else {
+                        debugLiveWatchPerf('Invoke activation catch-up started', {
+                            root: activeInvokeRoot
+                        });
+                        void cb.startInvokeSync({ mode: 'live' });
+                    }
+                }
+            }
 
         };
 

--- a/src/contexts/__tests__/LibraryIntegration.test.tsx
+++ b/src/contexts/__tests__/LibraryIntegration.test.tsx
@@ -6,6 +6,7 @@ import { LibraryProvider, useLibraryContext } from '../LibraryContext';
 import { useSync } from '../SyncContext';
 import { ToastProvider } from '../ToastContext';
 import { useLibraryStore } from '../../stores/libraryStore';
+import { useSettingsStore } from '../../stores/settingsStore';
 import type { InvokeDbSnapshotState } from '../../types';
 import { INVOKE_PATH_REPAIR_SNAPSHOT_VERSION } from '../../services/invoke/dbSnapshot';
 
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     getLibraryStatsSummary: vi.fn().mockResolvedValue({ totalImages: 0, totalGenerations: 0, avgSteps: 0, estSizeMB: '0', modelStats: [] }),
     getKeywordStats: vi.fn().mockResolvedValue([]),
     syncImages: vi.fn().mockResolvedValue({ imported: 5, updated: 0, maxTimestamp: 100, syncedIds: new Set(), boardMapping: new Map(), touchedFacetTypes: [], touchedFacetResources: { checkpoints: [], loras: [], embeddings: [], hypernetworks: [], controlNets: [], ipAdapters: [], tools: [] } }),
+    scanForOrphans: vi.fn().mockResolvedValue(0),
     rebuildFacetCache: vi.fn().mockResolvedValue(0),
     rebuildFacetCacheStrict: vi.fn().mockResolvedValue(0),
     rebuildFacetCacheIncrementalBatchStrict: vi.fn().mockResolvedValue(0),
@@ -138,7 +140,7 @@ vi.mock('../../services/invoke/syncService', () => ({
 }));
 
 vi.mock('../../services/invoke/orphanScanner', () => ({
-    scanForOrphans: vi.fn().mockResolvedValue(0)
+    scanForOrphans: (...args: unknown[]) => mocks.scanForOrphans(...args)
 }));
 
 vi.mock('../../services/importService', () => ({
@@ -155,6 +157,24 @@ const createDeferred = <T,>() => {
 
     return { promise, resolve, reject };
 };
+
+const createNoopInvokeSyncResult = () => ({
+    imported: 0,
+    updated: 0,
+    maxTimestamp: 100,
+    syncedIds: new Set<string>(),
+    boardMapping: new Map<string, { name: string; createdAt: number }>(),
+    touchedFacetTypes: [],
+    touchedFacetResources: {
+        checkpoints: [],
+        loras: [],
+        embeddings: [],
+        hypernetworks: [],
+        controlNets: [],
+        ipAdapters: [],
+        tools: []
+    }
+});
 
 // --- Test Consumer ---
 const TestConsumer = ({ onHook }: { onHook: (hook: any) => void }) => {
@@ -179,6 +199,7 @@ describe('Library Integration (Provider Stack)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         useLibraryStore.setState(useLibraryStore.getInitialState(), true);
+        useSettingsStore.setState(useSettingsStore.getInitialState(), true);
         // Reset location reload to prevent errors
         Object.defineProperty(window, 'location', {
             configurable: true,
@@ -224,7 +245,9 @@ describe('Library Integration (Provider Stack)', () => {
 
         // Initial state (Privacy Enabled by default)
         expect(hook.privacyEnabled).toBe(true);
-        expect(hook.activeSqlWhere).toContain("privacy_hidden = 0");
+        await waitFor(() => {
+            expect(hook.activeSqlWhere).toContain("privacy_hidden = 0");
+        });
 
         // Disable Privacy
         await act(async () => {
@@ -318,8 +341,218 @@ describe('Library Integration (Provider Stack)', () => {
             expect.any(AbortSignal),
             expect.objectContaining({ mode: 'live' })
         );
+        expect(mocks.scanForOrphans).not.toHaveBeenCalled();
         expect(mocks.searchImages).not.toHaveBeenCalled();
         expect(mocks.getFacets).not.toHaveBeenCalled();
+    });
+
+    it('runs a one-shot Invoke live catch-up after Live Watch attaches for Invoke-only paths', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        mocks.syncImages.mockResolvedValue(createNoopInvokeSyncResult());
+        mocks.syncImages.mockClear();
+        mocks.watcherStartWatching.mockClear();
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai'
+            });
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => {
+            expect(mocks.watcherStartWatching).toHaveBeenCalledWith(
+                ['D:/AI/art/webUI/invokeai/databases'],
+                expect.any(Function)
+            );
+        }, { timeout: 3000 });
+
+        await waitFor(() => {
+            expect(mocks.syncImages).toHaveBeenCalledTimes(1);
+        }, { timeout: 3000 });
+
+        expect(mocks.syncImages).toHaveBeenCalledWith(
+            'D:/AI/art/webUI/invokeai',
+            expect.any(Function),
+            expect.any(AbortSignal),
+            expect.objectContaining({ mode: 'live' })
+        );
+    });
+
+    it('skips the Invoke activation catch-up when a manual sync is already running', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai'
+            });
+        });
+
+        const deferred = createDeferred<ReturnType<typeof createNoopInvokeSyncResult>>();
+        mocks.syncImages.mockReturnValueOnce(deferred.promise);
+        mocks.syncImages.mockClear();
+        mocks.watcherStartWatching.mockClear();
+
+        let manualSyncPromise!: Promise<void> | undefined;
+        await act(async () => {
+            manualSyncPromise = hook?.startInvokeSync({ mode: 'manual' });
+            await Promise.resolve();
+        });
+
+        await waitFor(() => {
+            expect(useLibraryStore.getState().syncStatus).toBe('syncing');
+        });
+
+        await act(async () => {
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => {
+            expect(mocks.watcherStartWatching).toHaveBeenCalledWith(
+                ['D:/AI/art/webUI/invokeai/databases'],
+                expect.any(Function)
+            );
+        }, { timeout: 3000 });
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mocks.syncImages).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            deferred.resolve(createNoopInvokeSyncResult());
+            await manualSyncPromise;
+        });
+    });
+
+    it('keeps generic live imports working while running the Invoke activation catch-up', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        let watcherCallback: ((paths?: string[]) => void) | null = null;
+        mocks.watcherStartWatching.mockImplementationOnce(async (_paths: string[], onChange: (paths?: string[]) => void) => {
+            watcherCallback = onChange;
+        });
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        mocks.syncImages.mockResolvedValue(createNoopInvokeSyncResult());
+        mocks.syncImages.mockClear();
+        mocks.processTargetedFiles.mockClear();
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai',
+                monitoredFolders: [
+                    { id: 'watch-1', path: 'C:/watch', isActive: true, imageCount: 0, lastScanned: 10 }
+                ]
+            });
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => {
+            expect(mocks.watcherStartWatching).toHaveBeenCalledWith(
+                ['C:/watch', 'D:/AI/art/webUI/invokeai/databases'],
+                expect.any(Function)
+            );
+            expect(watcherCallback).not.toBeNull();
+        }, { timeout: 3000 });
+
+        await waitFor(() => {
+            expect(mocks.syncImages).toHaveBeenCalledTimes(1);
+        }, { timeout: 3000 });
+
+        await act(async () => {
+            watcherCallback?.(['C:/watch/new.png']);
+        });
+
+        await waitFor(() => {
+            expect(mocks.processTargetedFiles).toHaveBeenCalledWith(
+                ['C:/watch/new.png'],
+                expect.objectContaining({
+                    forceRescan: true,
+                    waitForStableFiles: true
+                })
+            );
+        });
+    });
+
+    it('does not repeat the Invoke activation catch-up for unrelated watcher restarts', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        mocks.syncImages.mockResolvedValue(createNoopInvokeSyncResult());
+        mocks.syncImages.mockClear();
+        mocks.watcherStartWatching.mockClear();
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai'
+            });
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => {
+            expect(mocks.syncImages).toHaveBeenCalledTimes(1);
+        }, { timeout: 3000 });
+
+        await act(async () => {
+            hook?.setSettings({
+                monitoredFolders: [
+                    { id: 'watch-1', path: 'C:/watch', isActive: true, imageCount: 0, lastScanned: 10 }
+                ]
+            });
+        });
+
+        await waitFor(() => {
+            expect(mocks.watcherStartWatching).toHaveBeenCalledTimes(2);
+        }, { timeout: 3000 });
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mocks.syncImages).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a new Invoke activation catch-up after Live Watch is turned off and back on', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        mocks.syncImages.mockResolvedValue(createNoopInvokeSyncResult());
+        mocks.syncImages.mockClear();
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai'
+            });
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => {
+            expect(mocks.syncImages).toHaveBeenCalledTimes(1);
+        }, { timeout: 3000 });
+
+        await act(async () => {
+            useLibraryStore.getState().setIsLiveWatching(false);
+            await Promise.resolve();
+        });
+
+        await act(async () => {
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => {
+            expect(mocks.syncImages).toHaveBeenCalledTimes(2);
+        }, { timeout: 3000 });
     });
 
     it('does not refresh image queries after a no-op startup Invoke catch-up', async () => {
@@ -352,6 +585,7 @@ describe('Library Integration (Provider Stack)', () => {
         mocks.searchImages.mockClear();
         mocks.getFacets.mockClear();
         mocks.appRepository.save.mockClear();
+        mocks.scanForOrphans.mockClear();
 
         await act(async () => {
             await hook.startInvokeSync({ mode: 'startup' });
@@ -365,6 +599,7 @@ describe('Library Integration (Provider Stack)', () => {
         );
         expect(mocks.searchImages).not.toHaveBeenCalled();
         expect(mocks.getFacets).not.toHaveBeenCalled();
+        expect(mocks.scanForOrphans).not.toHaveBeenCalled();
         expect(mocks.appRepository.save).toHaveBeenCalledWith(expect.objectContaining({
             settings: expect.objectContaining({
                 invokeDbSnapshot: expect.objectContaining({
@@ -376,6 +611,73 @@ describe('Library Integration (Provider Stack)', () => {
         await act(async () => {
             hook.setSettings({ invokeDbSnapshot: undefined });
         });
+    });
+
+    it('does not scan for orphans during startup Invoke catch-up by default', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai/databases',
+                lastSyncedAt: 100,
+                importOrphans: true
+            });
+        });
+
+        await waitFor(() => {
+            expect(hook?.settings.invokeAiPath).toBe('D:/AI/art/webUI/invokeai/databases');
+        });
+
+        mocks.syncImages.mockResolvedValueOnce(createNoopInvokeSyncResult());
+        mocks.scanForOrphans.mockClear();
+
+        await act(async () => {
+            await hook?.startInvokeSync({ mode: 'startup' });
+        });
+
+        expect(mocks.syncImages).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.any(Function),
+            expect.any(AbortSignal),
+            expect.objectContaining({ mode: 'startup' })
+        );
+        expect(mocks.scanForOrphans).not.toHaveBeenCalled();
+    });
+
+    it('honors explicit orphan recovery for manual Invoke sync', async () => {
+        let hook: ReturnType<typeof useLibraryContext> | undefined;
+        renderStack(h => hook = h);
+
+        await waitFor(() => expect(hook?.isLoaded).toBe(true));
+
+        await act(async () => {
+            hook?.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai/databases',
+                importIntermediates: false,
+                importOrphans: true
+            });
+        });
+
+        await waitFor(() => {
+            expect(hook?.settings.invokeAiPath).toBe('D:/AI/art/webUI/invokeai/databases');
+        });
+
+        mocks.syncImages.mockResolvedValueOnce(createNoopInvokeSyncResult());
+        mocks.scanForOrphans.mockClear();
+
+        await act(async () => {
+            await hook?.startInvokeSync({ mode: 'manual', importOrphans: true });
+        });
+
+        expect(mocks.scanForOrphans).toHaveBeenCalledWith(
+            'D:/AI/art/webUI/invokeai/databases',
+            expect.any(Set),
+            expect.any(Function),
+            expect.objectContaining({ importIntermediates: expect.anything() })
+        );
     });
 
     it('uses startup resource-incremental facet refresh for a small known Invoke catch-up', async () => {
@@ -629,6 +931,19 @@ describe('Library Integration (Provider Stack)', () => {
 
         await waitFor(() => expect(hook.isLoaded).toBe(true));
 
+        mocks.syncImages.mockResolvedValueOnce(createNoopInvokeSyncResult());
+
+        await act(async () => {
+            hook.setSettings({
+                invokeAiPath: 'D:/AI/art/webUI/invokeai/databases'
+            });
+            useLibraryStore.getState().setIsLiveWatching(true);
+        });
+
+        await waitFor(() => expect(watcherCallback).not.toBeNull());
+        await waitFor(() => expect(mocks.syncImages).toHaveBeenCalledTimes(1));
+        mocks.syncImages.mockClear();
+
         const deferred = createDeferred<{
             imported: number;
             updated: number;
@@ -647,15 +962,6 @@ describe('Library Integration (Provider Stack)', () => {
             };
         }>();
         mocks.syncImages.mockReturnValueOnce(deferred.promise);
-
-        await act(async () => {
-            hook.setSettings({
-                invokeAiPath: 'D:/AI/art/webUI/invokeai/databases'
-            });
-            useLibraryStore.getState().setIsLiveWatching(true);
-        });
-
-        await waitFor(() => expect(watcherCallback).not.toBeNull());
 
         await act(async () => {
             watcherCallback?.(['D:/AI/art/webUI/invokeai/databases/invokeai.db-wal']);
@@ -768,7 +1074,7 @@ describe('Library Integration (Provider Stack)', () => {
         expect(useLibraryStore.getState().liveWatchSessionCloseRequested).toBe(false);
     });
 
-    it('skips startup Invoke SQLite sync when the saved DB snapshot is unchanged', async () => {
+    it('skips startup Invoke SQLite sync when the saved DB snapshot is unchanged and orphan recovery is only enabled for manual sync', async () => {
         let hook: any;
         renderStack(h => hook = h);
 
@@ -807,7 +1113,7 @@ describe('Library Integration (Provider Stack)', () => {
                 invokeAiPath: 'D:/AI/art/webUI/invokeai/databases',
                 lastSyncedAt: 100,
                 importIntermediates: false,
-                importOrphans: false,
+                importOrphans: true,
                 syncBoardsToCollections: false,
                 invokeDbSnapshot: {
                     dbPath: 'D:/AI/art/webUI/invokeai/databases/invokeai.db',

--- a/src/features/settings/components/SyncSection.tsx
+++ b/src/features/settings/components/SyncSection.tsx
@@ -144,13 +144,13 @@ export const SyncSection: React.FC<SyncSectionProps> = React.memo(({ settings, s
                         </label>
 
                         <label className="flex items-start gap-3 cursor-pointer group/toggle">
-                            <div className={`mt-1 w-10 h-5 rounded-full relative transition-colors shrink-0 ${settings.importOrphans !== false ? 'bg-sage-600' : 'bg-gray-200 dark:bg-white/10'}`}>
-                                <input type="checkbox" className="absolute inset-0 opacity-0 w-full h-full cursor-pointer z-10" checked={settings.importOrphans !== false} onChange={e => handleImportOrphansToggle(e.target.checked)} />
-                                <div className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full pointer-events-none transition-transform ${settings.importOrphans !== false ? 'translate-x-5' : 'translate-x-0'}`} />
+                            <div className={`mt-1 w-10 h-5 rounded-full relative transition-colors shrink-0 ${settings.importOrphans === true ? 'bg-sage-600' : 'bg-gray-200 dark:bg-white/10'}`}>
+                                <input type="checkbox" className="absolute inset-0 opacity-0 w-full h-full cursor-pointer z-10" checked={settings.importOrphans === true} onChange={e => handleImportOrphansToggle(e.target.checked)} />
+                                <div className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full pointer-events-none transition-transform ${settings.importOrphans === true ? 'translate-x-5' : 'translate-x-0'}`} />
                             </div>
                             <div>
                                 <span className="text-[11px] font-bold text-gray-700 dark:text-gray-200 block">Orphan Recovery</span>
-                                <span className="text-[9px] text-gray-500 leading-tight">Find untracked files in output folder.</span>
+                                <span className="text-[9px] text-gray-500 leading-tight">Manual full output-folder recovery sweep.</span>
                             </div>
                         </label>
                     </div>

--- a/src/features/settings/components/__tests__/SyncSection.test.tsx
+++ b/src/features/settings/components/__tests__/SyncSection.test.tsx
@@ -59,4 +59,20 @@ describe('SyncSection', () => {
             afterTimestamp: 123456
         }));
     });
+
+    it('treats orphan recovery as opt-in when the setting is missing', () => {
+        const settings = createSettings();
+        delete settings.importOrphans;
+
+        render(<SyncSection settings={settings} setSettings={vi.fn()} />);
+
+        expect((screen.getByLabelText(/orphan recovery/i) as HTMLInputElement).checked).toBe(false);
+        expect(screen.queryByText(/manual full output-folder recovery sweep/i)).not.toBeNull();
+    });
+
+    it('checks orphan recovery only when explicitly enabled', () => {
+        render(<SyncSection settings={{ ...createSettings(), importOrphans: true }} setSettings={vi.fn()} />);
+
+        expect((screen.getByLabelText(/orphan recovery/i) as HTMLInputElement).checked).toBe(true);
+    });
 });

--- a/src/stores/__tests__/libraryStore.test.ts
+++ b/src/stores/__tests__/libraryStore.test.ts
@@ -38,7 +38,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().setIsLiveWatching(true);
             useLibraryStore.getState().startLiveWatchSession('invoke', {
                 phase: 'watching',
-                message: 'Detected InvokeAI activity.'
+                message: 'Checking InvokeAI for completed images.'
             });
             useLibraryStore.getState().reportLiveImagesReceived(1, { source: 'invoke' });
         });
@@ -54,7 +54,7 @@ describe('libraryStore live watch session', () => {
         act(() => {
             useLibraryStore.getState().startLiveWatchSession('generic', {
                 phase: 'watching',
-                message: 'Detected new files.'
+                message: 'Checking monitored folders.'
             });
         });
 
@@ -79,7 +79,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().setIsLiveWatching(true);
             useLibraryStore.getState().startLiveWatchSession('invoke', {
                 phase: 'summary',
-                message: '1 image received this session. Watching for more...'
+                message: '1 image added this session.'
             });
             useLibraryStore.getState().setIsLiveWatching(false);
         });
@@ -94,7 +94,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().setIsLiveWatching(true);
             useLibraryStore.getState().startLiveWatchSession('invoke', {
                 phase: 'syncing',
-                message: 'Synchronizing InvokeAI images...'
+                message: 'Syncing completed InvokeAI images...'
             });
             useLibraryStore.getState().setIsLiveWatching(false);
         });
@@ -107,7 +107,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().updateLiveWatchSession({
                 source: 'invoke',
                 phase: 'summary',
-                message: '1 image received this session. Watching for more...',
+                message: '1 image added this session.',
                 progress: null
             });
         });
@@ -121,7 +121,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().setIsLiveWatching(true);
             useLibraryStore.getState().startLiveWatchSession('invoke', {
                 phase: 'watching',
-                message: 'Detected InvokeAI activity. Waiting for completed images...'
+                message: 'Checking InvokeAI for completed images...'
             });
             useLibraryStore.getState().setIsLiveWatching(false);
         });
@@ -134,7 +134,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().updateLiveWatchSession({
                 source: 'invoke',
                 phase: 'summary',
-                message: 'Watching for completed images...',
+                message: 'Watching for new images...',
                 progress: null
             });
         });
@@ -148,7 +148,7 @@ describe('libraryStore live watch session', () => {
             useLibraryStore.getState().setIsLiveWatching(true);
             useLibraryStore.getState().startLiveWatchSession('generic', {
                 phase: 'importing',
-                message: 'Importing live images...'
+                message: 'Importing new images...'
             });
             useLibraryStore.getState().setIsLiveWatching(false);
         });
@@ -178,6 +178,34 @@ describe('libraryStore live watch session', () => {
 
         expect(useLibraryStore.getState().liveWatchSession.active).toBe(false);
         expect(useLibraryStore.getState().liveWatchSession.receivedCount).toBe(0);
+    });
+
+    it('keeps a dismissed Live Watch dock dismissed for routine live session updates', () => {
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'syncing',
+                message: 'Syncing completed InvokeAI images...'
+            });
+            useLibraryStore.getState().setIsActivityDockDismissed(true);
+            useLibraryStore.getState().updateLiveWatchSession({
+                source: 'invoke',
+                phase: 'syncing',
+                message: 'Still syncing...',
+                progress: { current: 1, total: 2, message: undefined }
+            });
+        });
+
+        expect(useLibraryStore.getState().isActivityDockDismissed).toBe(true);
+
+        act(() => {
+            useLibraryStore.getState().startLiveWatchSession('invoke', {
+                phase: 'syncing',
+                message: 'New live activity...'
+            });
+            useLibraryStore.getState().reportLiveImagesReceived(1, { source: 'invoke' });
+        });
+
+        expect(useLibraryStore.getState().isActivityDockDismissed).toBe(true);
     });
 
     it('cancels duplicate hashing when an import starts', () => {

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useSettingsStore } from '../settingsStore';
 import { appRepository } from '../../services/repository';
 import { commands } from '../../bindings';
+import type { AppSettings } from '../../types';
 
 // --- Mocks ---
 vi.mock('../../services/repository', () => ({
@@ -76,6 +77,20 @@ describe('SettingsStore', () => {
         await useSettingsStore.getState().initialize();
 
         expect(useSettingsStore.getState().settings.libraryLayoutMode).toBe('masonry');
+    });
+
+    it('should default orphan recovery to off', async () => {
+        vi.mocked(appRepository.load).mockResolvedValue({
+            images: [],
+            collections: [],
+            smartCollections: [],
+            settings: {} as AppSettings,
+            recentSearches: []
+        });
+
+        await useSettingsStore.getState().initialize();
+
+        expect(useSettingsStore.getState().settings.importOrphans).toBe(false);
     });
 
     it('should preserve persisted gallery layout mode on initialize', async () => {

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -4,7 +4,8 @@ import { commands, type FileHashBackfillResult } from '../bindings';
 import type { MissingFileAuditResult } from '../types';
 
 let liveWatchTimeout: ReturnType<typeof setTimeout> | null = null;
-const LIVE_WATCH_IDLE_TIMEOUT_MS = 60000;
+// Internal aggregation window for related Live Watch events, not dock visibility.
+const LIVE_WATCH_SESSION_IDLE_MS = 60000;
 let importRunCounter = 0;
 
 const createImportRunId = (owner: string): string => {
@@ -112,12 +113,12 @@ const mergeLiveWatchSource = (
 
 export const getLiveWatchSummaryMessage = (receivedCount: number): string => {
     if (receivedCount <= 0) {
-        return 'Watching for completed images...';
+        return 'Watching for new images...';
     }
 
     return receivedCount === 1
-        ? '1 image received this session. Watching for more...'
-        : `${receivedCount} images received this session. Watching for more...`;
+        ? '1 image added this session.'
+        : `${receivedCount} images added this session.`;
 };
 
 export const createInitialLiveWatchSessionState = (): LiveWatchSessionState => ({
@@ -139,7 +140,7 @@ const scheduleLiveWatchSessionEnd = () => {
     liveWatchTimeout = setTimeout(async () => {
         const endSession = useLibraryStore.getState().endLiveImageSession;
         await endSession();
-    }, LIVE_WATCH_IDLE_TIMEOUT_MS);
+    }, LIVE_WATCH_SESSION_IDLE_MS);
 };
 
 const clearLiveWatchSessionEnd = () => {
@@ -588,8 +589,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
                     startedAt: currentSession.active ? currentSession.startedAt : now,
                     lastActivityAt: now
                 },
-                liveWatchSessionCloseRequested: state.liveWatchSessionCloseRequested && isActiveLiveWatchPhase(nextPhase),
-                isActivityDockDismissed: false
+                liveWatchSessionCloseRequested: state.liveWatchSessionCloseRequested && isActiveLiveWatchPhase(nextPhase)
             };
         });
         if (useLibraryStore.getState().isLiveWatching) {
@@ -620,8 +620,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
                     receivedCount: currentSession.receivedCount,
                     startedAt: currentSession.startedAt ?? now,
                     lastActivityAt: now
-                },
-                isActivityDockDismissed: false
+                }
             };
         });
         if (useLibraryStore.getState().isLiveWatching) {
@@ -652,8 +651,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
                     receivedCount,
                     startedAt: currentSession.startedAt ?? now,
                     lastActivityAt: now
-                },
-                isActivityDockDismissed: false
+                }
             };
         });
         if (useLibraryStore.getState().isLiveWatching) {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -35,7 +35,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     enableAI: false,
     hasCompletedOnboarding: false,
     syncBoardsToCollections: false,
-    importOrphans: true,
+    importOrphans: false,
     starredAs: 'favorite',
     libraryLayoutMode: 'masonry',
     resourceViewModes: {},


### PR DESCRIPTION
## Summary
- Add one-shot InvokeAI Live Watch activation catch-up after watcher attach.
- Make orphan recovery opt-in and manual-sync-only by default.
- Calm Live Watch Activity Dock and header feedback while keeping Live Watch out of the topbar rail.

## Tests
- pnpm run test:run -- ActivityDock AppHeader libraryStore
- pnpm run test:run -- LibraryIntegration
- pnpm run typecheck
- Browser QA at http://127.0.0.1:1421/