### PR TITLE
[codex] Fix Match Any/All facet drilldown

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,6 +1,6 @@
 # Progress
 Status: Current
-Last reviewed: 2026-05-15
+Last reviewed: 2026-06-04
 
 ## Current State
 - The repo is currently on package version `0.5.0`; do not infer release publication status from this file alone.
@@ -9,6 +9,7 @@ Last reviewed: 2026-05-15
 - Frontend bundle cleanup has a build-output guard: `build:guard` fails if ineffective dynamic imports return or the startup entry chunk exceeds the 500 kB warning threshold.
 - The Live Watch incremental facet branch now avoids the old default idle-time full facet rebuild for normal live imports. Live Watch refreshes changed resource facets through the incremental queue, while manual recovery and non-live flows retain the full rebuild fallback.
 - The latest manual InvokeAI run showed the resource incremental path working as intended: browser logs emitted `mode:"resource-incremental"`, Rust resource refresh completed in about `452ms`, and the previously slow `caradhras-mix_style` LoRA refresh was about `106ms` instead of multi-second.
+- Asset drill-down now uses standard disjunctive faceting semantics: selected Match Any values keep sibling alternatives visible by counting that facet against all other active filters, while Match All keeps narrowed co-occurrence counts. Checkpoints remain multi-select but Any-only because each image has one checkpoint/model, and generator tools remain Any-only in the UI.
 
 ## Current Constraints
 - `package.json` defines dev, build, lint, typecheck, one-shot frontend test, coverage, Rust test, Tauri no-bundle check, and release verification scripts.
@@ -28,4 +29,5 @@ Last reviewed: 2026-05-15
 - Production builds now use the Tauri identifier `io.github.asuraace.ambit`. Release builds run a one-time startup migration from the legacy `com.ambit.app` Roaming and Local AppData directories before SQL initialization, and reset/repair paths still check both identifiers during the public-beta transition.
 - The durable engineering follow-up from earlier work still stands: clarify whether `src/services/repository.ts` remains a supported non-desktop or mock fallback, or should be retired in a dedicated cleanup.
 - Live Watch still needs a separate pending-completion UX pass if we want toggle-off to distinguish "activity detected but output not complete yet" from passive idle or summary states. See `docs/refactor.md#live-watch-pending-completion-state`.
+- Future asset-filter work should centralize facet taxonomy and match-mode support so hook logic, SQL filtering, browser mocks, and UI controls cannot drift. See `docs/refactor.md#facet-semantics-centralization`.
 - Use this file for active repo state and durable near-term follow-ups. Move recurring structural debt to `docs/refactor.md`, and keep personal scratch planning out of tracked files.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -1,6 +1,6 @@
 # Refactor Notes
 Status: Deferred
-Last reviewed: 2026-05-03
+Last reviewed: 2026-06-04
 
 ## How to Use This File
 Use this file to record deferred structural cleanup that changes how contributors should edit the repo safely. Keep active workstreams and short-lived blockers in `docs/progress.md`.
@@ -374,6 +374,46 @@ Status: Deferred
 - `src/services/db/searchRepo.ts`
 - `src-tauri/src/db/facets.rs`
 - `src-tauri/src/db/migrations/`
+
+## Facet Semantics Centralization
+Status: Deferred
+
+### Why Cleanup Is Needed
+- Asset filter semantics now intentionally differ by facet type:
+  - Checkpoints are multi-select but Any-only because each image has one checkpoint/model.
+  - LoRAs, embeddings, hypernetworks, ControlNets, and IP-Adapters support Match Any and Match All because images can contain multiple values in each category.
+  - Generator tools remain Any-only in the UI.
+- The current implementation keeps this behavior correct, but the taxonomy is expressed across `useLibraryStatsQuery`, `sqlHelpers`, `browserMockData`, and `ResourceSection`.
+- Future asset categories or smart-collection changes could drift if one layer learns a different match-mode rule than the others.
+
+### Current Pain Points
+- The same category-to-filter-key mapping is repeated in hook logic and mock filtering.
+- UI support for Match Any/All is component-local, while backend compatibility rules live in SQL helper code.
+- Tools still have internal stale `matchModes.tools` compatibility even though the visible UI does not generate a tool Match toggle.
+
+### Safe-Change Warning
+- Do not replace the current disjunctive faceting behavior with a broad abstraction unless the product semantics stay identical.
+- Checkpoints must remain OR-only even if persisted filters or smart collections contain `matchModes.models = 'all'`.
+- Categories should continue to combine with AND across categories; only same-category selected values use Any/All semantics.
+
+### Suggested Future Direction
+- Add a small shared facet taxonomy helper that declares the filter key, display facet type, whether Match All is supported, and whether stale Match All should be ignored.
+- Reuse that helper in:
+  - `useLibraryStatsQuery` self-excluded facet count selection,
+  - `buildSqlWhereClause` match-mode handling,
+  - browser mock filtering and mock facet generation,
+  - resource-section UI controls and tests.
+- Keep tools Any-only unless a future product decision treats generator tools as genuinely multi-valued per image.
+
+### Acceptance Direction
+- Adding or changing an asset facet updates one taxonomy definition instead of four independent logic paths.
+- Tests still prove Match Any sibling alternatives remain visible, Match All narrows to co-occurrence, and checkpoints cannot become impossible AND filters.
+
+### Related Code
+- `src/hooks/useLibraryStatsQuery.ts`
+- `src/utils/sqlHelpers.ts`
+- `src/services/browserMockData.ts`
+- `src/features/filters/components/ResourceSection.tsx`
 
 ## Resource Discovery Taxonomy Phase 2
 Status: Deferred

