### PR TITLE
[codex] fix Tailwind v4 default utilities

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 @config "../tailwind.config.js";
 
 @layer base {


### PR DESCRIPTION
## Summary

- Restores Tailwind v4's default theme/utilities by switching the CSS entrypoint from the v3 `@tailwind` directive trio to `@import "tailwindcss"`.
- Keeps the existing JavaScript Tailwind config connected with `@config "../tailwind.config.js"` so custom Ambit colors and animation utilities continue to compile.

## Root cause

The Tailwind dependency had been bumped to v4 and the PostCSS plugin was updated, but the app stylesheet still used the old v3 entrypoint. That allowed the build to pass while omitting many default utilities such as `text-white`, `rounded-xl`, `shadow-lg`, `bg-gray-50`, and `border-gray-200`, leaving the UI only partially styled.

## Validation

- `pnpm run build` passes.
- Verified emitted CSS contains restored default utilities and existing custom utilities.
- Checked the running app in the in-app browser at `http://localhost:1421/`; the app rendered, console stayed clean, and the View display controls opened correctly.
- Computed-style spot checks confirmed restored styling, including white text, rounded corners, shadows, Inter font, and dark zinc background.