### PR TITLE
docs: add user manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ docs/*
 !docs/progress.md
 !docs/refactor.md
 !docs/support.md
+!docs/manual/
+!docs/manual/**

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Official public beta builds are currently available for **Windows only** while m
 
 The Windows installer includes the packaged app. You do not need Node.js, pnpm, Rust, or VS Code unless you want to build Ambit from source.
 
+For a step-by-step product guide, see the [Ambit User Manual](docs/manual/index.md).
+
 ### Development Installation
 
 Development prerequisites:

--- a/docs/manual/adding-folders.md
+++ b/docs/manual/adding-folders.md
@@ -1,0 +1,58 @@
+# Adding Folders
+
+[Back to manual index](index.md)
+
+Ambit builds its library by scanning local image folders and selected files. It catalogs supported image files, parses generation metadata when available, and keeps the original files on disk.
+
+## Import Choices
+
+When Ambit asks you to add images, you can choose between integration setup and one-time import.
+
+```mermaid
+flowchart TD
+    A["Add Images"] --> B["Set Up Integration"]
+    A --> C["One-Time Import"]
+    B --> D["InvokeAI"]
+    B --> E["ComfyUI"]
+    B --> F["SD WebUI / A1111 / Forge"]
+    C --> G["Select Files"]
+    C --> H["Add Folder"]
+```
+
+Use integrations when you want Ambit to understand an existing generator workspace. Use one-time import for downloaded packs, screenshots, archives, or individual files.
+
+## Monitored Image Folders
+
+Open Settings, then Connections, then Folders to manage image folders.
+
+In the Folders section you can:
+
+- add folders containing AI-generated images
+- review folders Ambit is monitoring
+- rescan a single folder
+- refresh metadata across all folders
+- remove a folder from Ambit's monitored list
+
+Adding a folder catalogs the files. It does not move or delete your source files.
+
+## Generator Integrations
+
+Ambit has connection pages for common local generator tools:
+
+- InvokeAI: select the root folder containing `databases/invokeai.db`, then test the connection.
+- ComfyUI: select the output folder where ComfyUI saves generated images, then link it.
+- SD WebUI: select an installation or archive path, scan for output folders, choose folders, then link and import them.
+
+For SD WebUI style folders, Ambit can auto-detect variants such as A1111, Forge, SD.Next, and Anapnoe. If auto-detection is uncertain, select the installation type manually before scanning.
+
+## Resource Folders
+
+Settings, Connections, Folders also includes resource discovery. Use this for model, LoRA, embedding, ControlNet, or IP-Adapter folders. Resource folders help Ambit build a local asset inventory, which can make resource filters more useful.
+
+## During Scans
+
+Scans can take time on large folders. Ambit reports progress while it scans sources, imports images, and finalizes metadata. If an import is cancelled, imported images are kept and unfinished folders can be rescanned later.
+
+## Next Step
+
+After images appear, continue with [Browsing The Library](browsing-library.md).

--- a/docs/manual/browsing-library.md
+++ b/docs/manual/browsing-library.md
@@ -1,0 +1,55 @@
+# Browsing The Library
+
+[Back to manual index](index.md)
+
+The library is the main place to review images after Ambit has scanned folders or files.
+
+## Views
+
+Use the left sidebar to switch between:
+
+- Grid View for thumbnail browsing.
+- Timeline View for time-based browsing.
+- Statistics for library summaries.
+- Maintenance for cleanup workflows.
+
+The filter button opens or closes the library panel. Favorites Only and Pinned Only buttons narrow the current view without changing your source files.
+
+## Grid Browsing
+
+Grid View is designed for large libraries. Ambit uses virtualized rendering so it can browse many images without drawing every record at once.
+
+Typical grid actions:
+
+- click an image to open the viewer
+- use selection actions for batch work
+- mark images as favorites
+- pin images for quick resurfacing
+- right-click images for context-specific actions
+
+## Timeline Browsing
+
+Timeline View is useful when you remember when a batch was generated. It uses the same library data and filters as Grid View, but presents images around time.
+
+## Selection
+
+Ambit supports common selection patterns:
+
+- `Ctrl + Click` toggles individual selection.
+- `Shift + Click` selects a range.
+- `Ctrl + A` selects all visible items.
+- `Esc` clears selection or closes an open dialog.
+
+Open the Help button in the sidebar for the current shortcut reference.
+
+## Viewer Entry
+
+Open an image to enter the viewer. From the viewer you can navigate next and previous images, zoom and pan, toggle theater mode, favorite or pin the image, copy/open/share when supported, and inspect metadata in the sidebar.
+
+## Privacy Masking
+
+If content masking is configured, images with matching prompt keywords can be blurred or hidden depending on your Privacy settings. You can toggle global privacy mode with `Shift + H`.
+
+## Next Step
+
+For narrowing large libraries, continue with [Search, Filters, And Collections](search-filters-collections.md).

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -1,0 +1,55 @@
+# Getting Started
+
+[Back to manual index](index.md)
+
+Ambit is a local-first desktop app for organizing large AI-generated image libraries. The public beta is currently distributed as Windows builds through GitHub Releases.
+
+## Install The Public Beta
+
+1. Open the Ambit [GitHub Releases](https://github.com/AsuraAce/ambit/releases) page.
+2. Download the Windows setup installer ending in `-setup.exe`.
+3. Run the installer and launch Ambit.
+
+You do not need Node.js, pnpm, Rust, Tauri, or VS Code unless you want to build Ambit from source.
+
+## First Launch
+
+On first launch, Ambit shows an onboarding wizard. The wizard introduces:
+
+- integrations for InvokeAI, ComfyUI, and SD WebUI style output folders
+- optional Gemini-powered intelligence features
+- local-first privacy behavior
+- content masking for prompts containing configured keywords
+
+You can skip optional integrations during onboarding and set them up later from Settings.
+
+```mermaid
+flowchart TD
+    A["Install Ambit"] --> B["Launch app"]
+    B --> C["Complete or skip onboarding"]
+    C --> D["Add image folders"]
+    D --> E["Scan and catalog images"]
+    E --> F["Browse, search, and inspect metadata"]
+```
+
+## Main Areas
+
+The main Ambit workspace has a left sidebar, a library area, and an optional filter panel.
+
+- Grid View shows image thumbnails for everyday browsing.
+- Timeline View groups browsing around image time.
+- Statistics shows library-level summaries.
+- Maintenance helps resolve missing files, duplicates, removed items, and other cleanup tasks.
+- Filters opens the library filter panel.
+- Settings opens preferences and integrations.
+- Help opens keyboard shortcuts and search syntax.
+
+## What Ambit Stores
+
+Ambit keeps source image files where they already are. It stores a local catalog, metadata, thumbnails, settings, and optional integration configuration so the app can search and maintain the library quickly.
+
+Sensitive values such as a Gemini API key are stored locally through the OS keyring path Ambit uses rather than being required in the repository or source code.
+
+## Next Step
+
+After first launch, continue with [Adding Folders](adding-folders.md).

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -1,0 +1,36 @@
+# Ambit User Manual
+
+This manual is for people using Ambit public beta builds. It explains how to install Ambit, add image folders, browse and search a library, inspect metadata, organize images, and recover from common library problems.
+
+Ambit is currently a public beta. Official public beta builds are Windows-only while macOS and Linux support is being validated.
+
+## How Ambit Works
+
+Ambit catalogs local image folders. It does not need to move your original image files into a managed library folder.
+
+```mermaid
+flowchart LR
+    A["Your image folders"] --> B["Ambit scan"]
+    B --> C["Local SQLite catalog"]
+    B --> D["Generated thumbnails"]
+    C --> E["Browse, search, filter"]
+    C --> F["Collections and maintenance"]
+    C --> G["Viewer and metadata"]
+```
+
+The core app is local-first. Image records, metadata, thumbnails, and settings are stored on your machine. Optional network features are documented in [Settings And Privacy](settings-and-privacy.md).
+
+## Manual Pages
+
+- [Getting Started](getting-started.md): install the public beta, launch Ambit, and complete the first-run wizard.
+- [Adding Folders](adding-folders.md): add monitored image folders, connect generator outputs, and run one-time imports.
+- [Browsing The Library](browsing-library.md): use grid, timeline, statistics, selection, favorites, pins, and the viewer.
+- [Search, Filters, And Collections](search-filters-collections.md): search prompts and metadata, use facets, and organize images.
+- [Viewer And Metadata](viewer-and-metadata.md): inspect prompts, resources, workflow data, notes, and image versions.
+- [Maintenance](maintenance.md): resolve missing files, duplicates, removed items, untagged records, intermediates, and thumbnail problems.
+- [Settings And Privacy](settings-and-privacy.md): understand folders, privacy controls, AI features, update checks, and network behavior.
+- [Troubleshooting](troubleshooting.md): diagnose common first-run, scan, metadata, thumbnail, and privacy issues.
+
+## Related Project Docs
+
+This manual is user-facing. For development setup and pull request expectations, see [Contributing To Ambit](../../CONTRIBUTING.md). For security-sensitive reports, follow [Security Policy](../../SECURITY.md) instead of opening a public issue.

--- a/docs/manual/maintenance.md
+++ b/docs/manual/maintenance.md
@@ -1,0 +1,66 @@
+# Maintenance
+
+[Back to manual index](index.md)
+
+Maintenance helps keep Ambit's catalog aligned with your local files and metadata. Open Maintenance from the left sidebar.
+
+## Maintenance Areas
+
+Ambit currently exposes these maintenance tabs:
+
+- Duplicates: find and resolve duplicate candidates.
+- Untagged: review records with missing or incomplete metadata.
+- Intermediates: review images flagged as intermediates when the tab is visible.
+- Missing: find catalog records whose source files are missing.
+- Removed: restore removed records or permanently delete files when that action is chosen.
+
+```mermaid
+flowchart TD
+    A["Maintenance"] --> B["Duplicates"]
+    A --> C["Untagged"]
+    A --> D["Intermediates"]
+    A --> E["Missing"]
+    A --> F["Removed"]
+    E --> G["Verify library paths"]
+    F --> H["Restore or delete"]
+```
+
+## Duplicates
+
+The Duplicates tab scans for likely duplicate images. Duplicate cleanup is conservative: resolving duplicates removes redundant records from Ambit's library or Removed flow by default rather than deleting original files automatically.
+
+Use Compare when available to inspect candidates before resolving them.
+
+## Missing
+
+The Missing tab helps when files were moved, renamed, deleted outside Ambit, or live on a disconnected drive.
+
+Use the library health scan to check file availability. For missing records you can remove the record from Ambit's library. This cleans the catalog entry; it does not recover a file that no longer exists on disk.
+
+## Removed
+
+Removed contains images that were removed from the active library. You can restore selected records or choose a delete action when you intentionally want to delete files.
+
+Treat destructive delete actions carefully. Ambit separates library removal from file deletion so cleanup does not have to destroy source images.
+
+## Untagged And Intermediates
+
+Untagged helps find images without useful parsed metadata. Intermediates appears when Ambit has images flagged as intermediate outputs, such as images without the expected InvokeAI metadata.
+
+Use these tabs to remove, review, or unmark records depending on what the tab offers.
+
+## Thumbnail Problems
+
+Ambit performs thumbnail handling in the background. If thumbnails are stale or broken, use Settings, Advanced, Troubleshooting:
+
+- Verify Files checks thumbnail paths and resets missing thumbnail references.
+- Reset All clears thumbnail references so Ambit can rediscover or regenerate thumbnails.
+- Verify Library checks source files and thumbnails together.
+
+## Metadata Refresh
+
+From Settings, Connections, Folders, use Refresh All Metadata or a folder-level refresh when metadata filters look stale after external changes.
+
+## Next Step
+
+For settings and network behavior, continue with [Settings And Privacy](settings-and-privacy.md).

--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -1,0 +1,78 @@
+# Search, Filters, And Collections
+
+[Back to manual index](index.md)
+
+Ambit combines search text, metadata filters, resource facets, date filters, favorites, pins, and collections to narrow large local libraries.
+
+## Search Basics
+
+The search bar matches the positive prompt by default. Spaces narrow results. Use `OR` to match alternatives.
+
+Examples:
+
+```text
+sunset portrait
+orc OR elf
+"dark forest"
+```
+
+Open Help, then Search Syntax, for the in-app operator list.
+
+## Search Operators
+
+Useful operators include:
+
+- `neg:blur` searches the negative prompt.
+- `file:portrait` searches filename or path.
+- `model:sdxl` filters by model.
+- `lora:detail` filters by LoRA.
+- `tool:invoke` filters by generator.
+- `sampler:euler` filters by sampler.
+- `steps:>30` filters generation steps.
+- `cfg:<7` filters CFG.
+- `seed:12345` filters seed.
+- `date:2026-04` filters by local calendar month.
+- `after:2026-04` and `before:2025` filter date ranges.
+- `w:>1024` and `h:<768` filter dimensions.
+- `upscaled:true` shows upscaled images.
+
+Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity.
+
+## Filter Panel
+
+The Library filter panel is organized into tabs:
+
+- Organize: collections and collection-focused filters.
+- Assets: checkpoints, LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter resources.
+- Filters: generator tools, generation parameters, and guidance-related filters.
+
+The date filter is available at the bottom of the panel.
+
+Use Reset All to clear active filters. When filter state changes inside a smart collection, Ambit can show an Update action for saving the adjusted rules.
+
+## Asset Scope
+
+The Assets tab can switch between:
+
+- Used in Library: resources found in imported images.
+- Local on Disk: resources discovered from configured resource folders.
+- All Assets: both library-used and locally discovered resources.
+
+If Local on Disk is empty, add resource folders from Settings, Connections, Folders.
+
+## Collections
+
+Collections help organize images without moving files on disk.
+
+Use collections to:
+
+- group images manually
+- open a saved group from the library panel
+- rename, archive, pin, color, export, or reset collection thumbnails when those actions are available
+- save search/filter rules as smart collections
+
+Manual collections contain selected images. Smart collections represent saved filter rules.
+
+## Next Step
+
+For individual image details, continue with [Viewer And Metadata](viewer-and-metadata.md).

--- a/docs/manual/settings-and-privacy.md
+++ b/docs/manual/settings-and-privacy.md
@@ -1,0 +1,71 @@
+# Settings And Privacy
+
+[Back to manual index](index.md)
+
+Settings controls Ambit's app preferences, integrations, privacy behavior, optional intelligence features, and advanced maintenance tools.
+
+## Settings Sections
+
+The Settings window contains:
+
+- General: app-level preferences.
+- Connections: folders, InvokeAI, SD WebUI, and ComfyUI setup.
+- Intelligence: optional AI features and model/prompt configuration.
+- Privacy: content masking behavior and masked keywords.
+- Advanced: database, interface, update, and troubleshooting tools.
+- Dev Tools: development-only tools when enabled.
+
+## Local-First Behavior
+
+Ambit's core library management works locally. Browsing, search, metadata parsing, thumbnails, maintenance, and settings do not require telemetry.
+
+```mermaid
+flowchart LR
+    A["Local image files"] --> B["Ambit"]
+    B --> C["Local catalog"]
+    B --> D["Local thumbnails"]
+    B --> E["Local settings"]
+    B -. "only when enabled or clicked" .-> F["External services"]
+```
+
+## Network Behavior
+
+The public beta has a small set of disclosed network paths:
+
+- Automatic update checks contact GitHub Releases when enabled. Updates install only after you confirm the prompt.
+- Gemini features are optional and use your own key. Requests are sent only when you verify a key or run an AI action.
+- CivitAI model-hash resolution is optional. It runs only after you confirm Resolve Online and sends unresolved model hash strings, not image files.
+- GitHub Sponsors, Ko-fi, repository, and project links open only when clicked.
+
+## Privacy Controls
+
+Open Settings, then Privacy to configure content masking.
+
+You can choose:
+
+- Blur Content: keep matching images visible but blurred.
+- Hide Completely: hide matching images from normal browsing.
+
+Masked keywords are matched against prompts. Add only terms you actually want Ambit to use for local masking decisions.
+
+## Intelligence Features
+
+Intelligence features are off unless configured. When enabled, Ambit can use Gemini for tasks such as prompt analysis or variation ideas. These actions are on-demand and depend on your own Gemini API key.
+
+If an AI action fails, confirm that the key is saved, the key verifies successfully, and the network is available.
+
+## Advanced Tools
+
+Advanced includes:
+
+- backup settings
+- automatic update controls
+- reset onboarding
+- troubleshooting tools for sync cursors, thumbnails, and library verification
+- database reset tools
+
+Use Purge Database only when you intentionally want to remove all imported metadata and reset application state. The confirmation explains that source image files are not touched, but Ambit's catalog and linked folders are reset.
+
+## Next Step
+
+For common fixes, continue with [Troubleshooting](troubleshooting.md).

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -1,0 +1,95 @@
+# Troubleshooting
+
+[Back to manual index](index.md)
+
+This page lists common first-run and library issues. When in doubt, prefer actions that rescan or refresh Ambit's catalog before actions that remove records or delete files.
+
+## I Installed Ambit But Do Not See Images
+
+Confirm that you added image sources:
+
+- use Add Images, then Add Folder for a normal folder
+- use Settings, Connections, Folders for monitored folders
+- use Settings, Connections, ComfyUI for a ComfyUI output folder
+- use Settings, Connections, SD WebUI for A1111, Forge, SD.Next, Anapnoe, or archive folders
+- use Settings, Connections, InvokeAI for an InvokeAI root containing `databases/invokeai.db`
+
+Large folders can take time to scan. Wait for import activity to finish before assuming the scan failed.
+
+## A Folder Did Not Scan Correctly
+
+Try these steps:
+
+1. Confirm the folder path still exists and is accessible.
+2. Rescan the folder from Settings, Connections, Folders.
+3. Use Refresh All Metadata if the files exist but filters or parsed metadata look stale.
+4. For SD WebUI folders, scan again with the correct installation type selected instead of Auto if detection looked wrong.
+
+## Metadata Is Missing Or Wrong
+
+Metadata depends on what the generator embedded in the file. Some images do not contain complete generation data.
+
+Useful checks:
+
+- open the image viewer and inspect Info and Workflow tabs
+- check whether the image came from a supported generator output
+- refresh metadata for the folder
+- use Untagged maintenance to find records that need review
+- use Online Model Hash Resolution only when you intentionally want CivitAI lookup for unresolved model hashes
+
+## Thumbnails Are Broken
+
+Open Settings, Advanced, Troubleshooting.
+
+Use Verify Files first. If thumbnails still fail, use Reset All to clear thumbnail references so Ambit can rediscover or regenerate them. Use Verify Library when you want to check source files and thumbnails together.
+
+## Images Show As Missing
+
+Missing usually means Ambit has a catalog record but the source file path is not currently available.
+
+Check whether:
+
+- the folder or drive is connected
+- the file was moved or renamed outside Ambit
+- the monitored folder path changed
+
+If the file is intentionally gone, remove the missing record from Ambit's library. This cleans the catalog entry but does not restore the deleted file.
+
+## Search Does Not Find What I Expected
+
+Remember that plain search text matches the positive prompt by default.
+
+Try:
+
+- `neg:term` for negative prompts
+- `file:term` for filename or path
+- `model:name` for model filters
+- `lora:name` for LoRA filters
+- Reset All to clear hidden filter state
+- Help, Search Syntax for the full operator list
+
+## Gemini Features Do Not Work
+
+Confirm that:
+
+- Intelligence features are enabled
+- your Gemini API key is saved
+- key verification succeeds
+- you are running an explicit AI action
+- your network allows the request
+
+Gemini is not required for core Ambit browsing, search, metadata parsing, or maintenance.
+
+## Online Model Resolution Is Disabled Or Busy
+
+Resolve Online is blocked while library work is already running, such as import, sync, scan, thumbnail regeneration, duplicate scan, or background healing. Wait for the current task to finish, then run resolution again.
+
+Online model resolution sends unresolved model hash strings to CivitAI. It does not send image files.
+
+## I Want To Start Over
+
+Open Settings, Advanced, Database and use Purge Database only if you intentionally want to reset Ambit's catalog and linked folders. Read the confirmation carefully. Source image files are not touched, but imported metadata and application state are reset.
+
+## Reporting Issues
+
+Report bugs through GitHub Issues. For suspected security problems, do not open a public issue; follow the [Security Policy](../../SECURITY.md).

--- a/docs/manual/viewer-and-metadata.md
+++ b/docs/manual/viewer-and-metadata.md
@@ -1,0 +1,61 @@
+# Viewer And Metadata
+
+[Back to manual index](index.md)
+
+The image viewer is where Ambit shows a larger image preview and the metadata Ambit parsed from the source file.
+
+## Viewer Controls
+
+In the viewer you can:
+
+- move to the previous or next image
+- zoom, pan, and reset zoom
+- toggle theater mode with `Z`
+- favorite an image with `F`
+- pin an image with `P`
+- show or hide the metadata sidebar with `I`
+- copy, open externally, share, or remove when those actions are available
+
+The viewer may hide controls while you are focused on the image. Move the pointer to show them again.
+
+## Metadata Sidebar
+
+The sidebar has up to three tabs:
+
+- Info: parsed metadata, prompts, model/resource details, palette, and AI actions when enabled.
+- Edit: notes, prompt edits, negative prompt edits, and collection assignment.
+- Workflow: workflow inspection when workflow data is present or hinted.
+
+The header shows the generator tool, model or model hash when available, date, and dimensions.
+
+## Prompt And Resource Metadata
+
+Ambit parses generation metadata from common AI image outputs. Depending on the file, metadata can include:
+
+- positive and negative prompts
+- generator tool
+- model name or model hash
+- seed, steps, CFG, sampler, and generation type
+- dimensions and timestamp
+- LoRA and other resource references
+- workflow JSON or raw metadata chunks
+
+Metadata quality depends on what the generator embedded in the file.
+
+## Editing Metadata
+
+Ambit can store local edits such as notes and prompt corrections in its catalog. These edits help search and organization inside Ambit. They do not mean the original generator workflow is changed.
+
+When raw metadata is present, Ambit may offer recovery or revert actions for metadata-related workflows.
+
+## Image Versions
+
+If an image has versions or stack entries, the viewer can show a version selector. Use it to compare related outputs, such as a base image and an upscaled result.
+
+## Optional AI Actions
+
+If Gemini-powered intelligence features are enabled, the viewer can offer prompt analysis or variation generation. These actions contact Gemini only when you explicitly run them.
+
+## Next Step
+
+For cleanup and repair workflows, continue with [Maintenance](maintenance.md).


### PR DESCRIPTION
## Summary
- add a public user manual under docs/manual/
- link the manual from the README public beta setup section
- whitelist docs/manual/ in .gitignore so the manual pages are tracked

## Validation
- git diff --cached --check
- local Markdown link check for README and docs/manual/*.md

No frontend or Rust checks were run because this is documentation-only.