--- a/src/features/filters/components/ResourceSection.tsx
+++ b/src/features/filters/components/ResourceSection.tsx
@@ -458,6 +458,7 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
     };
 
     const isAllMode = filters.matchModes?.[filterKey] === 'all';
+    const supportsMatchMode = type !== 'checkpoints';
 
     return (
         <div className="space-y-2">
@@ -493,28 +494,29 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                         >
                             {viewMode === 'list' ? <LayoutGrid className="w-3.5 h-3.5" /> : <ListIcon className="w-3.5 h-3.5" />}
                         </button>
-                        {/* Match Mode Toggle - Icon Only */}
-                        <button
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                const nextMode = isAllMode ? 'any' : 'all';
-                                setFilters(prev => ({
-                                    ...prev,
-                                    matchModes: {
-                                        ...prev.matchModes,
-                                        [filterKey]: nextMode
-                                    }
-                                }));
-                            }}
-                            className={`transition-colors p-1.5 rounded-lg border ${isAllMode
-                                ? 'text-sage-600 dark:text-sage-400 bg-sage-50 dark:bg-sage-900/40 border-sage-200 dark:border-sage-500/30'
-                                : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5'}`}
-                            title={isAllMode
-                                ? "Match All: Show images that have EVERY selected item"
-                                : "Match Any: Show images with AT LEAST ONE selected item"}
-                        >
-                            {isAllMode ? <CircleDot className="w-3.5 h-3.5" /> : <Circle className="w-3.5 h-3.5" />}
-                        </button>
+                        {supportsMatchMode && (
+                            <button
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    const nextMode = isAllMode ? 'any' : 'all';
+                                    setFilters(prev => ({
+                                        ...prev,
+                                        matchModes: {
+                                            ...prev.matchModes,
+                                            [filterKey]: nextMode
+                                        }
+                                    }));
+                                }}
+                                className={`transition-colors p-1.5 rounded-lg border ${isAllMode
+                                    ? 'text-sage-600 dark:text-sage-400 bg-sage-50 dark:bg-sage-900/40 border-sage-200 dark:border-sage-500/30'
+                                    : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5'}`}
+                                title={isAllMode
+                                    ? "Match All: Show images that have EVERY selected item"
+                                    : "Match Any: Show images with AT LEAST ONE selected item"}
+                            >
+                                {isAllMode ? <CircleDot className="w-3.5 h-3.5" /> : <Circle className="w-3.5 h-3.5" />}
+                            </button>
+                        )}
                         <button
                             onClick={(e) => { e.stopPropagation(); setIsSearchOpen(!isSearchOpen); if (isSearchOpen) setSearchQuery(''); }}
                             className={`transition-colors p-1.5 rounded-lg border ${isSearchOpen ? 'text-sage-600 dark:text-sage-400 bg-sage-50 dark:bg-sage-900/40 border-sage-200 dark:border-sage-500/30' : 'text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 bg-gray-50 dark:bg-white/5 border-gray-200 dark:border-white/5'}`}

--- a/src/features/filters/components/__tests__/ResourceSection.test.tsx
+++ b/src/features/filters/components/__tests__/ResourceSection.test.tsx
@@ -287,6 +287,53 @@ describe('ResourceSection asset scope filtering', () => {
     });
 });
 
