### PR TITLE
[codex] clean up resource asset discovery

### DIFF
--- a/src-tauri/src/db/facets.rs
+++ b/src-tauri/src/db/facets.rs
@@ -1,6 +1,6 @@
-use super::{ProgressPayload, configure_connection, resolve_db_path};
+use super::{configure_connection, resolve_db_path, ProgressPayload};
 use regex::Regex;
-use rusqlite::{OptionalExtension, params, types::Value};
+use rusqlite::{params, types::Value, OptionalExtension};
 use std::collections::BTreeSet;
 use std::time::Instant;
 use tauri::Emitter;
@@ -1126,6 +1126,40 @@ where
     }
 
     let tx = conn.transaction().map_err(|e| e.to_string())?;
+    let refreshed = refresh_live_facet_resources_in_transaction_with_progress(
+        &tx,
+        touches,
+        &mut emit_progress,
+    )?;
+    tx.commit().map_err(|e| e.to_string())?;
+
+    if total > 0 {
+        emit_progress(resource_index_progress_payload(
+            total, total, message, refreshed,
+        ));
+    }
+
+    Ok(refreshed)
+}
+
+pub(crate) fn refresh_live_facet_resources_in_transaction(
+    conn: &rusqlite::Connection,
+    touches: &FacetResourceTouches,
+) -> Result<usize, String> {
+    refresh_live_facet_resources_in_transaction_with_progress(conn, touches, &mut |_| {})
+}
+
+fn refresh_live_facet_resources_in_transaction_with_progress<F>(
+    conn: &rusqlite::Connection,
+    touches: &FacetResourceTouches,
+    emit_progress: &mut F,
+) -> Result<usize, String>
+where
+    F: FnMut(ResourceIndexProgressPayload),
+{
+    let items = collect_resource_refresh_items(touches);
+    let total = items.len();
+    let message = resource_index_message(&items);
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
@@ -1135,11 +1169,11 @@ where
 
     for (index, item) in items.iter().enumerate() {
         let did_refresh = match item.kind {
-            ResourceIndexKind::Checkpoints => refresh_checkpoint_facet(&tx, &item.name)?,
-            ResourceIndexKind::Tools => refresh_tool_facet(&tx, &item.name)?,
+            ResourceIndexKind::Checkpoints => refresh_checkpoint_facet(conn, &item.name)?,
+            ResourceIndexKind::Tools => refresh_tool_facet(conn, &item.name)?,
             _ => {
                 let config = resource_config(item.kind.facet_type())?;
-                refresh_resource_facet(&tx, config, &item.name, now)?
+                refresh_resource_facet(conn, config, &item.name, now)?
             }
         };
 
@@ -1156,14 +1190,6 @@ where
             ));
             last_progress_emit = Instant::now();
         }
-    }
-
-    tx.commit().map_err(|e| e.to_string())?;
-
-    if total > 0 {
-        emit_progress(resource_index_progress_payload(
-            total, total, message, refreshed,
-        ));
     }
 
     Ok(refreshed)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         metadata::models::cancel_model_resolution,
         metadata::models::cancel_model_discovery,
         metadata::thumbs_scan::scan_model_thumbnails,
+        metadata::thumbs_scan::purge_resource_folder_assets,
         metadata::models::set_model_thumbnail,
         metadata::models::unset_model_thumbnail,
         metadata::models::clear_all_thumbnails,

--- a/src-tauri/src/metadata/thumbs_scan.rs
+++ b/src-tauri/src/metadata/thumbs_scan.rs
@@ -1,8 +1,9 @@
-use crate::db::facets::FacetResourceTouches;
+use crate::db::facets::{refresh_live_facet_resources_in_transaction, FacetResourceTouches};
 use crate::db::resolve_db_path;
 use crate::metadata::models::{ModelDiscoveryState, ThumbnailScanResult};
 use rusqlite::{params, Connection};
 use serde::Serialize;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -80,6 +81,17 @@ struct ModelRegistrationOutcome {
     cached: bool,
     registered_models: usize,
     filename: String,
+    hash: String,
+}
+
+#[derive(Debug, Default, Clone, Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourcePurgeResult {
+    pub removed_models: usize,
+    pub preserved_models: usize,
+    pub removed_scanned_files: usize,
+    pub refreshed_facets: usize,
+    pub resources: FacetResourceTouches,
 }
 
 fn file_size_and_modified(path: &Path) -> (i64, i64) {
@@ -143,8 +155,18 @@ fn register_discovered_model_file(
         .execute(
             "INSERT INTO models (hash, name, filename, lookup_source, scanned_at, resource_type)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(hash) DO UPDATE SET filename = excluded.filename, resource_type = excluded.resource_type WHERE filename IS NULL OR filename = ''",
-            params![hash, stem, filename, "disk_scan", now, resource_type],
+             ON CONFLICT(hash) DO UPDATE SET
+                filename = CASE
+                    WHEN models.filename IS NULL OR models.filename = '' THEN excluded.filename
+                    ELSE models.filename
+                END,
+                lookup_source = excluded.lookup_source,
+                scanned_at = excluded.scanned_at,
+                resource_type = excluded.resource_type
+             WHERE models.lookup_source != 'disk_scan'
+                OR models.filename IS NULL
+                OR models.filename = ''",
+            params![&hash, stem, filename, "disk_scan", now, resource_type],
         )
         .map_err(|e| e.to_string())?;
 
@@ -152,6 +174,7 @@ fn register_discovered_model_file(
         cached,
         registered_models,
         filename,
+        hash,
     })
 }
 
@@ -257,6 +280,269 @@ fn touch_resource(resources: &mut FacetResourceTouches, resource_type: &str, nam
         "ip_adapters" => push_unique_resource_name(&mut resources.ip_adapters, name),
         _ => {}
     }
