### PR TITLE
ci: extend release build timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         platform: [windows-latest]
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 


### PR DESCRIPTION
## Summary

Increase the Windows release job timeout from 60 to 90 minutes.

## Why

The `v0.6.0` release completed its dependency audits, full release gate, updater signing verification, Tauri build, signing, and asset upload in roughly 58 minutes. GitHub then terminated the job at the 60-minute limit during the Rust cache post-step, leaving a false-red workflow despite a complete release.

A 90-minute timeout preserves a finite failure bound while giving cold Windows builds and cache cleanup reasonable margin.

## Verification

- `actionlint` 1.7.12, with the downloaded binary verified against its official SHA-256 checksum
- `git diff --check`
- confirmed `v0.6.0` contains the NSIS and MSI installers, both updater signatures, and `latest.json`
- confirmed the updater manifest reports version `0.6.0`, points to the correct tag assets, and embeds signatures matching the uploaded `.sig` files

## Release note

The existing `v0.6.0` artifacts are complete and should be retained. This change prevents the same post-build timeout on future releases; it does not rebuild or modify `v0.6.0`.