+describe('ResourceSection match mode controls', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('does not render the Match Any/All toggle for checkpoints', () => {
+        render(
+            <ResourceSection
+                title="Checkpoints"
+                type="checkpoints"
+                filters={filters}
+                setFilters={vi.fn()}
+                data={[{
+                    name: 'Flux',
+                    hash: 'model_Flux',
+                    count: 3
+                }]}
+                isOpen
+                onToggle={vi.fn()}
+            />
+        );
+
+        expect(screen.queryByTitle(/Match Any/)).toBeNull();
+        expect(screen.queryByTitle(/Match All/)).toBeNull();
+    });
+
+    it('keeps the Match Any/All toggle for multi-valued resources', () => {
+        render(
+            <ResourceSection
+                title="Resources"
+                type="loras"
+                filters={filters}
+                setFilters={vi.fn()}
+                data={[{
+                    name: 'Detailer',
+                    hash: 'lora_Detailer',
+                    count: 3
+                }]}
+                isOpen
+                onToggle={vi.fn()}
+            />
+        );
+
+        expect(screen.getByTitle(/Match Any/)).toBeTruthy();
+    });
+});
+
 describe('ResourceSection asset sorting', () => {
     beforeEach(() => {
         vi.clearAllMocks();

--- a/src/hooks/__tests__/useLibraryStatsQuery.test.tsx
+++ b/src/hooks/__tests__/useLibraryStatsQuery.test.tsx
@@ -551,6 +551,7 @@ describe('useLibraryStatsQuery valid facets', () => {
         renderStatsHook(createDefaultFilters({ loras: ['CollectionLora'] }));
 
         await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(1));
 
         const calls = searchRepoMocks.getValidFacetNames.mock.calls as Array<
             [string, unknown[], string | undefined, string | undefined]
@@ -561,6 +562,40 @@ describe('useLibraryStatsQuery valid facets', () => {
         expect(baseCall[3]).toBe('CollectionLora');
         expect(loraSelfExcludedCall[1]).not.toContain('CollectionLora');
         expect(loraSelfExcludedCall[3]).toBeUndefined();
+
+        const facetCalls = searchRepoMocks.getFacets.mock.calls as Array<
+            [string, unknown[], unknown[], { loraName?: string; scopedCountOverrides?: Record<string, { params: unknown[]; loraName?: string }> }]
+        >;
+        const facetOptions = facetCalls[0][3];
+
+        expect(facetOptions.loraName).toBe('CollectionLora');
+        expect(facetOptions.scopedCountOverrides?.loras?.params).not.toContain('CollectionLora');
+        expect(facetOptions.scopedCountOverrides?.loras?.loraName).toBeUndefined();
+    });
+
+    it('self-excludes checkpoints even if stale matchModes requests ALL', async () => {
+        renderStatsHook(createDefaultFilters({
+            models: ['Model A', 'Model B'],
+            matchModes: { models: 'all' }
+        }));
+
+        await waitFor(() => expect(searchRepoMocks.getValidFacetNames).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(searchRepoMocks.getFacets).toHaveBeenCalledTimes(1));
+
+        const validFacetCalls = searchRepoMocks.getValidFacetNames.mock.calls as Array<
+            [string, unknown[], string | undefined, string | undefined]
+        >;
+        const checkpointSelfExcludedCall = validFacetCalls[1];
+
+        expect(checkpointSelfExcludedCall[1]).not.toContain('Model A');
+        expect(checkpointSelfExcludedCall[1]).not.toContain('Model B');
+
+        const facetCalls = searchRepoMocks.getFacets.mock.calls as Array<
+            [string, unknown[], unknown[], { scopedCountOverrides?: Record<string, { params: unknown[] }> }]
+        >;
+
+        expect(facetCalls[0][3].scopedCountOverrides?.checkpoints?.params).not.toContain('Model A');
+        expect(facetCalls[0][3].scopedCountOverrides?.checkpoints?.params).not.toContain('Model B');
     });
 
     it('debounces search-only stats updates and collapses rapid corrections', async () => {

--- a/src/hooks/useLibraryStatsQuery.ts
+++ b/src/hooks/useLibraryStatsQuery.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { AssetScope, FilterState, AppSettings, Collection, FacetType } from '../types';
-import { getFacets, getKeywordStats, getLibraryStatsSummary, Facets, LibraryStats, LibraryStatsSummary, getValidFacetNames, ValidFacetNames } from '../services/db/searchRepo';
+import { getFacets, getKeywordStats, getLibraryStatsSummary, Facets, LibraryStats, LibraryStatsSummary, getValidFacetNames, ValidFacetNames, type ScopedFacetCountInput } from '../services/db/searchRepo';
 import { buildSqlWhereClause } from '../utils/sqlHelpers';
 import { useLibraryStore } from '../stores/libraryStore';
 import { isBrowserMockMode } from '../services/runtime';
@@ -36,6 +36,25 @@ const INITIAL_FACETS: Facets = {
     controlNets: [],
     ipAdapters: [],
     tools: []
+};
+
+const getSelfExcludedFacetTypes = (filters: FilterState): FacetType[] => {
+    const facetTypes: FacetType[] = [];
+
+    if (filters.loras.length > 0 && filters.matchModes?.loras !== 'all') facetTypes.push('loras');
+    if (filters.embeddings.length > 0 && filters.matchModes?.embeddings !== 'all') facetTypes.push('embeddings');
+    if (filters.hypernetworks.length > 0 && filters.matchModes?.hypernetworks !== 'all') facetTypes.push('hypernetworks');
+    if (filters.tools.length > 0 && filters.matchModes?.tools !== 'all') facetTypes.push('tools');
+    if (filters.models.length > 0) facetTypes.push('checkpoints');
+    if (filters.controlNets.length > 0 && filters.matchModes?.controlNets !== 'all') facetTypes.push('controlNets');
+    if (filters.ipAdapters.length > 0 && filters.matchModes?.ipAdapters !== 'all') facetTypes.push('ipAdapters');
+
+    return facetTypes;
+};
+
+const getExcludeKeyForFacetType = (facetType: FacetType): string => {
+    if (facetType === 'checkpoints') return 'models';
+    return facetType;
 };
 
 const hasRangeFilter = (value: number | null | undefined): boolean =>
@@ -125,6 +144,49 @@ export const useLibraryStatsQuery = ({
         useBrowserMocks
     ]);
 
+    const selfExcludedFacetTypes = useMemo(
+        () => getSelfExcludedFacetTypes(sideQueryFilters),
+        [sideQueryFilters]
+    );
+
+    const scopedCountOverrides = useMemo<Partial<Record<FacetType, ScopedFacetCountInput>> | undefined>(() => {
+        if (useBrowserMocks || !settingsLoaded || selfExcludedFacetTypes.length === 0) return undefined;
+
+        const overrides: Partial<Record<FacetType, ScopedFacetCountInput>> = {};
+
+        for (const facetType of selfExcludedFacetTypes) {
+            if (facetType === 'tools') continue;
+
+            const partial = buildSqlWhereClause(
+                sideQueryFilters,
+                privacyEnabled,
+                settings.maskingMode,
+                settings.maskedKeywords,
+                allCollections,
+                false,
+                [getExcludeKeyForFacetType(facetType)]
+            );
+
+            overrides[facetType] = {
+                whereClause: partial.where,
+                params: partial.params,
+                collectionId: partial.collectionId,
+                loraName: partial.loraName
+            };
+        }
+
+        return Object.keys(overrides).length > 0 ? overrides : undefined;
+    }, [
+        allCollections,
+        privacyEnabled,
+        selfExcludedFacetTypes,
+        settings.maskedKeywords,
+        settings.maskingMode,
+        settingsLoaded,
+        sideQueryFilters,
+        useBrowserMocks
+    ]);
+
     const facetsQuery = useQuery({
         queryKey: ['libraryStats', 'facets', facetCacheVersion, assetScope, sideQueryFilters, privacyEnabled, settings.maskingMode, settings.maskedKeywords, smartFilterHash],
         queryFn: async () => {
@@ -137,7 +199,8 @@ export const useLibraryStatsQuery = ({
             return getFacets(queryInput.where, queryInput.params, ALL_FACET_TYPES, {
                 assetScope,
                 collectionId: queryInput.collectionId,
-                loraName: queryInput.loraName
+                loraName: queryInput.loraName,
+                scopedCountOverrides
             });
         },
         placeholderData: (previousData) => previousData,
@@ -197,31 +260,10 @@ export const useLibraryStatsQuery = ({
 
             const baseValidNames = await getValidFacetNames(where, params, collectionId, loraName);
 
-            const disjunctiveCategories: FacetType[] = [];
-            if (activeCollectionId) {
-                // Collections are single select, no disjunctive logic needed currently.
-            }
-            if (sideQueryFilters.loras.length > 0 && sideQueryFilters.matchModes?.loras !== 'all') disjunctiveCategories.push('loras');
-            if (sideQueryFilters.embeddings.length > 0 && sideQueryFilters.matchModes?.embeddings !== 'all') disjunctiveCategories.push('embeddings');
-            if (sideQueryFilters.hypernetworks.length > 0 && sideQueryFilters.matchModes?.hypernetworks !== 'all') disjunctiveCategories.push('hypernetworks');
-            if (sideQueryFilters.tools.length > 0 && sideQueryFilters.matchModes?.tools !== 'all') disjunctiveCategories.push('tools');
-            if (sideQueryFilters.models.length > 0 && sideQueryFilters.matchModes?.models !== 'all') disjunctiveCategories.push('checkpoints');
-            if (sideQueryFilters.controlNets.length > 0 && sideQueryFilters.matchModes?.controlNets !== 'all') disjunctiveCategories.push('controlNets');
-            if (sideQueryFilters.ipAdapters.length > 0 && sideQueryFilters.matchModes?.ipAdapters !== 'all') disjunctiveCategories.push('ipAdapters');
-
             let finalValidNames = baseValidNames ? { ...baseValidNames } : null;
 
-            if (finalValidNames && disjunctiveCategories.length > 0 && fetchValidFacets) {
-                const extraQueries = disjunctiveCategories.map(async (cat) => {
-                    let excludeKey = '';
-                    if (cat === 'loras') excludeKey = 'loras';
-                    if (cat === 'embeddings') excludeKey = 'embeddings';
-                    if (cat === 'hypernetworks') excludeKey = 'hypernetworks';
-                    if (cat === 'tools') excludeKey = 'tools';
-                    if (cat === 'checkpoints') excludeKey = 'models';
-                    if (cat === 'controlNets') excludeKey = 'controlNets';
-                    if (cat === 'ipAdapters') excludeKey = 'ipAdapters';
-
+            if (finalValidNames && selfExcludedFacetTypes.length > 0 && fetchValidFacets) {
+                const extraQueries = selfExcludedFacetTypes.map(async (cat) => {
                     const partial = buildSqlWhereClause(
                         sideQueryFilters,
                         privacyEnabled,
@@ -229,7 +271,7 @@ export const useLibraryStatsQuery = ({
                         settings.maskedKeywords,
                         allCollections,
                         false,
-                        [excludeKey]
+                        [getExcludeKeyForFacetType(cat)]
                     );
 
                     const result = await getValidFacetNames(

--- a/src/services/__tests__/browserMockData.test.ts
+++ b/src/services/__tests__/browserMockData.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getBrowserMockFacets, searchBrowserMockImages } from '../browserMockData';
+import { createDefaultFilters } from '../../utils/filterState';
+
+describe('browserMockData filtering', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it('honors Match All for multi-valued asset filters', () => {
+        const anyResult = searchBrowserMockImages(createDefaultFilters({
+            loras: ['detail_tweaker_v1', 'soft_portrait'],
+            matchModes: { loras: 'any' }
+        }), 'date_desc', 1000);
+        const allResult = searchBrowserMockImages(createDefaultFilters({
+            loras: ['detail_tweaker_v1', 'soft_portrait'],
+            matchModes: { loras: 'all' }
+        }), 'date_desc', 1000);
+
+        expect(anyResult.totalCount).toBeGreaterThan(0);
+        expect(allResult.totalCount).toBe(0);
+    });
+
+    it('keeps checkpoints Any-only even if stale matchModes requests ALL', () => {
+        const result = searchBrowserMockImages(createDefaultFilters({
+            models: ['Flux.1 Dev', 'SDXL 1.0 Base'],
+            matchModes: { models: 'all' }
+        }), 'date_desc', 1000);
+
+        expect(result.totalCount).toBeGreaterThan(0);
+    });
+
+    it('keeps same-category alternatives visible in Match Any mock facets', () => {
+        const facets = getBrowserMockFacets(createDefaultFilters({
+            loras: ['detail_tweaker_v1'],
+            matchModes: { loras: 'any' }
+        }));
+        const loraNames = facets.loras.map((item) => item.name);
+
+        expect(loraNames).toContain('detail_tweaker_v1');
+        expect(loraNames).toContain('soft_portrait');
+    });
+});

--- a/src/services/browserMockData.ts
+++ b/src/services/browserMockData.ts
@@ -261,10 +261,17 @@ const getCollectionCount = (collection: Collection): number => {
 
 const isSmartCollection = (collection: Collection): collection is SmartCollection => !!collection.filters;
 
-const matchesEverySelected = (values: string[] | undefined, selected: string[] | undefined): boolean => {
+const matchesSelectedValues = (
+    values: string[] | undefined,
+    selected: string[] | undefined,
+    matchMode: 'any' | 'all' = 'any'
+): boolean => {
     if (!selected || selected.length === 0) return true;
     const lowerValues = new Set((values ?? []).map((value) => value.toLowerCase()));
-    return selected.some((value) => lowerValues.has(value.toLowerCase()));
+    const matches = (value: string) => lowerValues.has(value.toLowerCase());
+    return matchMode === 'all'
+        ? selected.every(matches)
+        : selected.some(matches);
 };
 
 interface BrowserSearchToken {
@@ -429,15 +436,15 @@ const filterImages = (images: AIImage[], filters: FilterState, collections: Coll
         if (!timestampMatchesDateBounds(image.timestamp, dateBounds)) return false;
         if (collectionIds && !collectionIds.has(image.id)) return false;
         if (smartMatches && !smartMatches.has(image.id)) return false;
-        if (filters.models.length > 0 && !filters.models.includes(image.metadata.model)) return false;
-        if (filters.tools.length > 0 && !filters.tools.includes(image.metadata.tool)) return false;
-        if (!matchesEverySelected(image.metadata.loras, filters.loras)) return false;
-        if (!matchesEverySelected(image.metadata.embeddings, filters.embeddings)) return false;
-        if (!matchesEverySelected(image.metadata.hypernetworks, filters.hypernetworks)) return false;
-        if (!matchesEverySelected(image.metadata.controlNets, filters.controlNets)) return false;
-        if (!matchesEverySelected(image.metadata.ipAdapters, filters.ipAdapters)) return false;
-        if (!matchesEverySelected([image.metadata.sampler], filters.samplers)) return false;
-        if (!matchesEverySelected([image.metadata.generationType ?? 'unknown'], filters.generationTypes)) return false;
+        if (!matchesSelectedValues([image.metadata.model], filters.models)) return false;
+        if (!matchesSelectedValues([image.metadata.tool], filters.tools)) return false;
+        if (!matchesSelectedValues(image.metadata.loras, filters.loras, filters.matchModes?.loras)) return false;
+        if (!matchesSelectedValues(image.metadata.embeddings, filters.embeddings, filters.matchModes?.embeddings)) return false;
+        if (!matchesSelectedValues(image.metadata.hypernetworks, filters.hypernetworks, filters.matchModes?.hypernetworks)) return false;
+        if (!matchesSelectedValues(image.metadata.controlNets, filters.controlNets, filters.matchModes?.controlNets)) return false;
+        if (!matchesSelectedValues(image.metadata.ipAdapters, filters.ipAdapters, filters.matchModes?.ipAdapters)) return false;
+        if (!matchesSelectedValues([image.metadata.sampler], filters.samplers)) return false;
+        if (!matchesSelectedValues([image.metadata.generationType ?? 'unknown'], filters.generationTypes)) return false;
         if (filters.minSteps !== undefined && image.metadata.steps < filters.minSteps) return false;
         if (filters.maxSteps !== undefined && image.metadata.steps > filters.maxSteps) return false;
         if (filters.minCfg !== undefined && image.metadata.cfg < filters.minCfg) return false;
@@ -505,18 +512,47 @@ const buildFacetItems = (images: AIImage[], type: FacetType) => {
         .map(([name, count]) => ({ name, count, lastUsedAt: Date.now() - count * 1000 }));
 };
 
+const getFacetSourceFilters = (filters: FilterState, type: FacetType): FilterState => {
+    if (type === 'checkpoints' && filters.models.length > 0) {
+        return { ...filters, models: [] };
+    }
+    if (type === 'tools' && filters.tools.length > 0 && filters.matchModes?.tools !== 'all') {
+        return { ...filters, tools: [] };
+    }
+    if (type === 'loras' && filters.loras.length > 0 && filters.matchModes?.loras !== 'all') {
+        return { ...filters, loras: [] };
+    }
+    if (type === 'embeddings' && filters.embeddings.length > 0 && filters.matchModes?.embeddings !== 'all') {
+        return { ...filters, embeddings: [] };
+    }
+    if (type === 'hypernetworks' && filters.hypernetworks.length > 0 && filters.matchModes?.hypernetworks !== 'all') {
+        return { ...filters, hypernetworks: [] };
+    }
+    if (type === 'controlNets' && filters.controlNets.length > 0 && filters.matchModes?.controlNets !== 'all') {
+        return { ...filters, controlNets: [] };
+    }
+    if (type === 'ipAdapters' && filters.ipAdapters.length > 0 && filters.matchModes?.ipAdapters !== 'all') {
+        return { ...filters, ipAdapters: [] };
+    }
+
+    return filters;
+};
+
 export const getBrowserMockFacets = (filters?: FilterState): Facets => {
     const current = loadStoredState();
-    const sourceImages = filters ? filterImages(current.images, filters, getBrowserMockCollections()) : current.images;
-    const tools = buildFacetItems(sourceImages, 'tools').map((item) => item.name);
+    const collections = getBrowserMockCollections();
+    const sourceFor = (type: FacetType) => (
+        filters ? filterImages(current.images, getFacetSourceFilters(filters, type), collections) : current.images
+    );
+    const tools = buildFacetItems(sourceFor('tools'), 'tools').map((item) => item.name);
 
     return {
-        checkpoints: buildFacetItems(sourceImages, 'checkpoints'),
-        loras: buildFacetItems(sourceImages, 'loras'),
-        embeddings: buildFacetItems(sourceImages, 'embeddings'),
-        hypernetworks: buildFacetItems(sourceImages, 'hypernetworks'),
-        controlNets: buildFacetItems(sourceImages, 'controlNets'),
-        ipAdapters: buildFacetItems(sourceImages, 'ipAdapters'),
+        checkpoints: buildFacetItems(sourceFor('checkpoints'), 'checkpoints'),
+        loras: buildFacetItems(sourceFor('loras'), 'loras'),
+        embeddings: buildFacetItems(sourceFor('embeddings'), 'embeddings'),
+        hypernetworks: buildFacetItems(sourceFor('hypernetworks'), 'hypernetworks'),
+        controlNets: buildFacetItems(sourceFor('controlNets'), 'controlNets'),
+        ipAdapters: buildFacetItems(sourceFor('ipAdapters'), 'ipAdapters'),
         tools,
     };
 };

--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -409,6 +409,83 @@ describe('searchRepo getFacets', () => {
         expect(db.select.mock.calls.some(([sql]) => (sql as string).includes('FROM scoped_images'))).toBe(true);
     });
 
+    it('uses self-excluded scoped count overrides to keep Match Any lora alternatives visible', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'loras',
+                    resource_name: 'LoraA',
+                    resource_hash: 'hash-a',
+                    count: 10
+                },
+                {
+                    facet_type: 'loras',
+                    resource_name: 'LoraB',
+                    resource_hash: 'hash-b',
+                    count: 8
+                }
+            ],
+            [],
+            {
+                loras: [{ name: 'LoraA', count: 1 }]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE is_deleted = 0', [], ['loras'], {
+            assetScope: 'used',
+            loraName: 'LoraA',
+            scopedCountOverrides: {
+                loras: {
+                    whereClause: '',
+                    params: []
+                }
+            }
+        });
+
+        expect(facets.loras).toEqual([
+            expect.objectContaining({ name: 'LoraA', count: 10 }),
+            expect.objectContaining({ name: 'LoraB', count: 8 })
+        ]);
+        expect(db.select.mock.calls.some(([sql]) => (sql as string).includes('FROM scoped_images'))).toBe(false);
+    });
+
+    it('keeps narrowed scoped lora counts when Match All does not provide an override', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'loras',
+                    resource_name: 'LoraA',
+                    resource_hash: 'hash-a',
+                    count: 10
+                },
+                {
+                    facet_type: 'loras',
+                    resource_name: 'LoraB',
+                    resource_hash: 'hash-b',
+                    count: 8
+                }
+            ],
+            [],
+            {
+                loras: [{ name: 'LoraA', count: 1 }]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE is_deleted = 0', [], ['loras'], {
+            assetScope: 'used',
+            loraName: 'LoraA'
+        });
+
+        expect(facets.loras).toEqual([
+            expect.objectContaining({ name: 'LoraA', count: 1 })
+        ]);
+        expect(db.select.mock.calls.some(([sql]) => (sql as string).includes('FROM scoped_images'))).toBe(true);
+    });
+
     it('normalizes scoped checkpoint counts across merged aliases in used scope', async () => {
         const db = createFacetDb(
             [

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -118,6 +118,14 @@ export interface GetFacetsOptions {
     assetScope?: AssetScope;
     collectionId?: string;
     loraName?: string;
+    scopedCountOverrides?: Partial<Record<FacetType, ScopedFacetCountInput>>;
+}
+
+export interface ScopedFacetCountInput {
+    whereClause: string;
+    params: unknown[];
+    collectionId?: string;
+    loraName?: string;
 }
 
 interface ScopedImageQueryParts {
@@ -976,11 +984,46 @@ export const getFacets = async (
                 .filter((type): type is string => type !== null)
         ));
         const diskPlaceholders = diskResourceTypes.map(() => '?').join(',');
-        const shouldUseScopedFacetOverlay = assetScope !== 'local'
-            && !isDefaultGlobalScope(whereClause, params, options.collectionId, options.loraName);
-        const scopedCountMaps = shouldUseScopedFacetOverlay
-            ? await getScopedFacetCountMaps(whereClause, params, cacheTypes, options.collectionId, options.loraName)
-            : new Map<string, Map<string, number>>();
+        const defaultScopedCountInput: ScopedFacetCountInput = {
+            whereClause,
+            params,
+            collectionId: options.collectionId,
+            loraName: options.loraName
+        };
+        const scopedCountInputsByCacheType = new Map<string, ScopedFacetCountInput>();
+        const shouldUseScopedFacetOverlayByCacheType = new Map<string, boolean>();
+
+        for (const facetType of types) {
+            if (facetType === 'tools') continue;
+
+            const cacheType = cacheTypeMap[facetType];
+            const scopedInput = options.scopedCountOverrides?.[facetType] ?? defaultScopedCountInput;
+            scopedCountInputsByCacheType.set(cacheType, scopedInput);
+            shouldUseScopedFacetOverlayByCacheType.set(
+                cacheType,
+                assetScope !== 'local'
+                    && !isDefaultGlobalScope(
+                        scopedInput.whereClause,
+                        scopedInput.params,
+                        scopedInput.collectionId,
+                        scopedInput.loraName
+                    )
+            );
+        }
+
+        const scopedCountMaps = new Map<string, Map<string, number>>();
+        await Promise.all(Array.from(scopedCountInputsByCacheType.entries()).map(async ([cacheType, scopedInput]) => {
+            if (!shouldUseScopedFacetOverlayByCacheType.get(cacheType)) return;
+
+            const countMaps = await getScopedFacetCountMaps(
+                scopedInput.whereClause,
+                scopedInput.params,
+                [cacheType],
+                scopedInput.collectionId,
+                scopedInput.loraName
+            );
+            scopedCountMaps.set(cacheType, countMaps.get(cacheType) ?? new Map<string, number>());
+        }));
 
         const [cacheRows, diskRows] = await Promise.all([
             db.select<FacetCacheRow[]>(`
@@ -1072,6 +1115,7 @@ export const getFacets = async (
 
         const finalizeGroups = (facetType: keyof typeof mergedResources): FacetItem[] => {
             const scopedCountMap = scopedCountMaps.get(facetType);
+            const shouldUseScopedFacetOverlay = shouldUseScopedFacetOverlayByCacheType.get(facetType) ?? false;
 
             return sortFacetItems(
                 Array.from(mergedResources[facetType].values()).map(group => ({

--- a/src/utils/__tests__/sqlHelpers.test.ts
+++ b/src/utils/__tests__/sqlHelpers.test.ts
@@ -43,6 +43,18 @@ describe('sqlHelpers', () => {
             expect(params).toEqual(['SDXL', 'Flux']);
         });
 
+        it('should always OR checkpoint models even if stale matchModes requests ALL', () => {
+            const { where, params } = buildSqlWhereClause({
+                ...defaultFilters,
+                models: ['SDXL', 'Flux'],
+                matchModes: { models: 'all' }
+            }, false, 'blur', []);
+
+            expect(where).toContain("resolved_model_name = ? COLLATE NOCASE OR resolved_model_name = ? COLLATE NOCASE");
+            expect(where).not.toContain("resolved_model_name = ? COLLATE NOCASE AND resolved_model_name = ? COLLATE NOCASE");
+            expect(params).toEqual(['SDXL', 'Flux']);
+        });
+
         it('should filter model aliases as one selected asset', () => {
             const { where, params } = buildSqlWhereClause({
                 ...defaultFilters,

--- a/src/utils/sqlHelpers.ts
+++ b/src/utils/sqlHelpers.ts
@@ -334,7 +334,6 @@ export const buildSqlWhereClause = (
 
     // 5. Models (Array)
     if (filters.models.length > 0 && !excludeCategories.includes('models')) {
-        const matchMode = filters.matchModes?.models || 'any';
         const modelConditions = getAssetAliasGroups(filters, 'models', filters.models).map(aliases => (
             buildAliasGroupCondition(aliases, alias => {
                 if (alias === 'Unknown') {
@@ -343,7 +342,7 @@ export const buildSqlWhereClause = (
                 return `resolved_model_name = ? COLLATE NOCASE`;
             }, params)
         ));
-        conditions.push(`(${modelConditions.join(matchMode === 'all' ? ' AND ' : ' OR ')})`);
+        conditions.push(`(${modelConditions.join(' OR ')})`);
     }
 
     // 5. Tools (Array)


### PR DESCRIPTION
## Summary
- Fix Match Any facet counts so selected values keep same-category alternatives visible while the rest of the active filters still apply.
- Keep Match All as narrowed co-occurrence behavior for multi-valued asset categories.
- Treat checkpoints as Any-only in the UI and SQL, and keep browser mock mode aligned with the real filter behavior.
- Document the implemented semantics and the deferred facet-taxonomy refactor candidate.

## Why
Match Any should behave like inclusive alternatives within a facet category. The previous count flow narrowed sibling alternatives after a selection, which made asset drill-down feel like Match All even when users chose Match Any. Checkpoints also needed protection from stale persisted `matchModes.models = 'all'` because each image only has one checkpoint/model.

## Validation
- `pnpm exec vitest run src/utils/__tests__/sqlHelpers.test.ts src/hooks/__tests__/useLibraryStatsQuery.test.tsx src/features/filters/components/__tests__/ResourceSection.test.tsx src/features/filters/components/__tests__/FilterPanel.test.tsx src/services/db/__tests__/searchRepo.test.ts src/services/__tests__/browserMockData.test.ts`
- `pnpm run typecheck`
- `pnpm run lint`
- `cargo test --manifest-path src-tauri\Cargo.toml test_valid_facet_names --lib`
- Browser mock smoke: Assets tab had no checkpoint match toggle, LoRA still had Match Any/All, and LoRA alternatives remained visible after selecting a LoRA in Match Any.