+}
+
+fn normalize_scan_path(value: &str) -> String {
+    let normalized = value
+        .trim()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+
+    if cfg!(windows) {
+        normalized.to_lowercase()
+    } else {
+        normalized
+    }
+}
+
+fn is_same_or_child_path(path: &str, folder: &str) -> bool {
+    let path = normalize_scan_path(path);
+    let folder = normalize_scan_path(folder);
+    if path.is_empty() || folder.is_empty() {
+        return false;
+    }
+
+    path == folder
+        || path
+            .strip_prefix(&folder)
+            .map(|rest| rest.starts_with('/'))
+            .unwrap_or(false)
+}
+
+fn file_hash_path(hash: &str) -> Option<&str> {
+    hash.strip_prefix("file:")
+}
+
+fn link_sidecar_thumbnail_for_model(
+    conn: &Connection,
+    model_path: &str,
+    model_hash: &str,
+    images: &HashSet<String>,
+) -> Result<bool, String> {
+    let model_path_buf = std::path::PathBuf::from(model_path);
+
+    let parent = match model_path_buf.parent() {
+        Some(p) => p,
+        None => return Ok(false),
+    };
+
+    let stem = match model_path_buf.file_stem().and_then(|s| s.to_str()) {
+        Some(s) => s,
+        None => return Ok(false),
+    };
+
+    let filename = match model_path_buf.file_name().and_then(|s| s.to_str()) {
+        Some(n) => n,
+        None => return Ok(false),
+    };
+
+    let candidates = [
+        format!("{}.preview.png", stem),
+        format!("{}.preview.jpg", stem),
+        format!("{}.preview.webp", stem),
+        format!("{}.png", stem),
+        format!("{}.jpg", stem),
+        format!("{}.webp", stem),
+        format!("{}.jpeg", stem),
+        format!("{}.png", filename),
+        format!("{}.jpg", filename),
+        format!("{}.webp", filename),
+    ];
+
+    for cand_name in candidates {
+        let candidate_path = parent.join(&cand_name).to_string_lossy().to_string();
+        if images.contains(&candidate_path) {
+            let rows = conn
+                .execute(
+                    "UPDATE models
+                     SET sidecar_thumbnail_path = ?1
+                     WHERE hash = ?2
+                       AND (sidecar_thumbnail_path IS NULL OR sidecar_thumbnail_path = '')",
+                    params![candidate_path, model_hash],
+                )
+                .map_err(|e| e.to_string())?;
+            return Ok(rows > 0);
+        }
+    }
+
+    Ok(false)
+}
+
+fn purge_resource_folder_assets_inner(
+    conn: &mut Connection,
+    folder_path: &str,
+    remaining_paths: &[String],
+) -> Result<ResourcePurgeResult, String> {
+    purge_resource_folder_assets_with_refresh(
+        conn,
+        folder_path,
+        remaining_paths,
+        refresh_live_facet_resources_in_transaction,
+    )
+}
+
+fn purge_resource_folder_assets_with_refresh<F>(
+    conn: &mut Connection,
+    folder_path: &str,
+    remaining_paths: &[String],
+    refresh_facets: F,
+) -> Result<ResourcePurgeResult, String>
+where
+    F: FnOnce(&Connection, &FacetResourceTouches) -> Result<usize, String>,
+{
+    if normalize_scan_path(folder_path).is_empty() {
+        return Err("Resource folder path is required".to_string());
+    }
+
+    let remaining_paths: Vec<&str> = remaining_paths
+        .iter()
+        .map(String::as_str)
+        .filter(|path| !normalize_scan_path(path).is_empty())
+        .collect();
+    let is_covered_by_remaining_path = |path: &str| {
+        remaining_paths
+            .iter()
+            .any(|folder| is_same_or_child_path(path, folder))
+    };
+
+    let tx = conn.transaction().map_err(|e| e.to_string())?;
+    let mut resources = FacetResourceTouches::default();
+    let mut model_candidates = Vec::new();
+
+    {
+        let mut stmt = tx
+            .prepare(
+                "SELECT hash, name, resource_type, thumbnail_path, thumbnail_mode,
+                        thumbnail_sensitivity_override
+                 FROM models
+                 WHERE lookup_source = 'disk_scan'
+                   AND hash LIKE 'file:%'",
+            )
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, Option<i64>>(5)?,
+                ))
+            })
+            .map_err(|e| e.to_string())?;
+
+        for row in rows {
+            let (hash, name, resource_type, thumbnail_path, thumbnail_mode, sensitivity_override) =
+                row.map_err(|e| e.to_string())?;
+            let Some(path) = file_hash_path(&hash) else {
+                continue;
+            };
+            if !is_same_or_child_path(path, folder_path) || is_covered_by_remaining_path(path) {
+                continue;
+            }
+
+            let path_buf = Path::new(path);
+            let fallback_name = path_buf.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+            let resource_name = name
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or(fallback_name);
+            let resource_type = resource_type
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_else(|| resource_type_for_model_path(path));
+            touch_resource(&mut resources, resource_type, resource_name);
+            let has_thumbnail_override = thumbnail_path
+                .as_deref()
+                .map(|value| !value.trim().is_empty())
+                .unwrap_or(false);
+            let uses_dynamic_thumbnail = thumbnail_mode.as_deref() == Some("dynamic");
+            let preserved_source = if has_thumbnail_override || uses_dynamic_thumbnail {
+                Some("manual_thumbnail")
+            } else if sensitivity_override.is_some() {
+                Some("manual_thumbnail_privacy")
+            } else {
+                None
+            };
+            model_candidates.push((hash, preserved_source));
+        }
+    }
+
+    let mut scanned_file_paths = Vec::new();
+    {
+        let mut stmt = tx
+            .prepare("SELECT DISTINCT path FROM scanned_files")
+            .map_err(|e| e.to_string())?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| e.to_string())?;
+
+        for row in rows {
+            let path = row.map_err(|e| e.to_string())?;
+            if is_same_or_child_path(&path, folder_path) && !is_covered_by_remaining_path(&path) {
+                scanned_file_paths.push(path);
+            }
+        }
+    }
+
+    let mut removed_models = 0;
+    let mut preserved_models = 0;
+    for (hash, preserved_source) in model_candidates {
+        if let Some(lookup_source) = preserved_source {
+            preserved_models += tx
+                .execute(
+                    "UPDATE models
+                     SET lookup_source = ?2, sidecar_thumbnail_path = NULL
+                     WHERE lookup_source = 'disk_scan' AND hash = ?1",
+                    params![hash, lookup_source],
+                )
+                .map_err(|e| e.to_string())?;
+        } else {
+            removed_models += tx
+                .execute(
+                    "DELETE FROM models WHERE lookup_source = 'disk_scan' AND hash = ?1",
+                    params![hash],
+                )
+                .map_err(|e| e.to_string())?;
+        }
+    }
+
+    let mut removed_scanned_files = 0;
+    for path in scanned_file_paths {
+        removed_scanned_files += tx
+            .execute("DELETE FROM scanned_files WHERE path = ?1", params![path])
+            .map_err(|e| e.to_string())?;
+    }
+    let refreshed_facets = refresh_facets(&tx, &resources)?;
+    tx.commit().map_err(|e| e.to_string())?;
+
+    Ok(ResourcePurgeResult {
+        removed_models,
+        preserved_models,
+        removed_scanned_files,
+        refreshed_facets,
+        resources,
+    })
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn purge_resource_folder_assets(
+    app: tauri::AppHandle,
+    path: String,
+    remaining_paths: Vec<String>,
+) -> Result<ResourcePurgeResult, String> {
+    let db_path = resolve_db_path(&app)?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let mut conn = Connection::open(db_path).map_err(|e| e.to_string())?;
+        crate::db::configure_connection(&conn).map_err(|e| e.to_string())?;
+        purge_resource_folder_assets_inner(&mut conn, &path, &remaining_paths)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -396,6 +682,7 @@ pub async fn scan_model_thumbnails(
     let mut cached_files = 0;
     let mut new_or_changed_files = 0;
     let mut registered_models = 0;
+    let mut registered_hashes: HashMap<String, String> = HashMap::new();
 
     {
         emit_progress(
@@ -448,6 +735,7 @@ pub async fn scan_model_thumbnails(
                 new_or_changed_files += 1;
             }
             registered_models += outcome.registered_models;
+            registered_hashes.insert(model_path.to_string(), outcome.hash.clone());
 
             if last_emit.elapsed().as_millis() > 200 || i == models_found.len() - 1 {
                 if state.is_cancelled.load(Ordering::SeqCst) {
@@ -482,57 +770,16 @@ pub async fn scan_model_thumbnails(
             ),
         );
 
-        let mut update_stmt = conn.prepare_cached(
-            "UPDATE models SET sidecar_thumbnail_path = ?1 WHERE (filename = ?2 COLLATE NOCASE OR name = ?3 COLLATE NOCASE OR name = ?4 COLLATE NOCASE) AND (sidecar_thumbnail_path IS NULL OR sidecar_thumbnail_path = '')"
-        ).map_err(|e| e.to_string())?;
-
         for (i, model_path) in models_found.iter().enumerate() {
-            let model_path_buf = std::path::PathBuf::from(&model_path);
-
-            let parent = match model_path_buf.parent() {
-                Some(p) => p,
-                None => continue,
-            };
-
-            let stem = match model_path_buf.file_stem().and_then(|s| s.to_str()) {
-                Some(s) => s,
-                None => continue,
-            };
-
+            let model_path_buf = Path::new(model_path);
             let filename = match model_path_buf.file_name().and_then(|s| s.to_str()) {
-                Some(n) => n,
-                None => continue,
+                Some(n) => n.to_string(),
+                None => model_path.to_string(),
             };
 
-            let candidates = [
-                format!("{}.preview.png", stem),
-                format!("{}.preview.jpg", stem),
-                format!("{}.preview.webp", stem),
-                format!("{}.png", stem),
-                format!("{}.jpg", stem),
-                format!("{}.webp", stem),
-                format!("{}.jpeg", stem),
-                format!("{}.png", filename),
-                format!("{}.jpg", filename),
-                format!("{}.webp", filename),
-            ];
-
-            let mut best_thumb: Option<String> = None;
-
-            for cand_name in candidates {
-                let candidate_path = parent.join(&cand_name).to_string_lossy().to_string();
-                if images_map.contains(&candidate_path) {
-                    best_thumb = Some(candidate_path);
-                    break;
-                }
-            }
-
-            if let Some(thumb_path) = best_thumb {
-                if let Ok(rows) = update_stmt.execute(params![thumb_path, filename, stem, filename])
-                {
-                    if rows > 0 {
-                        updated_count += 1;
-                    }
+            if let Some(hash) = registered_hashes.get(model_path) {
+                if link_sidecar_thumbnail_for_model(&conn, model_path, hash, &images_map)? {
+                    updated_count += 1;
                 }
             }
 
@@ -754,7 +1001,11 @@ mod tests {
                 filename TEXT,
                 lookup_source TEXT,
                 scanned_at INTEGER,
-                resource_type TEXT
+                resource_type TEXT,
+                sidecar_thumbnail_path TEXT,
+                thumbnail_path TEXT,
+                thumbnail_mode TEXT,
+                thumbnail_sensitivity_override INTEGER
             )",
             [],
         )
@@ -762,6 +1013,35 @@ mod tests {
         conn.execute("CREATE TABLE images (metadata_json TEXT)", [])
             .unwrap();
         conn
+    }
+
+    fn insert_test_model(
+        conn: &Connection,
+        hash: &str,
+        name: &str,
+        lookup_source: &str,
+        resource_type: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO models (hash, name, filename, lookup_source, scanned_at, resource_type)
+             VALUES (?1, ?2, ?3, ?4, 100, ?5)",
+            params![
+                hash,
+                name,
+                format!("{name}.safetensors"),
+                lookup_source,
+                resource_type
+            ],
+        )
+        .unwrap();
+    }
+
+    fn insert_test_scanned_file(conn: &Connection, path: &str, hash: &str) {
+        conn.execute(
+            "INSERT INTO scanned_files (path, size, modified, hash) VALUES (?1, 10, 20, ?2)",
+            params![path, hash],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -910,6 +1190,372 @@ mod tests {
         assert_eq!(disk_rows, 1);
 
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn purge_resource_folder_assets_removes_only_disk_scan_rows_inside_folder() {
+        let mut conn = registration_test_conn();
+        let inside_path = "C:/AI/models/loras/Foo.safetensors";
+        let sibling_path = "C:/AI/models/loras-old/Bar.safetensors";
+        let manual_path = "C:/AI/models/loras/Manual.safetensors";
+
+        insert_test_model(
+            &conn,
+            &format!("file:{inside_path}"),
+            "Foo",
+            "disk_scan",
+            "loras",
+        );
+        insert_test_model(
+            &conn,
+            &format!("file:{sibling_path}"),
+            "Bar",
+            "disk_scan",
+            "loras",
+        );
+        insert_test_model(
+            &conn,
+            &format!("file:{manual_path}"),
+            "Manual",
+            "manual_thumbnail",
+            "loras",
+        );
+        insert_test_scanned_file(&conn, inside_path, &format!("file:{inside_path}"));
+        insert_test_scanned_file(&conn, sibling_path, &format!("file:{sibling_path}"));
+
+        let result = purge_resource_folder_assets_with_refresh(
+            &mut conn,
+            "C:/AI/models/loras",
+            &[],
+            |_, _| Ok(1),
+        )
+        .unwrap();
+
+        assert_eq!(result.removed_models, 1);
+        assert_eq!(result.preserved_models, 0);
+        assert_eq!(result.removed_scanned_files, 1);
+        assert_eq!(result.refreshed_facets, 1);
+        assert_eq!(result.resources.loras, vec!["Foo"]);
+
+        let remaining_models: i64 = conn
+            .query_row("SELECT COUNT(*) FROM models", [], |row| row.get(0))
+            .unwrap();
+        let remaining_scanned_files: i64 = conn
+            .query_row("SELECT COUNT(*) FROM scanned_files", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining_models, 2);
+        assert_eq!(remaining_scanned_files, 1);
+
+        let manual_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM models WHERE name = 'Manual'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(manual_exists, 1);
+    }
+
+    #[test]
+    fn purge_resource_folder_assets_returns_touched_resources_by_type() {
+        let mut conn = registration_test_conn();
+        let rows = [
+            (
+                "C:/AI/models/checkpoints/Pony.safetensors",
+                "Pony",
+                "checkpoint",
+            ),
+            (
+                "C:/AI/models/controlnet/Canny.safetensors",
+                "Canny",
+                "control_nets",
+            ),
+            ("C:/AI/models/ipadapter/FaceID.bin", "FaceID", "ip_adapters"),
+        ];
+
+        for (path, name, resource_type) in rows {
+            insert_test_model(
+                &conn,
+                &format!("file:{path}"),
+                name,
+                "disk_scan",
+                resource_type,
+            );
+        }
+
+        let result =
+            purge_resource_folder_assets_with_refresh(&mut conn, "C:/AI/models", &[], |_, _| Ok(3))
+                .unwrap();
+
+        assert_eq!(result.removed_models, 3);
+        assert_eq!(result.refreshed_facets, 3);
+        assert_eq!(result.resources.checkpoints, vec!["Pony"]);
+        assert_eq!(result.resources.control_nets, vec!["Canny"]);
+        assert_eq!(result.resources.ip_adapters, vec!["FaceID"]);
+    }
+
+    #[test]
+    fn purge_preserves_assets_covered_by_remaining_child_folder() {
+        let mut conn = registration_test_conn();
+        let lora_path = "C:/AI/models/loras/Foo.safetensors";
+        let checkpoint_path = "C:/AI/models/checkpoints/Bar.safetensors";
+
+        insert_test_model(
+            &conn,
+            &format!("file:{lora_path}"),
+            "Foo",
+            "disk_scan",
+            "loras",
+        );
+        insert_test_model(
+            &conn,
+            &format!("file:{checkpoint_path}"),
+            "Bar",
+            "disk_scan",
+            "checkpoint",
+        );
+        insert_test_scanned_file(&conn, lora_path, &format!("file:{lora_path}"));
+        insert_test_scanned_file(&conn, checkpoint_path, &format!("file:{checkpoint_path}"));
+
+        let result = purge_resource_folder_assets_with_refresh(
+            &mut conn,
+            "C:/AI/models",
+            &["C:/AI/models/loras".to_string()],
+            |_, _| Ok(1),
+        )
+        .unwrap();
+
+        assert_eq!(result.removed_models, 1);
+        assert_eq!(result.resources.checkpoints, vec!["Bar"]);
+        assert!(result.resources.loras.is_empty());
+        let lora_exists: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM models WHERE hash = ?1",
+                [format!("file:{lora_path}")],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(lora_exists, 1);
+    }
+
+    #[test]
+    fn purge_preserves_assets_covered_by_remaining_parent_folder() {
+        let mut conn = registration_test_conn();
+        let lora_path = "C:/AI/models/loras/Foo.safetensors";
+        insert_test_model(
+            &conn,
+            &format!("file:{lora_path}"),
+            "Foo",
+            "disk_scan",
+            "loras",
+        );
+        insert_test_scanned_file(&conn, lora_path, &format!("file:{lora_path}"));
+
+        let result = purge_resource_folder_assets_with_refresh(
+            &mut conn,
+            "C:/AI/models/loras",
+            &["C:/AI/models".to_string()],
+            |_, _| Ok(0),
+        )
+        .unwrap();
+
+        assert_eq!(result.removed_models, 0);
+        assert_eq!(result.removed_scanned_files, 0);
+        assert!(result.resources.loras.is_empty());
+    }
+
+    #[test]
+    fn purge_preserves_manual_thumbnail_state_as_non_local_metadata() {
+        let mut conn = registration_test_conn();
+        let path = "C:/AI/models/loras/Customized.safetensors";
+        let hash = format!("file:{path}");
+        insert_test_model(&conn, &hash, "Customized", "disk_scan", "loras");
+        insert_test_scanned_file(&conn, path, &hash);
+        conn.execute(
+            "UPDATE models
+             SET thumbnail_path = 'C:/thumbs/custom.webp',
+                 thumbnail_sensitivity_override = 1,
+                 sidecar_thumbnail_path = 'C:/AI/models/loras/Customized.preview.png'
+             WHERE hash = ?1",
+            [&hash],
+        )
+        .unwrap();
+
+        let result = purge_resource_folder_assets_with_refresh(
+            &mut conn,
+            "C:/AI/models/loras",
+            &[],
+            |_, _| Ok(1),
+        )
+        .unwrap();
+
+        assert_eq!(result.removed_models, 0);
+        assert_eq!(result.preserved_models, 1);
+        assert_eq!(result.removed_scanned_files, 1);
+        let preserved: (String, Option<String>, Option<String>, Option<i64>) = conn
+            .query_row(
+                "SELECT lookup_source, thumbnail_path, sidecar_thumbnail_path,
+                        thumbnail_sensitivity_override
+                 FROM models WHERE hash = ?1",
+                [&hash],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(preserved.0, "manual_thumbnail");
+        assert_eq!(preserved.1.as_deref(), Some("C:/thumbs/custom.webp"));
+        assert_eq!(preserved.2, None);
+        assert_eq!(preserved.3, Some(1));
+    }
+
+    #[test]
+    fn purge_preserves_dynamic_and_privacy_only_customizations() {
+        let mut conn = registration_test_conn();
+        let dynamic_path = "C:/AI/models/loras/Dynamic.safetensors";
+        let privacy_path = "C:/AI/models/loras/Private.safetensors";
+        let dynamic_hash = format!("file:{dynamic_path}");
+        let privacy_hash = format!("file:{privacy_path}");
+        insert_test_model(&conn, &dynamic_hash, "Dynamic", "disk_scan", "loras");
+        insert_test_model(&conn, &privacy_hash, "Private", "disk_scan", "loras");
+        insert_test_scanned_file(&conn, dynamic_path, &dynamic_hash);
+        insert_test_scanned_file(&conn, privacy_path, &privacy_hash);
+        conn.execute(
+            "UPDATE models SET thumbnail_mode = 'dynamic' WHERE hash = ?1",
+            [&dynamic_hash],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE models SET thumbnail_sensitivity_override = 0 WHERE hash = ?1",
+            [&privacy_hash],
+        )
+        .unwrap();
+
+        let result = purge_resource_folder_assets_with_refresh(
+            &mut conn,
+            "C:/AI/models/loras",
+            &[],
+            |_, _| Ok(1),
+        )
+        .unwrap();
+
+        assert_eq!(result.removed_models, 0);
+        assert_eq!(result.preserved_models, 2);
+        let dynamic_source: String = conn
+            .query_row(
+                "SELECT lookup_source FROM models WHERE hash = ?1",
+                [&dynamic_hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let privacy_source: String = conn
+            .query_row(
+                "SELECT lookup_source FROM models WHERE hash = ?1",
+                [&privacy_hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(dynamic_source, "manual_thumbnail");
+        assert_eq!(privacy_source, "manual_thumbnail_privacy");
+    }
+
+    #[test]
+    fn rediscovery_restores_preserved_model_as_local_without_losing_customization() {
+        let root = temp_resource_dir("rediscover_customized");
+        let lora_dir = root.join("loras");
+        fs::create_dir_all(&lora_dir).unwrap();
+        let model_path = lora_dir.join("Customized.safetensors");
+        fs::write(&model_path, b"model").unwrap();
+        let model_path = model_path.to_string_lossy().to_string();
+        let hash = format!("file:{model_path}");
+        let conn = registration_test_conn();
+        insert_test_model(&conn, &hash, "Customized", "manual_thumbnail", "loras");
+        conn.execute(
+            "UPDATE models SET thumbnail_path = 'C:/thumbs/custom.webp' WHERE hash = ?1",
+            [&hash],
+        )
+        .unwrap();
+        let mut resources = FacetResourceTouches::default();
+
+        register_discovered_model_file(&conn, &model_path, 200, &mut resources).unwrap();
+
+        let restored: (String, Option<String>) = conn
+            .query_row(
+                "SELECT lookup_source, thumbnail_path FROM models WHERE hash = ?1",
+                [&hash],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(restored.0, "disk_scan");
+        assert_eq!(restored.1.as_deref(), Some("C:/thumbs/custom.webp"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn purge_rolls_back_when_facet_refresh_fails() {
+        let mut conn = registration_test_conn();
+        let path = "C:/AI/models/loras/Foo.safetensors";
+        let hash = format!("file:{path}");
+        insert_test_model(&conn, &hash, "Foo", "disk_scan", "loras");
+        insert_test_scanned_file(&conn, path, &hash);
+
+        let result = purge_resource_folder_assets_with_refresh(
+            &mut conn,
+            "C:/AI/models/loras",
+            &[],
+            |_, _| Err("forced refresh failure".to_string()),
+        );
+
+        assert_eq!(result.unwrap_err(), "forced refresh failure");
+        let model_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM models", [], |row| row.get(0))
+            .unwrap();
+        let scanned_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM scanned_files", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(model_count, 1);
+        assert_eq!(scanned_count, 1);
+    }
+
+    #[test]
+    fn sidecar_linking_updates_only_exact_discovered_hash() {
+        let conn = registration_test_conn();
+        let first_path = "C:/AI/models/loras/Duplicate.safetensors";
+        let second_path = "D:/Archive/loras/Duplicate.safetensors";
+        let first_hash = format!("file:{first_path}");
+        let second_hash = format!("file:{second_path}");
+        let first_thumb = Path::new(first_path)
+            .parent()
+            .unwrap()
+            .join("Duplicate.preview.png")
+            .to_string_lossy()
+            .to_string();
+        let mut images = HashSet::new();
+        images.insert(first_thumb.clone());
+
+        insert_test_model(&conn, &first_hash, "Duplicate", "disk_scan", "loras");
+        insert_test_model(&conn, &second_hash, "Duplicate", "disk_scan", "loras");
+
+        let linked =
+            link_sidecar_thumbnail_for_model(&conn, first_path, &first_hash, &images).unwrap();
+
+        assert!(linked);
+        let first_sidecar: Option<String> = conn
+            .query_row(
+                "SELECT sidecar_thumbnail_path FROM models WHERE hash = ?1",
+                params![first_hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let second_sidecar: Option<String> = conn
+            .query_row(
+                "SELECT sidecar_thumbnail_path FROM models WHERE hash = ?1",
+                params![second_hash],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(first_sidecar.as_deref(), Some(first_thumb.as_str()));
+        assert_eq!(second_sidecar, None);
     }
 
     #[test]

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -462,6 +462,14 @@ async scanModelThumbnails(paths: string[]) : Promise<Result<ThumbnailScanResult,
     else return { status: "error", error: e  as any };
 }
 },
+async purgeResourceFolderAssets(path: string, remainingPaths: string[]) : Promise<Result<ResourcePurgeResult, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("purge_resource_folder_assets", { path, remainingPaths }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async setModelThumbnail(modelHash: string, modelName: string | null, imagePath: string, resourceType: string | null) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("set_model_thumbnail", { modelHash, modelName, imagePath, resourceType }) };
@@ -573,6 +581,7 @@ export type ReparseBatchResult = { processed: number; updated: number; errors: n
  */
 export type ReparseJobResult = { processed: number; updated: number; errors: number; wasCancelled: boolean }
 export type ResolutionResult = { resolvedCount: number; harvestedCount: number; failedCount: number; namedFallbackCount: number; unknownCount: number }
+export type ResourcePurgeResult = { removedModels: number; preservedModels: number; removedScannedFiles: number; refreshedFacets: number; resources: FacetResourceTouches }
 export type ScanResult = { width: number; height: number; size: number; modified: number; thumbnail: string; 
 /**
  * Base64 encoded 32px WebP micro-thumbnail for instant previews

--- a/src/features/filters/components/ResourceSection.tsx
+++ b/src/features/filters/components/ResourceSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Search, Puzzle, Check, LayoutGrid, List as ListIcon, SortAsc, SortDesc, Clock, Calendar, ArrowDownWideNarrow, ArrowUpWideNarrow, Pin, Circle, CircleDot, Eye, EyeOff, RotateCcw } from 'lucide-react';
+import { Search, Puzzle, Check, LayoutGrid, List as ListIcon, SortAsc, SortDesc, Clock, Calendar, ArrowDownWideNarrow, ArrowUpWideNarrow, Pin, Circle, CircleDot, Eye, EyeOff, RotateCcw, HardDrive, ImageOff } from 'lucide-react';
 import type { AssetScope, FacetSortOption, FilterState } from '../../../types';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { SectionHeader, SearchInput, SortDropdown } from './FilterPrimitives';
@@ -10,6 +10,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { PrivacyAwareThumbnail } from '../../../components/ui/PrivacyAwareThumbnail';
 import { commands } from '../../../bindings';
 import { uniqueAssetAliases } from '../../../utils/assetIdentity';
+import type { ResourceThumbnailSource } from '../../../services/db/searchRepo';
 
 export type { AssetScope };
 
@@ -32,6 +33,7 @@ interface ResourceItem {
     thumbnailImageId?: string;
     thumbnailIsSensitive?: number;
     thumbnailSensitivityOverride?: number | null;
+    thumbnailSource?: ResourceThumbnailSource;
     isLocalDisk?: boolean;
     assetMatchKey?: string;
     filterAliases?: string[];
@@ -333,6 +335,13 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
         const isSelected = isItemSelected(item);
         const isInventoryOnly = item.count === 0 && item.isLocalDisk;
         const thumbUrl = item.thumbnailPath || item.previewUrl;
+        const hasSidecarPreview = item.thumbnailSource === 'sidecar';
+        const unusedTitle = hasSidecarPreview
+            ? 'Unused: local asset has no matching library images. Preview from sidecar image.'
+            : 'Unused: local asset has no matching library images.';
+        const localTitle = hasSidecarPreview
+            ? 'Local asset on disk. Preview from sidecar image.'
+            : 'Local asset on disk';
 
         return (
             <div
@@ -382,15 +391,25 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                 {/* Count Badge - Hover Only for ALL items, always Top Right */}
                 {!isSelected && (
                     <div className={`absolute top-1.5 right-1.5 transition-opacity z-10 ${isInventoryOnly ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
-                        <div className={`px-1.5 py-0.5 rounded-md backdrop-blur-sm text-[9px] font-bold shadow-sm ${isInventoryOnly ? 'bg-blue-500/80 text-white' : 'bg-black/40 text-white/90'}`}>
-                            {isInventoryOnly ? 'Unused' : formatCountCompact(item.count)}
+                        <div
+                            role={isInventoryOnly ? 'img' : undefined}
+                            aria-label={isInventoryOnly ? unusedTitle : undefined}
+                            title={isInventoryOnly ? unusedTitle : `${item.count.toLocaleString()} total images`}
+                            className={`px-1.5 py-0.5 rounded-md backdrop-blur-sm text-[9px] font-bold shadow-sm ${isInventoryOnly ? 'bg-blue-500/80 text-white' : 'bg-black/40 text-white/90'}`}
+                        >
+                            {isInventoryOnly ? <ImageOff className="h-3 w-3" aria-hidden="true" /> : formatCountCompact(item.count)}
                         </div>
                     </div>
                 )}
 
                 {item.isLocalDisk && !isInventoryOnly && (
-                    <div className="absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded-md bg-white/80 dark:bg-black/50 backdrop-blur-sm text-[9px] font-bold text-blue-700 dark:text-blue-200 shadow-sm">
-                        Local
+                    <div
+                        role="img"
+                        aria-label={localTitle}
+                        title={localTitle}
+                        className="absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded-md bg-white/80 dark:bg-black/50 backdrop-blur-sm text-blue-700 dark:text-blue-200 shadow-sm"
+                    >
+                        <HardDrive className="h-3 w-3" aria-hidden="true" />
                     </div>
                 )}
 
@@ -403,6 +422,13 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
         const isSelected = isItemSelected(item);
         const isInventoryOnly = item.count === 0 && item.isLocalDisk;
         const thumbUrl = item.thumbnailPath || item.previewUrl;
+        const hasSidecarPreview = item.thumbnailSource === 'sidecar';
+        const unusedTitle = hasSidecarPreview
+            ? 'Unused: local asset has no matching library images. Preview from sidecar image.'
+            : 'Unused: local asset has no matching library images.';
+        const localTitle = hasSidecarPreview
+            ? 'Local asset on disk. Preview from sidecar image.'
+            : 'Local asset on disk';
 
         return (
             <div
@@ -442,14 +468,21 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                 </div>
                 <div className="flex items-center gap-2 flex-shrink-0">
                     <span
+                        role={isInventoryOnly ? 'img' : undefined}
+                        aria-label={isInventoryOnly ? unusedTitle : undefined}
                         className={`text-[10px] px-1.5 py-0.5 rounded-md transition-opacity group-hover:opacity-100 ${isInventoryOnly ? 'bg-blue-50 dark:bg-blue-500/15 text-blue-700 dark:text-blue-300 opacity-100' : `bg-gray-100 dark:bg-white/10 ${validNames != null ? 'opacity-30' : 'opacity-60'}`}`}
-                        title={isInventoryOnly ? 'Local asset with no matching images yet' : `${item.count.toLocaleString()} total images`}
+                        title={isInventoryOnly ? unusedTitle : `${item.count.toLocaleString()} total images`}
                     >
-                        {isInventoryOnly ? 'Unused' : formatCountCompact(item.count)}
+                        {isInventoryOnly ? <ImageOff className="h-3 w-3" aria-hidden="true" /> : formatCountCompact(item.count)}
                     </span>
                     {item.isLocalDisk && !isInventoryOnly && (
-                        <span className="text-[9px] bg-blue-50 dark:bg-blue-500/15 text-blue-700 dark:text-blue-300 px-1.5 py-0.5 rounded-md font-bold uppercase tracking-wide">
-                            Local
+                        <span
+                            role="img"
+                            aria-label={localTitle}
+                            title={localTitle}
+                            className="bg-blue-50 dark:bg-blue-500/15 text-blue-700 dark:text-blue-300 px-1.5 py-0.5 rounded-md"
+                        >
+                            <HardDrive className="h-3 w-3" aria-hidden="true" />
                         </span>
                     )}
                 </div>

--- a/src/features/filters/components/__tests__/ResourceSection.test.tsx
+++ b/src/features/filters/components/__tests__/ResourceSection.test.tsx
@@ -201,8 +201,10 @@ describe('ResourceSection asset scope filtering', () => {
         renderScopedSection({ assetScope: 'local' });
 
         expect(screen.getByText('UnusedLocal')).toBeTruthy();
-        expect(screen.getByText('Unused')).toBeTruthy();
+        expect(screen.queryByText('Unused', { exact: true })).toBeNull();
+        expect(screen.getByLabelText('Unused: local asset has no matching library images.')).toBeTruthy();
         expect(screen.getByText('UsedLocal')).toBeTruthy();
+        expect(screen.getByLabelText('Local asset on disk')).toBeTruthy();
         expect(screen.queryByText('HarvestedOnly')).toBeNull();
     });
 
@@ -284,6 +286,58 @@ describe('ResourceSection asset scope filtering', () => {
         );
 
         expect(screen.getByText('Detailer-Style')).toBeTruthy();
+    });
+
+    it('explains sidecar previews on unused local asset badges', () => {
+        render(
+            <ResourceSection
+                title="Resources"
+                type="loras"
+                filters={filters}
+                setFilters={vi.fn()}
+                data={[{
+                    name: 'SidecarOnly',
+                    hash: 'file:C:/models/SidecarOnly.safetensors',
+                    count: 0,
+                    isLocalDisk: true,
+                    thumbnailPath: 'sidecar.webp',
+                    hasSidecar: 1,
+                    thumbnailSource: 'sidecar'
+                }]}
+                isOpen
+                onToggle={vi.fn()}
+                assetScope="local"
+            />
+        );
+
+        expect(screen.getByLabelText('Unused: local asset has no matching library images. Preview from sidecar image.')).toBeTruthy();
+    });
+
+    it('does not describe an available sidecar when a manual preview is displayed', () => {
+        render(
+            <ResourceSection
+                title="Resources"
+                type="loras"
+                filters={filters}
+                setFilters={vi.fn()}
+                data={[{
+                    name: 'ManualPreview',
+                    hash: 'file:C:/models/ManualPreview.safetensors',
+                    count: 0,
+                    isLocalDisk: true,
+                    thumbnailPath: 'manual.webp',
+                    hasSidecar: 1,
+                    isUserOverride: 1,
+                    thumbnailSource: 'manual'
+                }]}
+                isOpen
+                onToggle={vi.fn()}
+                assetScope="local"
+            />
+        );
+
+        expect(screen.getByLabelText('Unused: local asset has no matching library images.')).toBeTruthy();
+        expect(screen.queryByLabelText(/Preview from sidecar image/)).toBeNull();
     });
 });
 

--- a/src/features/settings/components/ResourceDiscoverySection.tsx
+++ b/src/features/settings/components/ResourceDiscoverySection.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Folder, FolderSearch, RefreshCw, Trash2, Plus } from 'lucide-react';
+import { AlertTriangle, Folder, FolderSearch, RefreshCw, Trash2, Plus } from 'lucide-react';
 import { APP_NAME } from '../../../constants/app';
 
 interface ResourceDiscoverySectionProps {
@@ -7,19 +7,26 @@ interface ResourceDiscoverySectionProps {
     isScanning: boolean;
     scanProgress?: { message?: string };
     isPopulatingThumbnails: boolean;
+    removingResourcePath: string | null;
     newResourcePath: string;
     setNewResourcePath: (val: string) => void;
     onBrowse: () => void;
     onAdd: (e: React.FormEvent) => void;
-    onRemove: (path: string) => void;
+    onRemove: (path: string) => void | Promise<void>;
     onScanNow: () => void;
 }
+
+const isBroadModelsPath = (path: string): boolean => {
+    const normalized = path.trim().replace(/\\/g, '/').replace(/\/+$/g, '').toLowerCase();
+    return normalized.split('/').pop() === 'models';
+};
 
 export const ResourceDiscoverySection: React.FC<ResourceDiscoverySectionProps> = ({
     resourceFolders,
     isScanning,
     scanProgress,
     isPopulatingThumbnails,
+    removingResourcePath,
     newResourcePath,
     setNewResourcePath,
     onBrowse,
@@ -27,6 +34,10 @@ export const ResourceDiscoverySection: React.FC<ResourceDiscoverySectionProps> =
     onRemove,
     onScanNow
 }) => {
+    const showBroadPathWarning = isBroadModelsPath(newResourcePath);
+    const hasConfiguredBroadPath = resourceFolders.some(isBroadModelsPath);
+    const isDiscoveryBusy = isScanning || isPopulatingThumbnails || removingResourcePath !== null;
+
     return (
         <div className="space-y-4 pt-4 border-t border-gray-200 dark:border-white/5">
             <div className="p-4 bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/20 rounded-xl text-sm text-blue-800 dark:text-blue-200 flex items-center justify-between gap-3">
@@ -48,8 +59,8 @@ export const ResourceDiscoverySection: React.FC<ResourceDiscoverySectionProps> =
                             <button
                                 type="button"
                                 onClick={onScanNow}
-                                disabled={isScanning || isPopulatingThumbnails}
-                                className={`flex items-center gap-2 px-3 py-1.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-lg text-xs font-medium hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors ${isScanning || isPopulatingThumbnails ? 'opacity-70 cursor-wait' : ''}`}
+                                disabled={isDiscoveryBusy}
+                                className={`flex items-center gap-2 px-3 py-1.5 bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-lg text-xs font-medium hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors ${isDiscoveryBusy ? 'opacity-70 cursor-wait' : ''}`}
                             >
                                 <RefreshCw className={`w-3.5 h-3.5 ${isScanning ? 'animate-spin' : ''}`} />
                                 {isScanning ? 'Scanning...' : 'Scan Now'}
@@ -61,25 +72,53 @@ export const ResourceDiscoverySection: React.FC<ResourceDiscoverySectionProps> =
 
             <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/5 rounded-xl overflow-hidden shadow-sm">
                 <div className="p-2 space-y-1">
-                    {resourceFolders.map((path, idx) => (
-                        <div key={idx} className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-white/5 group transition-colors">
-                            <div className="flex items-center gap-3 overflow-hidden">
-                                <div className="p-2 bg-gray-100 dark:bg-white/10 rounded-lg text-gray-500 dark:text-gray-400">
-                                    <Folder className="w-4 h-4" />
+                    {resourceFolders.map((path, idx) => {
+                        const isRemoving = removingResourcePath === path;
+                        const isBroadPath = isBroadModelsPath(path);
+
+                        return (
+                            <div key={idx} className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-white/5 group transition-colors">
+                                <div className="flex items-center gap-3 overflow-hidden">
+                                    <div className="p-2 bg-gray-100 dark:bg-white/10 rounded-lg text-gray-500 dark:text-gray-400">
+                                        <Folder className="w-4 h-4" />
+                                    </div>
+                                    <span className="text-sm text-gray-700 dark:text-gray-300 font-mono truncate">{path}</span>
+                                    {isBroadPath && (
+                                        <span
+                                            className="flex-shrink-0 text-amber-500"
+                                            role="img"
+                                            aria-label={`Broad models root ${path}`}
+                                            title="Broad models root; prefer specific resource folders"
+                                        >
+                                            <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+                                        </span>
+                                    )}
                                 </div>
-                                <span className="text-sm text-gray-700 dark:text-gray-300 font-mono truncate">{path}</span>
+                                <button
+                                    type="button"
+                                    onClick={() => onRemove(path)}
+                                    disabled={isDiscoveryBusy}
+                                    aria-label={`${isRemoving ? 'Removing' : 'Remove'} resource folder ${path}`}
+                                    title={`${isRemoving ? 'Removing' : 'Remove'} resource folder ${path}`}
+                                    className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-all disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-gray-400"
+                                >
+                                    {isRemoving
+                                        ? <RefreshCw className="h-4 w-4 animate-spin" />
+                                        : <Trash2 className="w-4 h-4" />}
+                                </button>
                             </div>
-                            <button
-                                type="button"
-                                onClick={() => onRemove(path)}
-                                className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-all"
-                            >
-                                <Trash2 className="w-4 h-4" />
-                            </button>
-                        </div>
-                    ))}
+                        );
+                    })}
                     {resourceFolders.length === 0 && (
                         <div className="text-sm text-gray-400 text-center py-8 italic">No resource folders added.</div>
+                    )}
+                    {hasConfiguredBroadPath && (
+                        <div className="mx-2 mb-2 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                            <span>
+                                A configured models root may include false positives. Remove it and add specific folders such as <span className="font-mono">models/Lora</span> or <span className="font-mono">models/checkpoints</span>.
+                            </span>
+                        </div>
                     )}
                 </div>
                 <div className="border-t border-gray-200 dark:border-white/5 p-4 bg-gray-50/50 dark:bg-black/20">
@@ -88,26 +127,37 @@ export const ResourceDiscoverySection: React.FC<ResourceDiscoverySectionProps> =
                             type="text"
                             value={newResourcePath}
                             onChange={(e) => setNewResourcePath(e.target.value)}
+                            disabled={isDiscoveryBusy}
                             placeholder="e.g. D:/StableDiffusion/models/Lora"
-                            className="flex-1 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-lg px-3 py-2 text-sm focus:border-sage-500 outline-none text-gray-900 dark:text-white placeholder-gray-400"
+                            className="flex-1 bg-white dark:bg-black/20 border border-gray-200 dark:border-white/10 rounded-lg px-3 py-2 text-sm focus:border-sage-500 outline-none text-gray-900 dark:text-white placeholder-gray-400 disabled:cursor-not-allowed disabled:opacity-60"
                         />
                         <button
                             type="button"
                             onClick={onBrowse}
-                            className="px-3 py-2 bg-gray-100 dark:bg-white/10 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-white/20 transition-colors"
+                            disabled={isDiscoveryBusy}
+                            className="px-3 py-2 bg-gray-100 dark:bg-white/10 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-white/20 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                             title="Browse"
+                            aria-label="Browse for resource folder"
                         >
                             <FolderSearch className="w-4 h-4" />
                         </button>
                         <button
                             type="submit"
-                            disabled={!newResourcePath.trim() || isScanning}
+                            disabled={!newResourcePath.trim() || isDiscoveryBusy}
                             className="px-4 py-2 bg-blue-600 disabled:bg-gray-300 disabled:text-gray-500 text-white rounded-lg hover:bg-blue-500 transition-colors font-medium text-sm flex items-center gap-1"
                         >
                             {isScanning ? <RefreshCw className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
                             {isScanning ? 'Scanning...' : 'Add Path'}
                         </button>
                     </form>
+                    {showBroadPathWarning && (
+                        <div className="mt-3 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800 dark:border-amber-500/30 dark:bg-amber-500/10 dark:text-amber-200">
+                            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                            <span>
+                                This looks like a broad models root. Prefer specific folders such as <span className="font-mono">models/Lora</span> or <span className="font-mono">models/checkpoints</span> to avoid false positives.
+                            </span>
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/features/settings/components/ResourcesTab.tsx
+++ b/src/features/settings/components/ResourcesTab.tsx
@@ -16,6 +16,7 @@ export const ResourcesTab: React.FC<TabProps> = React.memo(({ settings, setSetti
         isScanningDiscovery,
         discoveryScanProgress,
         isPopulatingThumbnails,
+        removingResourcePath,
         newResourcePath,
         setNewResourcePath,
         resourceInputRef,
@@ -42,6 +43,7 @@ export const ResourcesTab: React.FC<TabProps> = React.memo(({ settings, setSetti
                 isScanning={isScanningDiscovery}
                 scanProgress={discoveryScanProgress ?? undefined}
                 isPopulatingThumbnails={isPopulatingThumbnails}
+                removingResourcePath={removingResourcePath}
                 newResourcePath={newResourcePath}
                 setNewResourcePath={setNewResourcePath}
                 onBrowse={handleBrowseResource}

--- a/src/features/settings/components/__tests__/ResourceDiscoverySection.test.tsx
+++ b/src/features/settings/components/__tests__/ResourceDiscoverySection.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '../../../../test/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+import { ResourceDiscoverySection } from '../ResourceDiscoverySection';
+
+const defaultProps = {
+    resourceFolders: [],
+    isScanning: false,
+    isPopulatingThumbnails: false,
+    removingResourcePath: null,
+    newResourcePath: '',
+    setNewResourcePath: vi.fn(),
+    onBrowse: vi.fn(),
+    onAdd: vi.fn(),
+    onRemove: vi.fn(),
+    onScanNow: vi.fn()
+};
+
+describe('ResourceDiscoverySection', () => {
+    it('warns when the pending resource path looks like a broad models root', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                newResourcePath="D:/StableDiffusion/models"
+            />
+        );
+
+        expect(screen.getByText(/This looks like a broad models root/)).toBeTruthy();
+    });
+
+    it('does not warn for a specific resource subfolder', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                newResourcePath="D:/StableDiffusion/models/Lora"
+            />
+        );
+
+        expect(screen.queryByText(/This looks like a broad models root/)).toBeNull();
+    });
+
+    it('warns for broad models roots already configured in settings', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                resourceFolders={['D:/StableDiffusion/models']}
+            />
+        );
+
+        expect(screen.getByRole('img', { name: 'Broad models root D:/StableDiffusion/models' })).toBeTruthy();
+        expect(screen.getByText(/A configured models root may include false positives/)).toBeTruthy();
+    });
+
+    it('does not warn for configured resource subfolders', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                resourceFolders={['D:/StableDiffusion/models/Lora']}
+            />
+        );
+
+        expect(screen.queryByText(/A configured models root may include false positives/)).toBeNull();
+    });
+
+    it('labels icon-only resource folder remove buttons', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                resourceFolders={['D:/StableDiffusion/models']}
+            />
+        );
+
+        expect(screen.getByLabelText('Remove resource folder D:/StableDiffusion/models')).toBeTruthy();
+    });
+
+    it('disables resource folder removal while discovery work is active', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                resourceFolders={['D:/StableDiffusion/models']}
+                isScanning
+            />
+        );
+
+        expect(
+            screen.getByLabelText('Remove resource folder D:/StableDiffusion/models').hasAttribute('disabled')
+        ).toBe(true);
+    });
+
+    it('disables all discovery controls and identifies the folder being removed', () => {
+        render(
+            <ResourceDiscoverySection
+                {...defaultProps}
+                resourceFolders={['D:/StableDiffusion/models', 'D:/StableDiffusion/models/Lora']}
+                removingResourcePath="D:/StableDiffusion/models"
+                newResourcePath="D:/StableDiffusion/models/checkpoints"
+            />
+        );
+
+        expect(screen.getByRole('button', { name: 'Scan Now' }).hasAttribute('disabled')).toBe(true);
+        expect(screen.getByPlaceholderText('e.g. D:/StableDiffusion/models/Lora').hasAttribute('disabled')).toBe(true);
+        expect(screen.getByRole('button', { name: 'Browse for resource folder' }).hasAttribute('disabled')).toBe(true);
+        expect(screen.getByRole('button', { name: 'Add Path' }).hasAttribute('disabled')).toBe(true);
+        expect(screen.getByLabelText('Removing resource folder D:/StableDiffusion/models').hasAttribute('disabled')).toBe(true);
+        expect(screen.getByLabelText('Remove resource folder D:/StableDiffusion/models/Lora').hasAttribute('disabled')).toBe(true);
+    });
+});

--- a/src/features/settings/hooks/__tests__/useResourcesTabLogic.test.tsx
+++ b/src/features/settings/hooks/__tests__/useResourcesTabLogic.test.tsx
@@ -47,6 +47,7 @@ vi.mock('../../../../bindings', () => ({
     commands: {
         resolveHashesOnline: vi.fn(),
         cancelModelResolution: vi.fn().mockResolvedValue(undefined),
+        purgeResourceFolderAssets: vi.fn(),
     },
 }));
 
@@ -107,6 +108,14 @@ const finishResourceScanTimer = async (promise: Promise<void>) => {
     await promise;
 };
 
+const createDeferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>(promiseResolve => {
+        resolve = promiseResolve;
+    });
+    return { promise, resolve };
+};
+
 describe('useResourcesTabLogic', () => {
     beforeEach(() => {
         vi.clearAllMocks();
@@ -115,6 +124,16 @@ describe('useResourcesTabLogic', () => {
         refreshFacetCacheForResourcesStrictMock.mockResolvedValue(2);
         rebuildFacetCacheIncrementalMock.mockResolvedValue(2);
         vi.mocked(commands.resolveHashesOnline).mockResolvedValue({ status: 'ok', data: resolutionResult });
+        vi.mocked(commands.purgeResourceFolderAssets).mockResolvedValue({
+            status: 'ok',
+            data: {
+                removedModels: 0,
+                preservedModels: 0,
+                removedScannedFiles: 0,
+                refreshedFacets: 0,
+                resources: emptyResources
+            }
+        });
         libraryContextState.isResolvingModels = false;
         libraryContextState.modelResolutionProgress = null;
         libraryContextState.lastModelResolutionResult = null;
@@ -245,6 +264,135 @@ describe('useResourcesTabLogic', () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+
+    it('purges only assets not covered by remaining resource folders before removing the path', async () => {
+        const settings = {
+            ...baseSettings,
+            resourceFolders: ['D:/AI/models', 'D:/AI/models/loras'],
+        };
+        vi.mocked(commands.purgeResourceFolderAssets).mockResolvedValueOnce({
+            status: 'ok',
+            data: {
+                removedModels: 2,
+                preservedModels: 1,
+                removedScannedFiles: 2,
+                refreshedFacets: 2,
+                resources: {
+                    ...emptyResources,
+                    checkpoints: ['FalsePositive']
+                }
+            }
+        });
+        const { result, setSettings } = renderResourcesHook(settings);
+
+        await act(async () => {
+            await result.current.handleRemoveResourceFolder('D:/AI/models');
+        });
+
+        expect(commands.purgeResourceFolderAssets).toHaveBeenCalledWith(
+            'D:/AI/models',
+            ['D:/AI/models/loras']
+        );
+        expect(refreshFacetCacheForResourcesStrictMock).not.toHaveBeenCalled();
+        const updateSettings = setSettings.mock.calls[0][0] as (previous: AppSettings) => AppSettings;
+        expect(updateSettings(settings).resourceFolders).toEqual(['D:/AI/models/loras']);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+        expect(addToastMock).toHaveBeenCalledWith(
+            'Removed resource folder: 2 local assets purged, 1 customized asset preserved',
+            'success'
+        );
+    });
+
+    it('keeps the resource folder and facet version unchanged when atomic purge fails', async () => {
+        const settings = {
+            ...baseSettings,
+            resourceFolders: ['D:/AI/models'],
+        };
+        vi.mocked(commands.purgeResourceFolderAssets).mockResolvedValueOnce({
+            status: 'error',
+            error: 'facet refresh failed'
+        });
+        const { result, setSettings } = renderResourcesHook(settings);
+
+        await act(async () => {
+            await result.current.handleRemoveResourceFolder('D:/AI/models');
+        });
+
+        expect(setSettings).not.toHaveBeenCalled();
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(0);
+        expect(result.current.removingResourcePath).toBeNull();
+        expect(addToastMock).toHaveBeenCalledWith('Failed to remove resource folder', 'error');
+    });
+
+    it('serializes resource cleanup and blocks discovery actions until purge completes', async () => {
+        const settings = {
+            ...baseSettings,
+            resourceFolders: ['D:/AI/models', 'D:/AI/models/loras'],
+        };
+        const purge = createDeferred<Awaited<ReturnType<typeof commands.purgeResourceFolderAssets>>>();
+        vi.mocked(commands.purgeResourceFolderAssets).mockReturnValueOnce(purge.promise);
+        const { result, setSettings } = renderResourcesHook(settings);
+
+        act(() => {
+            result.current.setNewResourcePath('D:/AI/models/checkpoints');
+        });
+
+        let removalPromise!: Promise<void>;
+        await act(async () => {
+            removalPromise = result.current.handleRemoveResourceFolder('D:/AI/models');
+            await Promise.resolve();
+        });
+
+        expect(result.current.removingResourcePath).toBe('D:/AI/models');
+
+        await act(async () => {
+            await result.current.handleBrowseResource();
+            await result.current.handleAddResourceFolder({
+                preventDefault: vi.fn(),
+            } as unknown as React.FormEvent);
+            await result.current.handleScanNow();
+            await result.current.handleRemoveResourceFolder('D:/AI/models/loras');
+        });
+
+        expect(openMock).not.toHaveBeenCalled();
+        expect(scanResourceThumbnailsMock).not.toHaveBeenCalled();
+        expect(commands.purgeResourceFolderAssets).toHaveBeenCalledTimes(1);
+        expect(setSettings).not.toHaveBeenCalled();
+
+        await act(async () => {
+            purge.resolve({
+                status: 'ok',
+                data: {
+                    removedModels: 1,
+                    preservedModels: 0,
+                    removedScannedFiles: 1,
+                    refreshedFacets: 1,
+                    resources: emptyResources
+                }
+            });
+            await removalPromise;
+        });
+
+        expect(result.current.removingResourcePath).toBeNull();
+        expect(setSettings).toHaveBeenCalledTimes(1);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+    });
+
+    it('does not start folder removal while resource discovery is busy', async () => {
+        useLibraryStore.setState({ isScanningDiscovery: true });
+        const settings = {
+            ...baseSettings,
+            resourceFolders: ['D:/AI/models'],
+        };
+        const { result, setSettings } = renderResourcesHook(settings);
+
+        await act(async () => {
+            await result.current.handleRemoveResourceFolder('D:/AI/models');
+        });
+
+        expect(commands.purgeResourceFolderAssets).not.toHaveBeenCalled();
+        expect(setSettings).not.toHaveBeenCalled();
     });
 
     it('keeps Resolve Online behind confirmation before calling CivitAI lookup', async () => {

--- a/src/features/settings/hooks/useResourcesTabLogic.ts
+++ b/src/features/settings/hooks/useResourcesTabLogic.ts
@@ -1,12 +1,13 @@
 import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { AppSettings } from '../../../types';
-import { commands, type ThumbnailScanResult } from '../../../bindings';
+import { commands, type ResourcePurgeResult, type ThumbnailScanResult } from '../../../bindings';
 import { useToast } from '../../../hooks/useToast';
 import { useLibraryContext } from '../../../contexts/LibraryContext';
 import { useLibraryStore } from '../../../stores/libraryStore';
 import { scanResourceThumbnails } from '../../../services/importService';
 import { refreshFacetCacheForResourcesStrict, rebuildFacetCacheIncremental } from '../../../services/db/imageRepo';
+import { isBrowserMockMode } from '../../../services/runtime';
 import { normalizePath } from '../../../utils/pathUtils';
 import { unwrap } from '../../../utils/spectaUtils';
 import {
@@ -78,6 +79,20 @@ const formatResourceScanToast = (result: ThumbnailScanResult, indexedRows: numbe
     return `Resource scan complete: ${result.found} ${resourceFileLabel(result)} found${indexedDetail}`;
 };
 
+const formatResourcePurgeToast = (result: ResourcePurgeResult): string => {
+    const details: string[] = [];
+    if (result.removedModels > 0) {
+        details.push(`${result.removedModels} local ${result.removedModels === 1 ? 'asset' : 'assets'} purged`);
+    }
+    if (result.preservedModels > 0) {
+        details.push(`${result.preservedModels} customized ${result.preservedModels === 1 ? 'asset' : 'assets'} preserved`);
+    }
+
+    return details.length > 0
+        ? `Removed resource folder: ${details.join(', ')}`
+        : 'Removed resource folder; no indexed local assets needed cleanup';
+};
+
 const formatResourceIndexMessage = (resources: TouchedFacetResources): string => {
     const keys = touchedResourceKeys(resources);
     if (keys.length === 1) {
@@ -129,8 +144,10 @@ export const useResourcesTabLogic = ({
     const { addToast } = useToast();
     const queryClient = useQueryClient();
     const [newResourcePath, setNewResourcePath] = React.useState('');
+    const [removingResourcePath, setRemovingResourcePath] = React.useState<string | null>(null);
     const [isResolveConfirmOpen, setIsResolveConfirmOpen] = React.useState(false);
     const resourceInputRef = React.useRef<HTMLInputElement>(null);
+    const removingResourcePathRef = React.useRef<string | null>(null);
 
     const {
         isResolvingModels: isResolving,
@@ -207,6 +224,8 @@ export const useResourcesTabLogic = ({
     }, [refreshResourceFacetCache]);
 
     const handleBrowseResource = React.useCallback(async () => {
+        if (removingResourcePathRef.current) return;
+
         try {
             const { open } = await import('@tauri-apps/plugin-dialog');
             const selected = await open({ directory: true, multiple: false });
@@ -220,6 +239,7 @@ export const useResourcesTabLogic = ({
 
     const handleAddResourceFolder = React.useCallback(async (e: React.FormEvent) => {
         e.preventDefault();
+        if (removingResourcePathRef.current) return;
         if (!newResourcePath.trim()) return;
 
         const pathToAdd = normalizePath(newResourcePath.trim());
@@ -263,14 +283,49 @@ export const useResourcesTabLogic = ({
         showResourceScanComplete
     ]);
 
-    const handleRemoveResourceFolder = React.useCallback((path: string) => {
-        setSettings(prev => ({
-            ...prev,
-            resourceFolders: (prev.resourceFolders || []).filter(p => p !== path)
-        }));
-    }, [setSettings]);
+    const handleRemoveResourceFolder = React.useCallback(async (path: string) => {
+        if (isScanningDiscovery || isPopulatingThumbnails || removingResourcePathRef.current) return;
+
+        const normalizedPath = normalizePath(path);
+        const remainingPaths = (settings.resourceFolders || [])
+            .map(normalizePath)
+            .filter(configuredPath => configuredPath !== normalizedPath);
+
+        removingResourcePathRef.current = normalizedPath;
+        setRemovingResourcePath(path);
+
+        try {
+            let purgeResult: ResourcePurgeResult | null = null;
+            if (!isBrowserMockMode()) {
+                purgeResult = await unwrap(commands.purgeResourceFolderAssets(path, remainingPaths));
+                incrementFacetCacheVersion();
+            }
+
+            setSettings(prev => ({
+                ...prev,
+                resourceFolders: (prev.resourceFolders || []).filter(
+                    configuredPath => normalizePath(configuredPath) !== normalizedPath
+                )
+            }));
+            addToast(purgeResult ? formatResourcePurgeToast(purgeResult) : 'Removed resource folder', 'success');
+        } catch (error) {
+            console.error('Failed to remove resource folder', error);
+            addToast('Failed to remove resource folder', 'error');
+        } finally {
+            removingResourcePathRef.current = null;
+            setRemovingResourcePath(null);
+        }
+    }, [
+        addToast,
+        incrementFacetCacheVersion,
+        isPopulatingThumbnails,
+        isScanningDiscovery,
+        setSettings,
+        settings.resourceFolders
+    ]);
 
     const handleScanNow = React.useCallback(async () => {
+        if (removingResourcePathRef.current) return;
         if (!settings.resourceFolders?.length) return;
         setIsScanningDiscovery(true);
         try {
@@ -394,6 +449,7 @@ export const useResourcesTabLogic = ({
         isScanningDiscovery,
         discoveryScanProgress,
         isPopulatingThumbnails,
+        removingResourcePath,
         newResourcePath,
         setNewResourcePath,
         resourceInputRef,

--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -184,6 +184,88 @@ describe('searchRepo getFacets', () => {
         });
     });
 
+    it('keeps thumbnail provenance paired with the thumbnail selected during alias merging', async () => {
+        const db = createFacetDb([
+            {
+                facet_type: 'loras',
+                resource_name: 'Detailer Style',
+                resource_hash: 'used-hash',
+                count: 4,
+                thumbnail_path: null,
+                preview_url: null
+            },
+            {
+                facet_type: 'loras',
+                resource_name: 'detailer_style',
+                resource_hash: 'file:C:/models/detailer_style.safetensors',
+                count: 0,
+                thumbnail_path: 'manual.webp',
+                has_sidecar: 1,
+                is_manual: 1,
+                is_user_override: 1
+            }
+        ], [
+            {
+                resource_type: 'loras',
+                name: 'detailer_style',
+                hash: 'file:C:/models/detailer_style.safetensors'
+            }
+        ]);
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('', [], ['loras'], { assetScope: 'all' });
+
+        expect(facets.loras[0]).toMatchObject({
+            name: 'Detailer Style',
+            thumbnailPath: 'manual.webp',
+            thumbnailSource: 'manual',
+            hasSidecar: 1
+        });
+    });
+
+    it('identifies a selected sidecar separately from sidecar availability', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'loras',
+                    resource_name: 'SidecarSelected',
+                    resource_hash: 'file:C:/models/SidecarSelected.safetensors',
+                    count: 0,
+                    thumbnail_path: 'sidecar.webp',
+                    has_sidecar: 1,
+                    is_manual: 1,
+                    is_user_override: 0
+                },
+                {
+                    facet_type: 'loras',
+                    resource_name: 'LibrarySelected',
+                    resource_hash: 'library-hash',
+                    count: 1,
+                    thumbnail_path: 'library.webp',
+                    thumbnail_image_id: 'image-1',
+                    has_sidecar: 1,
+                    is_manual: 0,
+                    is_user_override: 0
+                }
+            ],
+            [
+                {
+                    resource_type: 'loras',
+                    name: 'SidecarSelected',
+                    hash: 'file:C:/models/SidecarSelected.safetensors'
+                }
+            ]
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('', [], ['loras'], { assetScope: 'all' });
+
+        expect(facets.loras.find(item => item.name === 'SidecarSelected')?.thumbnailSource).toBe('sidecar');
+        expect(facets.loras.find(item => item.name === 'LibrarySelected')?.thumbnailSource).toBe('library');
+    });
+
     it('combines image-used aliases under one local-aware row', async () => {
         const db = createFacetDb(
             [

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -23,6 +23,8 @@ export interface LibraryStatsSummary {
     modelStats: { name: string; fullName: string; count: number }[];
 }
 
+export type ResourceThumbnailSource = 'manual' | 'sidecar' | 'library' | 'remote';
+
 export interface FacetItem {
     name: string;
     count: number;
@@ -39,6 +41,7 @@ export interface FacetItem {
     thumbnailImageId?: string;
     thumbnailIsSensitive?: number;
     thumbnailSensitivityOverride?: number | null;
+    thumbnailSource?: ResourceThumbnailSource;
     isLocalDisk?: boolean;
     assetMatchKey?: string;
     filterAliases?: string[];
@@ -166,18 +169,33 @@ const minOptionalNumber = (a: number | undefined, b: number | undefined): number
     return Math.min(a, b);
 };
 
-const copyFallbackFacetFields = (target: FacetItem, source: FacetItem): FacetItem => ({
-    ...target,
-    thumbnailPath: target.thumbnailPath || source.thumbnailPath,
-    previewUrl: target.previewUrl || source.previewUrl,
-    safeThumbnailPath: target.safeThumbnailPath || source.safeThumbnailPath,
-    thumbnailImageId: target.thumbnailImageId || source.thumbnailImageId,
-    thumbnailIsSensitive: target.thumbnailIsSensitive ?? source.thumbnailIsSensitive,
-    thumbnailSensitivityOverride: target.thumbnailSensitivityOverride ?? source.thumbnailSensitivityOverride,
-    isManual: Math.max(target.isManual ?? 0, source.isManual ?? 0),
-    hasSidecar: Math.max(target.hasSidecar ?? 0, source.hasSidecar ?? 0),
-    isUserOverride: Math.max(target.isUserOverride ?? 0, source.isUserOverride ?? 0),
-});
+const getThumbnailSource = (row: FacetCacheRow): ResourceThumbnailSource | undefined => {
+    if (row.thumbnail_path) {
+        if (row.is_user_override === 1) return 'manual';
+        if (row.has_sidecar === 1 && row.is_manual === 1) return 'sidecar';
+        if (row.thumbnail_image_id) return 'library';
+        if (row.preview_url && row.thumbnail_path === row.preview_url) return 'remote';
+        return 'library';
+    }
+    return row.preview_url ? 'remote' : undefined;
+};
+
+const copyFallbackFacetFields = (target: FacetItem, source: FacetItem): FacetItem => {
+    const thumbnailOwner = target.thumbnailPath ? target : source;
+    return {
+        ...target,
+        thumbnailPath: target.thumbnailPath || source.thumbnailPath,
+        previewUrl: target.previewUrl || source.previewUrl,
+        safeThumbnailPath: thumbnailOwner.safeThumbnailPath,
+        thumbnailImageId: thumbnailOwner.thumbnailImageId,
+        thumbnailIsSensitive: thumbnailOwner.thumbnailIsSensitive,
+        thumbnailSource: thumbnailOwner.thumbnailSource,
+        thumbnailSensitivityOverride: target.thumbnailSensitivityOverride ?? source.thumbnailSensitivityOverride,
+        isManual: Math.max(target.isManual ?? 0, source.isManual ?? 0),
+        hasSidecar: Math.max(target.hasSidecar ?? 0, source.hasSidecar ?? 0),
+        isUserOverride: Math.max(target.isUserOverride ?? 0, source.isUserOverride ?? 0),
+    };
+};
 
 const mergeFacetItem = (group: FacetMergeGroup, candidate: FacetItem): void => {
     group.usedAliases.add(candidate.name);
@@ -1088,6 +1106,7 @@ export const getFacets = async (
                 thumbnailImageId: row.thumbnail_image_id ?? undefined,
                 thumbnailIsSensitive: row.thumbnail_is_sensitive ?? undefined,
                 thumbnailSensitivityOverride: row.thumbnail_sensitivity_override,
+                thumbnailSource: getThumbnailSource(row),
                 isLocalDisk,
                 assetMatchKey
             };


### PR DESCRIPTION
## Summary

- clean up disk-discovered assets when a resource folder is removed while preserving user thumbnail and privacy customization
- keep overlapping configured roots safe and refresh affected facets atomically
- tighten sidecar provenance and replace local/unused text tags with accessible icon indicators
- serialize folder cleanup and warn about overly broad `models` roots

## Root Cause

Resource discovery indexed every supported model under configured roots, but removing an overly broad root only changed settings. Indexed disk rows and facet state remained, and sidecar metadata could be associated or described too broadly.

## Validation

- focused frontend tests: 61 passed
- `pnpm run typecheck`
- `pnpm run bindings:check`
- `pnpm run test:rust`: 188 passed, 1 ignored
- Build Web Apps Browser validation of Resources settings and console health
