### PR TITLE
[codex] Clarify contribution policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing To Ambit
 
-Thanks for helping improve Ambit. The project is in public beta, so changes should stay focused, reviewable, and easy to validate.
+Thanks for helping improve Ambit. The project is in public beta and is currently maintainer-led.
+
+Bug reports, security reports, reproducible issue details, documentation corrections, and feature requests are welcome. Code contributions and pull requests are not being accepted at this stage, and unsolicited pull requests may be closed without review.
+
+If Ambit begins accepting outside code contributions in the future, contributor terms may be required before a change is reviewed or merged.
 
 ## Development Setup
 
@@ -22,11 +26,11 @@ pnpm run app:dev
 
 - Use a focused feature or fix branch.
 - Use Conventional Commits, such as `fix: repair metadata import` or `feat: add collection action`.
-- Keep pull requests scoped to one concern.
+- Keep changes scoped to one concern.
 
 ## Checks
 
-Run the narrowest relevant checks for your change before opening a pull request:
+For local development or maintainer changes, run the narrowest relevant checks for your change:
 
 ```bash
 pnpm run typecheck

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Development prerequisites:
     ```bash
     pnpm run app:dev
     ```
-5.  Run focused checks before opening a pull request:
+5.  Run focused checks before sharing or publishing local changes:
     ```bash
     pnpm run typecheck
     pnpm run test:run
@@ -78,7 +78,9 @@ Development prerequisites:
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and pull request expectations.
+Ambit is currently maintainer-led. Bug reports, security reports, documentation corrections, and feature requests are welcome, but code contributions and pull requests are not being accepted at this stage.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local development notes and the current contribution policy.
 
 For security-sensitive reports, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 


### PR DESCRIPTION
## Summary

Clarifies that Ambit is currently maintainer-led and not accepting outside code contributions or pull requests at this stage.

## Why

The public docs previously invited contributions and pull request expectations, which conflicted with the intended early-project licensing and ownership posture.

## Impact

Users can still file bug reports, security reports, documentation corrections, and feature requests. Code contribution policy remains simple while future contributor terms are left open before accepting outside code.

## Validation

- Reviewed the docs diff for scope and consistency
- Scanned `README.md` and `CONTRIBUTING.md` for conflicting contribution/PR wording
- No automated tests run; docs-only change