### PR TITLE
fix: clarify startup background activity

### DIFF
--- a/src-tauri/src/db/reparse.rs
+++ b/src-tauri/src/db/reparse.rs
@@ -31,6 +31,8 @@ impl Default for ReparseState {
 pub struct ReparseProgress {
     pub current: usize,
     pub total: usize,
+    pub updated: usize,
+    pub errors: usize,
     pub phase: String,
     pub message: String,
 }
@@ -86,6 +88,8 @@ pub async fn start_reparse_job(
         let _ = app.emit("refresh-progress", ReparseProgress {
             current: 0,
             total: 0,
+            updated: 0,
+            errors: 0,
             phase: "counting".to_string(),
             message: "Calculating total images...".to_string(),
         });
@@ -159,6 +163,8 @@ pub async fn start_reparse_job(
         let _ = app.emit("refresh-progress", ReparseProgress {
             current: 0,
             total,
+            updated: 0,
+            errors: 0,
             phase: "starting".to_string(),
             message: format!("Found {} images to refresh", total),
         });
@@ -336,6 +342,8 @@ pub async fn start_reparse_job(
                         let _ = app.emit("refresh-progress", ReparseProgress {
                             current: processed,
                             total,
+                            updated,
+                            errors,
                             phase: "processing".to_string(),
                             message: format!("Processed {}/{} (Updated: {}). Timings: Fetch {}ms, Parse {}ms, DB {}ms", 
                                 processed, total, updated, fetch_ms, parse_duration.as_millis(), update_ms),
@@ -459,6 +467,8 @@ pub async fn start_reparse_job(
         let _ = app.emit("refresh-progress", ReparseProgress {
             current: processed,
             total,
+            updated,
+            errors,
             phase: "complete".to_string(),
             message: format!("Completed {} / {} images", processed, total),
         });
@@ -490,4 +500,28 @@ pub async fn start_reparse_job(
 pub fn cancel_reparse_job(state: tauri::State<'_, ReparseState>) {
     log::info!("[Refresh] Cancellation requested");
     state.is_cancelled.store(true, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn progress_payload_serializes_structured_counters() {
+        let payload = ReparseProgress {
+            current: 126_700,
+            total: 288_222,
+            updated: 123_981,
+            errors: 2,
+            phase: "processing".to_string(),
+            message: "Processing metadata".to_string(),
+        };
+
+        let value = serde_json::to_value(payload).expect("serialize progress payload");
+
+        assert_eq!(value["current"], 126_700);
+        assert_eq!(value["total"], 288_222);
+        assert_eq!(value["updated"], 123_981);
+        assert_eq!(value["errors"], 2);
+    }
 }

--- a/src/components/StartupMaintenanceGate.tsx
+++ b/src/components/StartupMaintenanceGate.tsx
@@ -18,6 +18,18 @@ const nextFrame = () => new Promise<void>((resolve) => {
     window.requestAnimationFrame(() => resolve());
 });
 
+const dismissStaticLoader = () => {
+    const loader = document.getElementById('static-loading');
+    if (!loader) return;
+
+    loader.style.opacity = '0';
+    loader.style.pointerEvents = 'none';
+
+    window.setTimeout(() => {
+        loader.remove();
+    }, 500);
+};
+
 export const StartupMaintenanceGate: React.FC<StartupMaintenanceGateProps> = ({ children }) => {
     const [phase, setPhase] = React.useState<StartupDbPhase>('Preparing library database');
     const [isReady, setIsReady] = React.useState(isBrowserMockMode());
@@ -31,6 +43,7 @@ export const StartupMaintenanceGate: React.FC<StartupMaintenanceGateProps> = ({ 
         const prepareDatabase = async () => {
             try {
                 setPhase('Preparing library database');
+                dismissStaticLoader();
                 await nextFrame();
                 await getDb({
                     onPhase: (nextPhase) => {

--- a/src/components/StartupMaintenanceGate.tsx
+++ b/src/components/StartupMaintenanceGate.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { AlertCircle, Database, Loader2 } from 'lucide-react';
+import { getDb, type StartupDbPhase } from '../services/db/connection';
+import { isBrowserMockMode } from '../services/runtime';
+
+interface StartupMaintenanceGateProps {
+    children: React.ReactNode;
+}
+
+const STARTUP_PHASE_COPY: Record<StartupDbPhase, string> = {
+    'Preparing library database': 'Checking the local library database before Ambit opens.',
+    'Updating database schema': 'Updating library database. Startup may take longer than usual this time.',
+    'Optimizing database': 'Optimizing the local database for large libraries.',
+    'Loading library': 'Loading your library.'
+};
+
+const nextFrame = () => new Promise<void>((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+});
+
+export const StartupMaintenanceGate: React.FC<StartupMaintenanceGateProps> = ({ children }) => {
+    const [phase, setPhase] = React.useState<StartupDbPhase>('Preparing library database');
+    const [isReady, setIsReady] = React.useState(isBrowserMockMode());
+    const [error, setError] = React.useState<string | null>(null);
+
+    React.useEffect(() => {
+        if (isReady) return;
+
+        let isMounted = true;
+
+        const prepareDatabase = async () => {
+            try {
+                setPhase('Preparing library database');
+                await nextFrame();
+                await getDb({
+                    onPhase: (nextPhase) => {
+                        if (isMounted) setPhase(nextPhase);
+                    }
+                });
+                if (isMounted) setIsReady(true);
+            } catch (err) {
+                console.error('[Startup] Failed to prepare database', err);
+                if (isMounted) {
+                    setError(err instanceof Error ? err.message : String(err));
+                }
+            }
+        };
+
+        void prepareDatabase();
+
+        return () => {
+            isMounted = false;
+        };
+    }, [isReady]);
+
+    if (isReady) {
+        return <>{children}</>;
+    }
+
+    return (
+        <main className="min-h-screen bg-zinc-950 text-white flex items-center justify-center p-6">
+            <section className="w-full max-w-md rounded-3xl border border-white/10 bg-zinc-900/80 p-8 shadow-2xl backdrop-blur-xl">
+                <div className="flex items-center gap-4">
+                    <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-sage-500/10 text-sage-300">
+                        {error ? <AlertCircle className="h-6 w-6" /> : <Database className="h-6 w-6" />}
+                    </div>
+                    <div className="min-w-0">
+                        <p className="text-xs font-black uppercase tracking-[0.22em] text-gray-500">
+                            Startup Maintenance
+                        </p>
+                        <h1 className="mt-1 text-xl font-black tracking-tight">
+                            {error ? 'Database startup failed' : phase}
+                        </h1>
+                    </div>
+                </div>
+
+                <p className="mt-6 text-sm leading-6 text-gray-300">
+                    {error
+                        ? 'Ambit could not prepare the local library database. Restart the app and contact support if this repeats.'
+                        : STARTUP_PHASE_COPY[phase]}
+                </p>
+
+                {error ? (
+                    <pre className="mt-4 max-h-32 overflow-auto rounded-xl bg-black/30 p-3 text-xs text-red-200">
+                        {error}
+                    </pre>
+                ) : (
+                    <div className="mt-6 flex items-center gap-3 text-sm font-semibold text-sage-300">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        <span>Please keep Ambit open.</span>
+                    </div>
+                )}
+            </section>
+        </main>
+    );
+};

--- a/src/components/__tests__/StartupMaintenanceGate.test.tsx
+++ b/src/components/__tests__/StartupMaintenanceGate.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor } from '../../test/testUtils';
 import { StartupMaintenanceGate } from '../StartupMaintenanceGate';
 import { getDb } from '../../services/db/connection';
@@ -23,6 +23,10 @@ describe('StartupMaintenanceGate', () => {
         vi.clearAllMocks();
         vi.mocked(isBrowserMockMode).mockReturnValue(false);
         vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+    });
+
+    afterEach(() => {
+        document.getElementById('static-loading')?.remove();
     });
 
     it('shows database maintenance before mounting the app', async () => {
@@ -52,6 +56,25 @@ describe('StartupMaintenanceGate', () => {
         await waitFor(() => {
             expect(screen.getByText('Library ready')).toBeTruthy();
         });
+    });
+
+    it('dismisses the static preloader so startup maintenance is visible', async () => {
+        const staticLoader = document.createElement('div');
+        staticLoader.id = 'static-loading';
+        document.body.appendChild(staticLoader);
+        vi.mocked(getDb).mockImplementation(() => new Promise(() => undefined));
+
+        render(
+            <StartupMaintenanceGate>
+                <div>Library ready</div>
+            </StartupMaintenanceGate>
+        );
+
+        await waitFor(() => {
+            expect(staticLoader.style.opacity).toBe('0');
+            expect(staticLoader.style.pointerEvents).toBe('none');
+        });
+        expect(screen.getByText('Startup Maintenance')).toBeTruthy();
     });
 
     it('skips database preparation in browser mock mode', () => {

--- a/src/components/__tests__/StartupMaintenanceGate.test.tsx
+++ b/src/components/__tests__/StartupMaintenanceGate.test.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '../../test/testUtils';
+import { StartupMaintenanceGate } from '../StartupMaintenanceGate';
+import { getDb } from '../../services/db/connection';
+import { isBrowserMockMode } from '../../services/runtime';
+
+vi.mock('../../services/db/connection', () => ({
+    getDb: vi.fn()
+}));
+
+vi.mock('../../services/runtime', () => ({
+    isBrowserMockMode: vi.fn()
+}));
+
+const requestAnimationFrameMock = (callback: FrameRequestCallback) => {
+    callback(0);
+    return 1;
+};
+
+describe('StartupMaintenanceGate', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(isBrowserMockMode).mockReturnValue(false);
+        vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+    });
+
+    it('shows database maintenance before mounting the app', async () => {
+        let resolveDb!: () => void;
+        vi.mocked(getDb).mockImplementation(({ onPhase } = {}) => new Promise((resolve) => {
+            onPhase?.('Updating database schema');
+            resolveDb = () => resolve({} as Awaited<ReturnType<typeof getDb>>);
+        }));
+
+        render(
+            <StartupMaintenanceGate>
+                <div>Library ready</div>
+            </StartupMaintenanceGate>
+        );
+
+        expect(screen.getByText('Startup Maintenance')).toBeTruthy();
+        expect(screen.getByText('Preparing library database')).toBeTruthy();
+        expect(screen.queryByText('Library ready')).toBeNull();
+
+        await waitFor(() => {
+            expect(screen.getByText('Updating database schema')).toBeTruthy();
+            expect(screen.getByText('Updating library database. Startup may take longer than usual this time.')).toBeTruthy();
+        });
+
+        resolveDb();
+
+        await waitFor(() => {
+            expect(screen.getByText('Library ready')).toBeTruthy();
+        });
+    });
+
+    it('skips database preparation in browser mock mode', () => {
+        vi.mocked(isBrowserMockMode).mockReturnValue(true);
+
+        render(
+            <StartupMaintenanceGate>
+                <div>Browser mock app</div>
+            </StartupMaintenanceGate>
+        );
+
+        expect(screen.getByText('Browser mock app')).toBeTruthy();
+        expect(vi.mocked(getDb)).not.toHaveBeenCalled();
+    });
+
+    it('shows an actionable error when database preparation fails', async () => {
+        vi.mocked(getDb).mockRejectedValue(new Error('migration failed'));
+
+        render(
+            <StartupMaintenanceGate>
+                <div>Library ready</div>
+            </StartupMaintenanceGate>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Database startup failed')).toBeTruthy();
+            expect(screen.getByText('Ambit could not prepare the local library database. Restart the app and contact support if this repeats.')).toBeTruthy();
+            expect(screen.getByText('migration failed')).toBeTruthy();
+        });
+        expect(screen.queryByText('Library ready')).toBeNull();
+    });
+});

--- a/src/components/ui/ActivityDock.tsx
+++ b/src/components/ui/ActivityDock.tsx
@@ -51,6 +51,29 @@ const splitDetailItems = (detail?: string): string[] => (
         : []
 );
 
+const formatProgressNumber = (value: number): string => value.toLocaleString();
+
+const formatMetadataRefreshMessage = (progress: SyncProgress | null, percent: number): string => {
+    if (!progress || progress.total <= 0) {
+        return progress?.message || progress?.phase || 'Preparing metadata refresh...';
+    }
+
+    const pieces = [
+        `${formatProgressNumber(progress.current)} / ${formatProgressNumber(progress.total)} images`,
+        `${percent}%`
+    ];
+
+    if (typeof progress.updated === 'number') {
+        pieces.push(`${formatProgressNumber(progress.updated)} updated`);
+    }
+
+    if (typeof progress.errors === 'number' && progress.errors > 0) {
+        pieces.push(`${formatProgressNumber(progress.errors)} errors`);
+    }
+
+    return pieces.join(' | ');
+};
+
 const getLiveWatchSourceLabel = (source: LiveWatchSessionSource | null): LiveWatchPresentation['sourceLabel'] => {
     if (source === 'invoke') return 'InvokeAI';
     if (source === 'generic') return 'Folders';
@@ -242,7 +265,7 @@ export const ActivityDock: React.FC = () => {
         footerMessage = THUMBNAIL_QUEUE_RUNNING_FOOTER;
     } else if (isRefreshActive) {
         progress = refreshProgress;
-        label = "Refreshing Metadata";
+        label = "Metadata Refresh";
         isLowPriority = false;
         supportsCancel = true;
     } else if (isLiveWatchVisible) {
@@ -279,11 +302,13 @@ export const ActivityDock: React.FC = () => {
         return () => window.clearInterval(interval);
     }, [active, progress?.startedAt, showIndeterminateProgress]);
 
+    const percent = isLiveWatchVisible ? 0 : isCompleteProgress ? 100 : total > 0 ? Math.round((current / total) * 100) : 0;
     const message = isLiveWatchVisible
         ? liveWatchPresentation.message
-        : (progress?.message || progress?.phase || '');
-    const percent = isLiveWatchVisible ? 0 : isCompleteProgress ? 100 : total > 0 ? Math.round((current / total) * 100) : 0;
-    const showCounts = total > 0 && !isLiveWatchVisible && !isBackgroundActive && !showIndeterminateProgress && !isCompleteProgress;
+        : isRefreshActive
+            ? formatMetadataRefreshMessage(progress, percent)
+            : (progress?.message || progress?.phase || '');
+    const showCounts = total > 0 && !isLiveWatchVisible && !isBackgroundActive && !isRefreshActive && !showIndeterminateProgress && !isCompleteProgress;
     const smartThumbnailHasFailures = isBackgroundActive && message.includes('need attention');
     const smartThumbnailIsComplete = isBackgroundActive && total > 0 && current >= total;
     const visibleFooterMessage = smartThumbnailHasFailures
@@ -376,7 +401,7 @@ export const ActivityDock: React.FC = () => {
                                     </motion.div>
                                     <motion.div layout="position">
                                         <h4 className="text-[10px] font-black uppercase tracking-widest text-gray-500 italic opacity-80 leading-none mb-1">{isLiveWatchVisible ? 'Live Watch' : 'Background Activity'}</h4>
-                                        <p className="text-sm font-bold text-gray-900 dark:text-white flex items-center gap-2">
+                                        <p className="text-sm font-bold text-gray-900 dark:text-white flex min-w-0 items-center gap-2 whitespace-nowrap">
                                             {isLiveWatchVisible ? (
                                                 liveWatchPresentation.sourceLabel && (
                                                     <span className={LIVE_WATCH_SOURCE_CHIP_CLASS}>
@@ -438,7 +463,7 @@ export const ActivityDock: React.FC = () => {
                                     <p className="text-[11px] font-medium text-gray-500 dark:text-gray-400 truncate flex-1 pr-4 h-4 leading-4">
                                         {message || "Starting work..."}
                                     </p>
-                                    {!showIndeterminateProgress && !isLiveWatchActive && !isBackgroundActive && !isCompleteProgress && (
+                                    {!showIndeterminateProgress && !isLiveWatchActive && !isBackgroundActive && !isRefreshActive && !isCompleteProgress && (
                                         <span className={`text-[11px] font-black font-mono italic ${accentClasses.percentText}`}>
                                             {percent}%
                                         </span>

--- a/src/components/ui/__tests__/ActivityDock.test.tsx
+++ b/src/components/ui/__tests__/ActivityDock.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen } from '../../../test/testUtils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ActivityDock } from '../ActivityDock';
 import { createInitialLiveWatchSessionState, useLibraryStore } from '../../../stores/libraryStore';
+import { invoke } from '@tauri-apps/api/core';
 
 vi.mock('framer-motion', () => ({
     AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -225,6 +226,34 @@ describe('ActivityDock', () => {
 
         expect(screen.getByText('Optimized 338 thumbnails; 2 need attention')).toBeTruthy();
         expect(screen.getByText('Some files may be corrupt or unavailable.')).toBeTruthy();
+    });
+
+    it('renders metadata refresh progress without duplicate count chrome and can cancel', () => {
+        vi.mocked(invoke).mockResolvedValue(undefined);
+        useLibraryStore.setState({
+            isRefreshingMetadata: true,
+            refreshProgress: {
+                current: 126700,
+                total: 288222,
+                updated: 123981,
+                errors: 0,
+                phase: 'processing',
+                message: 'Processed 126700/288222 (Updated: 123981). Timings: Fetch 54ms'
+            }
+        });
+
+        render(<ActivityDock />);
+
+        expect(screen.getByText('Metadata Refresh')).toBeTruthy();
+        expect(screen.getByText('126,700 / 288,222 images | 44% | 123,981 updated')).toBeTruthy();
+        expect(screen.queryByText('Refreshing Metadata')).toBeNull();
+        expect(screen.queryByText('126,700 / 288,222')).toBeNull();
+        expect(screen.queryByText(/Processed 126700/)).toBeNull();
+        expect(screen.queryByText('44%')).toBeNull();
+
+        fireEvent.click(screen.getByText('Cancel'));
+
+        expect(invoke).toHaveBeenCalledWith('cancel_reparse_job');
     });
 
     it('renders indeterminate discovery progress without a misleading percentage', () => {

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -188,6 +188,15 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             mode: 'manual' as const,
             ...optionsInput
         };
+        const isStartupMode = options.mode === 'startup';
+        let startupSyncVisible = false;
+        const setVisibleStartupProgress = (progress: NonNullable<typeof syncProgress>) => {
+            if (!startupSyncVisible) {
+                startupSyncVisible = true;
+                setSyncStatus('syncing');
+            }
+            setSyncProgress(progress);
+        };
         const syncStartedAt = liveWatchNow();
         const livePerfContext = options.mode === 'live' ? options.perfContext : undefined;
         let liveTotalProcessed = 0;
@@ -276,8 +285,10 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 watcherToSyncStartMs: livePerfContext ? elapsedMs(livePerfContext.firstEventAt) : undefined
             });
         } else {
-            setSyncStatus('syncing');
-            setSyncProgress({ current: 0, total: 0, message: options.mode === 'startup' ? 'Catching up InvokeAI DB...' : 'Preparing...' });
+            if (!isStartupMode) {
+                setSyncStatus('syncing');
+                setSyncProgress({ current: 0, total: 0, message: 'Preparing...' });
+            }
         }
 
         const ctrl = new AbortController();
@@ -323,7 +334,13 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                             progress: { current: c, total: t, message: undefined }
                         });
                     } else {
-                        setSyncProgress({ current: c, total: t, message: msg });
+                        if (isStartupMode) {
+                            if (t > 0) {
+                                setVisibleStartupProgress({ current: c, total: t, message: msg });
+                            }
+                        } else {
+                            setSyncProgress({ current: c, total: t, message: msg });
+                        }
                     }
                 },
                 ctrl.signal,
@@ -342,7 +359,12 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             // Sync Boards to Collections
             if (settingsRef.current.syncBoardsToCollections && boardMapping && boardMapping.size > 0) {
                 if (options.mode !== 'live') {
-                    setSyncProgress({ ...useLibraryStore.getState().syncProgress, message: 'Synchronizing boards...' });
+                    const nextProgress = { ...useLibraryStore.getState().syncProgress, message: 'Synchronizing boards...' };
+                    if (isStartupMode) {
+                        setVisibleStartupProgress(nextProgress);
+                    } else {
+                        setSyncProgress(nextProgress);
+                    }
                 }
                 setCollections(prev => {
                     const next = [...prev];
@@ -384,7 +406,9 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                 );
             }
 
-            setSyncStatus('complete');
+            if (!isStartupMode || startupSyncVisible) {
+                setSyncStatus('complete');
+            }
             const totalProcessed = (imported || 0) + (updated || 0) + orphansImported;
             liveTotalProcessed = totalProcessed;
             // Conditional Facet Rebuild
@@ -437,7 +461,11 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                     }
                 } else {
                     // MANUAL HEAVY REBUILD
-                    setSyncProgress({ current: totalProcessed, total: totalProcessed, message: 'Updating gallery...' });
+                    if (isStartupMode) {
+                        setVisibleStartupProgress({ current: totalProcessed, total: totalProcessed, message: 'Updating gallery...' });
+                    } else {
+                        setSyncProgress({ current: totalProcessed, total: totalProcessed, message: 'Updating gallery...' });
+                    }
 
                     // IMMEDIATE UI REFRESH (Block here until data hits RAM)
                     await queryClient.refetchQueries({ queryKey: ['images'] });
@@ -447,11 +475,16 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         setSettings(prev => ({ ...prev, lastSyncedAt: newTs }));
                     }
 
-                    setSyncProgress({
+                    const cacheProgress = {
                         current: totalProcessed,
                         total: totalProcessed,
                         message: options.mode === 'startup' ? 'Updating startup filters...' : 'Rebuilding filter cache...'
-                    });
+                    };
+                    if (isStartupMode) {
+                        setVisibleStartupProgress(cacheProgress);
+                    } else {
+                        setSyncProgress(cacheProgress);
+                    }
 
                     try {
                         if (options.mode === 'startup') {
@@ -473,7 +506,12 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         return; // Halt completion if critical DB error
                     }
 
-                    setSyncProgress({ ...useLibraryStore.getState().syncProgress, message: undefined });
+                    const clearedMessageProgress = { ...useLibraryStore.getState().syncProgress, message: undefined };
+                    if (isStartupMode && startupSyncVisible) {
+                        setSyncProgress(clearedMessageProgress);
+                    } else if (!isStartupMode) {
+                        setSyncProgress(clearedMessageProgress);
+                    }
 
                     // Trigger complete routines
                     if (totalProcessed > 0 && (options.mode === 'manual' || options.mode === 'startup')) {
@@ -486,7 +524,9 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
                         if (shouldRefreshBoardCollectionThumbnails) {
                             await refreshCollections();
                         }
-                        setSyncStatus('complete');
+                        if (startupSyncVisible) {
+                            setSyncStatus('complete');
+                        }
                     }
 
                     if (shouldRefreshBoardCollectionThumbnails) {
@@ -553,6 +593,10 @@ export const SyncProvider: React.FC<{ children: ReactNode; onSyncComplete?: (sco
             }
         } finally {
             setSyncAbortController(null);
+            if (isStartupMode && !startupSyncVisible) {
+                setSyncStatus('idle');
+                setSyncProgress({ current: 0, total: 0, message: undefined });
+            }
             if (options.mode === 'live') {
                 infoLiveWatchPerf('Invoke live cycle complete', {
                     cycleId: livePerfContext?.cycleId,

--- a/src/contexts/__tests__/LibraryIntegration.test.tsx
+++ b/src/contexts/__tests__/LibraryIntegration.test.tsx
@@ -673,6 +673,8 @@ describe('Library Integration (Provider Stack)', () => {
         expect(mocks.searchImages).not.toHaveBeenCalled();
         expect(mocks.getFacets).not.toHaveBeenCalled();
         expect(mocks.scanForOrphans).not.toHaveBeenCalled();
+        expect(useLibraryStore.getState().syncStatus).toBe('idle');
+        expect(useLibraryStore.getState().syncProgress.message).toBeUndefined();
         expect(mocks.appRepository.save).toHaveBeenCalledWith(expect.objectContaining({
             settings: expect.objectContaining({
                 invokeDbSnapshot: expect.objectContaining({
@@ -800,6 +802,8 @@ describe('Library Integration (Provider Stack)', () => {
         expect(mocks.refreshFacetCacheForResourcesStrict).toHaveBeenCalledWith(touchedFacetResources);
         expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();
         expect(mocks.rebuildFacetCacheStrict).not.toHaveBeenCalled();
+        expect(useLibraryStore.getState().syncStatus).toBe('complete');
+        expect(useLibraryStore.getState().syncProgress.total).toBe(2);
         expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
     });
 

--- a/src/features/library/components/__tests__/VirtualGrid.test.tsx
+++ b/src/features/library/components/__tests__/VirtualGrid.test.tsx
@@ -215,7 +215,10 @@ describe('VirtualGrid gallery motion', () => {
             />
         );
 
-        await waitFor(() => expect(screen.getByTestId('grid-item-item-5').style.transform).toContain('100px, 100px'));
+        await waitFor(() => {
+            expect(screen.getByTestId('grid-item-item-5').style.transform).toContain('100px, 100px');
+            expect(onLayoutChange).toHaveBeenLastCalledWith(4, 100);
+        });
         const callsAfterInitialLayout = onLayoutChange.mock.calls.length;
 
         rerender(

--- a/src/hooks/__tests__/useMetadataRefresh.test.tsx
+++ b/src/hooks/__tests__/useMetadataRefresh.test.tsx
@@ -1,0 +1,273 @@
+import { act, renderHook } from '../../test/testUtils';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { useMetadataRefresh } from '../useMetadataRefresh';
+import { useLibraryStore } from '../../stores/libraryStore';
+
+const { mockAddToast, listenerCallbacks } = vi.hoisted(() => ({
+    mockAddToast: vi.fn(),
+    listenerCallbacks: new Map<string, (event: { payload: unknown }) => void>()
+}));
+
+vi.mock('../useToast', () => ({
+    useToast: () => ({
+        addToast: mockAddToast
+    })
+}));
+
+vi.mock('../../utils/tauriListener', () => ({
+    listenWithCleanup: vi.fn((eventName: string, callback: (event: { payload: unknown }) => void) => {
+        listenerCallbacks.set(eventName, callback);
+        return { cleanup: vi.fn() };
+    })
+}));
+
+describe('useMetadataRefresh', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.useFakeTimers();
+        listenerCallbacks.clear();
+        useLibraryStore.setState({
+            isStartupCatchupPending: false,
+            isMetadataRefreshPending: false,
+            isRefreshingMetadata: false,
+            refreshProgress: null
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('retries automatic startup refresh when the database is temporarily locked', async () => {
+        let startAttempts = 0;
+        vi.mocked(invoke).mockImplementation((command) => {
+            if (command === 'get_reparse_count') {
+                return Promise.resolve(12);
+            }
+            if (command === 'start_reparse_job') {
+                startAttempts += 1;
+                if (startAttempts === 1) {
+                    return Promise.reject('database is locked');
+                }
+                return Promise.resolve({
+                    processed: 12,
+                    updated: 12,
+                    errors: 0,
+                    wasCancelled: false
+                });
+            }
+            return Promise.resolve(undefined);
+        });
+
+        renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(startAttempts).toBe(1);
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            'Parser updated - re-analyzing 12 images in the background',
+            'info'
+        );
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            expect.stringContaining('Failed to start refresh'),
+            'error'
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(15000);
+        });
+
+        expect(startAttempts).toBe(2);
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            expect.stringContaining('Failed to start refresh'),
+            'error'
+        );
+    });
+
+    it('keeps automatic startup refresh pending while startup catch-up is still checking', async () => {
+        vi.mocked(invoke).mockImplementation((command) => {
+            if (command === 'get_reparse_count') {
+                return Promise.resolve(12);
+            }
+            if (command === 'start_reparse_job') {
+                return Promise.resolve({
+                    processed: 12,
+                    updated: 12,
+                    errors: 0,
+                    wasCancelled: false
+                });
+            }
+            return Promise.resolve(undefined);
+        });
+        useLibraryStore.setState({ isStartupCatchupPending: true });
+
+        renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(true);
+        expect(invoke).not.toHaveBeenCalledWith('start_reparse_job', expect.anything());
+
+        act(() => {
+            useLibraryStore.setState({ isStartupCatchupPending: false });
+        });
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(15000);
+        });
+
+        expect(invoke).toHaveBeenCalledWith('start_reparse_job', {
+            forceReparse: false,
+            filterRoot: null,
+            filterTool: null
+        });
+    });
+
+    it('announces automatic startup refresh only after processing starts', async () => {
+        let resolveStart: ((value: unknown) => void) | undefined;
+        vi.mocked(invoke).mockImplementation((command) => {
+            if (command === 'get_reparse_count') {
+                return Promise.resolve(12);
+            }
+            if (command === 'start_reparse_job') {
+                return new Promise(resolve => {
+                    resolveStart = resolve;
+                });
+            }
+            return Promise.resolve(undefined);
+        });
+
+        renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            'Parser updated - re-analyzing 12 images in the background',
+            'info'
+        );
+
+        act(() => {
+            listenerCallbacks.get('refresh-progress')?.({
+                payload: {
+                    current: 0,
+                    total: 12,
+                    updated: 0,
+                    errors: 0,
+                    phase: 'counting',
+                    message: 'Calculating total images...'
+                }
+            });
+        });
+
+        expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(true);
+        expect(useLibraryStore.getState().isRefreshingMetadata).toBe(false);
+        expect(useLibraryStore.getState().refreshProgress).toBeNull();
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            'Parser updated - re-analyzing 12 images in the background',
+            'info'
+        );
+
+        act(() => {
+            listenerCallbacks.get('refresh-progress')?.({
+                payload: {
+                    current: 0,
+                    total: 12,
+                    updated: 0,
+                    errors: 0,
+                    phase: 'starting',
+                    message: 'Found 12 images to refresh'
+                }
+            });
+        });
+
+        expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(true);
+        expect(useLibraryStore.getState().isRefreshingMetadata).toBe(false);
+        expect(useLibraryStore.getState().refreshProgress).toBeNull();
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            'Parser updated - re-analyzing 12 images in the background',
+            'info'
+        );
+
+        act(() => {
+            listenerCallbacks.get('refresh-progress')?.({
+                payload: {
+                    current: 1,
+                    total: 12,
+                    updated: 10,
+                    errors: 0,
+                    phase: 'processing',
+                    message: 'Processed 1/12'
+                }
+            });
+        });
+
+        expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(false);
+        expect(useLibraryStore.getState().isRefreshingMetadata).toBe(true);
+        expect(useLibraryStore.getState().refreshProgress).toEqual(expect.objectContaining({
+            current: 1,
+            phase: 'processing'
+        }));
+        expect(mockAddToast).toHaveBeenCalledWith(
+            'Parser updated - re-analyzing 12 images in the background',
+            'info'
+        );
+
+        await act(async () => {
+            resolveStart?.({
+                processed: 12,
+                updated: 12,
+                errors: 0,
+                wasCancelled: false
+            });
+        });
+    });
+
+    it('clears automatic startup refresh pending state when backend events are missed', async () => {
+        vi.mocked(invoke).mockImplementation((command) => {
+            if (command === 'get_reparse_count') {
+                return Promise.resolve(12);
+            }
+            if (command === 'start_reparse_job') {
+                return Promise.resolve({
+                    processed: 12,
+                    updated: 12,
+                    errors: 0,
+                    wasCancelled: false
+                });
+            }
+            return Promise.resolve(undefined);
+        });
+
+        renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(3000);
+        });
+
+        expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(false);
+        expect(useLibraryStore.getState().isRefreshingMetadata).toBe(false);
+        expect(useLibraryStore.getState().refreshProgress).toBeNull();
+    });
+
+    it('still reports manual refresh failures immediately', async () => {
+        vi.mocked(invoke).mockRejectedValue('database is locked');
+
+        const { result } = renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await result.current.startRefresh();
+        });
+
+        expect(mockAddToast).toHaveBeenCalledWith(
+            'Failed to start refresh: database is locked',
+            'error'
+        );
+    });
+});

--- a/src/hooks/__tests__/useThumbnailQueue.test.ts
+++ b/src/hooks/__tests__/useThumbnailQueue.test.ts
@@ -56,7 +56,6 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).not.toContain('BATCH_DELAY_MS');
         expect(content).not.toContain('getUnoptimizedImageEntries');
         expect(content).not.toContain('getUnoptimizedImagesCount');
-        expect(content).toContain('total: 0');
     });
 
     it('should check settings for enableAutoThumbnailHealing', async () => {
@@ -121,12 +120,33 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).toContain('isScanningDuplicates');
         expect(content).toContain('isScanningMissingFiles');
         expect(content).toContain('isPopulatingThumbnails');
+        expect(content).toContain('isStartupCatchupPending');
+        expect(content).toContain('isMetadataRefreshPending');
         expect(content).toContain('isRefreshingMetadata');
         expect(content).toContain('thumbnailMaintenanceOperation');
         expect(content).toContain('isHardBlocked');
         expect(content).toContain('setThumbnailOptimizationThrottled');
         expect(content).toContain('isImageQueryFetching');
         expect(content).not.toContain("queryClient.isFetching({ queryKey: ['images'] }) > 0");
+    });
+
+    it('should keep startup-only blockers internal instead of showing thumbnail work early', async () => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
+        const content = await fs.readFile(hookPath, 'utf-8');
+
+        const runQueueStart = content.indexOf('const runQueue = useCallback');
+        const runQueueEnd = content.indexOf('const [isStartupDelayComplete', runQueueStart);
+        const runQueueBlock = content.slice(runQueueStart, runQueueEnd);
+        const queueClaim = runQueueBlock.indexOf('isRunningRef.current = true;');
+        const backendStart = runQueueBlock.indexOf('commands.startThumbnailOptimizationJob');
+        const beforeBackendStarts = runQueueBlock.slice(queueClaim, backendStart);
+
+        expect(content).toContain('hasVisibleThumbnailProgress');
+        expect(content).toContain('hasVisibleThumbnailResult');
+        expect(beforeBackendStarts).not.toContain('setBackgroundHealingActive(true)');
+        expect(beforeBackendStarts).not.toContain('THUMBNAIL_QUEUE_START_MESSAGE');
     });
 
     it('should keep image query throttling out of startup scheduling', async () => {

--- a/src/hooks/useFolderMonitor.ts
+++ b/src/hooks/useFolderMonitor.ts
@@ -91,6 +91,7 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
             });
 
             const performStartupScan = async () => {
+                useLibraryStore.getState().setStartupCatchupPending(true);
                 const startupStartedAt = Date.now();
                 const folderScanStartedAt = Date.now();
                 const tasks: { paths: string[], variant: GeneratorTool | undefined, folderId: string }[] = [];
@@ -98,45 +99,46 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                 let startupScanWasCancelled = false;
                 const scanTime = Date.now();
 
-                // Phase 1: Aggregation - Collect all new files from all valid folders
-                for (const folder of activeFolders) {
-                    if (folder.lastScanned) {
-                        try {
-                            console.log(`[FolderMonitor] Smart Scan for ${folder.path}`);
-                            const newFiles = await unwrap(commands.scanDirectorySince(folder.path, folder.lastScanned));
+                try {
+                    // Phase 1: Aggregation - Collect all new files from all valid folders
+                    for (const folder of activeFolders) {
+                        if (folder.lastScanned) {
+                            try {
+                                console.log(`[FolderMonitor] Smart Scan for ${folder.path}`);
+                                const newFiles = await unwrap(commands.scanDirectorySince(folder.path, folder.lastScanned));
 
-                            if (newFiles && newFiles.length > 0) {
-                                console.log(`[FolderMonitor] Found ${newFiles.length} new files in ${folder.path}`);
-                                const paths = newFiles.map(f => f.path);
-                                tasks.push({ paths, variant: folder.variant, folderId: folder.id });
-                                totalFilesFound += paths.length;
-                            } else {
-                                console.log(`[FolderMonitor] No new files in ${folder.path}`);
-                                updateFolderLastScanned(folder.id, scanTime); // Safe to update if nothing found
+                                if (newFiles && newFiles.length > 0) {
+                                    console.log(`[FolderMonitor] Found ${newFiles.length} new files in ${folder.path}`);
+                                    const paths = newFiles.map(f => f.path);
+                                    tasks.push({ paths, variant: folder.variant, folderId: folder.id });
+                                    totalFilesFound += paths.length;
+                                } else {
+                                    console.log(`[FolderMonitor] No new files in ${folder.path}`);
+                                    updateFolderLastScanned(folder.id, scanTime); // Safe to update if nothing found
+                                }
+                            } catch (e) {
+                                console.error(`[FolderMonitor] Smart scan failed for ${folder.path}, falling back to full scan`, e);
                             }
-                        } catch (e) {
-                            console.error(`[FolderMonitor] Smart scan failed for ${folder.path}, falling back to full scan`, e);
-                        }
-                    } else {
-                        // Full scan usage (rare on startup if already configured)
-                        console.log(`[FolderMonitor] Full Scan for ${folder.path} (first time)`);
-                        const result = await onScan([{ path: folder.path, variant: folder.variant }], { mode: 'startup' });
-                        if (isImportSourceCompleted(result, folder.path)) {
-                            updateFolderLastScanned(folder.id, scanTime);
-                        } else if (isImportSourceCancelled(result, folder.path)) {
-                            markInitialScanCancelled([folder.id]);
-                            startupScanWasCancelled = true;
-                            break;
                         } else {
-                            warnCursorHeld('Startup full scan', folder.id, result);
+                            // Full scan usage (rare on startup if already configured)
+                            console.log(`[FolderMonitor] Full Scan for ${folder.path} (first time)`);
+                            const result = await onScan([{ path: folder.path, variant: folder.variant }], { mode: 'startup' });
+                            if (isImportSourceCompleted(result, folder.path)) {
+                                updateFolderLastScanned(folder.id, scanTime);
+                            } else if (isImportSourceCancelled(result, folder.path)) {
+                                markInitialScanCancelled([folder.id]);
+                                startupScanWasCancelled = true;
+                                break;
+                            } else {
+                                warnCursorHeld('Startup full scan', folder.id, result);
+                            }
                         }
                     }
-                }
-                console.info('[Startup Catch-up] Folder scan phase complete.', {
-                    activeFolders: activeFolders.length,
-                    filesFound: totalFilesFound,
-                    durationMs: Date.now() - folderScanStartedAt
-                });
+                    console.info('[Startup Catch-up] Folder scan phase complete.', {
+                        activeFolders: activeFolders.length,
+                        filesFound: totalFilesFound,
+                        durationMs: Date.now() - folderScanStartedAt
+                    });
 
                 // Phase 2: Execution - Run single unified batch for smart updates
                 if (!startupScanWasCancelled && totalFilesFound > 0) {
@@ -265,9 +267,12 @@ export function useFolderMonitor({ isLoaded, monitoredFolders, onScan, handleImp
                     });
                 }
 
-                console.info('[Startup Catch-up] Complete.', {
-                    durationMs: Date.now() - startupStartedAt
-                });
+                    console.info('[Startup Catch-up] Complete.', {
+                        durationMs: Date.now() - startupStartedAt
+                    });
+                } finally {
+                    useLibraryStore.getState().setStartupCatchupPending(false);
+                }
             };
 
             void performStartupScan();

--- a/src/hooks/useMetadataRefresh.ts
+++ b/src/hooks/useMetadataRefresh.ts
@@ -15,6 +15,8 @@ import { listenWithCleanup } from '../utils/tauriListener';
 interface RefreshProgress {
     current: number;
     total: number;
+    updated: number;
+    errors: number;
     phase: string;
     message: string;
 }
@@ -45,6 +47,9 @@ export function useMetadataRefresh() {
                 setRefreshProgress({
                     current: event.payload.current,
                     total: event.payload.total,
+                    updated: event.payload.updated,
+                    errors: event.payload.errors,
+                    phase: event.payload.phase,
                     message: event.payload.message,
                 });
             },
@@ -147,13 +152,13 @@ export function useMetadataRefresh() {
     useEffect(() => {
         if (browserMockMode) return;
 
-        // Run after a short delay to allow app to settle
+        // Run after a short delay to allow app to settle after startup maintenance.
         const timer = setTimeout(async () => {
             try {
                 const countRes = await invoke<number>('get_reparse_count');
                 if (countRes > 0) {
                     addToast(
-                        `Parser updated — re-analyzing ${countRes.toLocaleString()} images in the background`,
+                        `Parser updated - re-analyzing ${countRes.toLocaleString()} images in the background`,
                         'info'
                     );
                     startRefresh();

--- a/src/hooks/useMetadataRefresh.ts
+++ b/src/hooks/useMetadataRefresh.ts
@@ -5,7 +5,7 @@
  * The actual processing happens entirely in the Rust backend.
  */
 
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useRef } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { useLibraryStore } from '../stores/libraryStore';
 import { useToast } from './useToast';
@@ -28,11 +28,42 @@ interface RefreshResult {
     wasCancelled: boolean;
 }
 
+interface RefreshStartResult {
+    ok: boolean;
+    error?: unknown;
+}
+
+interface StartRefreshOptions {
+    showFailureToast?: boolean;
+    deferActiveUntilProgress?: boolean;
+}
+
+const STARTUP_REFRESH_INITIAL_DELAY_MS = 3000;
+const STARTUP_REFRESH_RETRY_DELAY_MS = 15000;
+const STARTUP_REFRESH_MAX_ATTEMPTS = 20;
+
+const getErrorMessage = (err: unknown): string => (
+    err instanceof Error ? err.message : String(err)
+);
+
+const isTransientDatabaseLock = (err: unknown): boolean => {
+    const message = getErrorMessage(err).toLowerCase();
+    return message.includes('database is locked')
+        || message.includes('database table is locked')
+        || message.includes('database schema is locked')
+        || message.includes('database busy')
+        || message.includes('sqlite_busy');
+};
+
 export function useMetadataRefresh() {
     const { addToast } = useToast();
     const browserMockMode = isBrowserMockMode();
+    const startupAnnouncementCountRef = useRef<number | null>(null);
+    const startupAnnouncementShownRef = useRef(false);
+    const deferStartupVisibilityUntilProcessingRef = useRef(false);
 
     const {
+        setMetadataRefreshPending,
         setIsRefreshingMetadata,
         setRefreshProgress,
     } = useLibraryStore();
@@ -44,6 +75,19 @@ export function useMetadataRefresh() {
         const progressListener = listenWithCleanup<RefreshProgress>(
             'refresh-progress',
             (event) => {
+                if (
+                    deferStartupVisibilityUntilProcessingRef.current
+                    && event.payload.phase !== 'processing'
+                ) {
+                    setMetadataRefreshPending(true);
+                    setIsRefreshingMetadata(false);
+                    setRefreshProgress(null);
+                    return;
+                }
+
+                deferStartupVisibilityUntilProcessingRef.current = false;
+                setMetadataRefreshPending(false);
+                setIsRefreshingMetadata(true);
                 setRefreshProgress({
                     current: event.payload.current,
                     total: event.payload.total,
@@ -52,6 +96,14 @@ export function useMetadataRefresh() {
                     phase: event.payload.phase,
                     message: event.payload.message,
                 });
+                const startupCount = startupAnnouncementCountRef.current;
+                if (startupCount !== null && !startupAnnouncementShownRef.current) {
+                    startupAnnouncementShownRef.current = true;
+                    addToast(
+                        `Parser updated - re-analyzing ${startupCount.toLocaleString()} images in the background`,
+                        'info'
+                    );
+                }
             },
             'Metadata refresh progress'
         );
@@ -62,7 +114,10 @@ export function useMetadataRefresh() {
                 const { processed, updated, errors, wasCancelled } = event.payload;
 
                 setIsRefreshingMetadata(false);
+                setMetadataRefreshPending(false);
                 setRefreshProgress(null);
+                startupAnnouncementCountRef.current = null;
+                startupAnnouncementShownRef.current = false;
 
                 if (wasCancelled) {
                     addToast(`Refresh cancelled: ${processed.toLocaleString()} processed before stop`, 'info');
@@ -82,17 +137,28 @@ export function useMetadataRefresh() {
             progressListener.cleanup();
             completeListener.cleanup();
         };
-    }, [setIsRefreshingMetadata, setRefreshProgress, addToast, browserMockMode]);
+    }, [setMetadataRefreshPending, setIsRefreshingMetadata, setRefreshProgress, addToast, browserMockMode]);
 
     // Start refresh job
-    const startRefresh = useCallback(async (filterTool?: string) => {
+    const startRefresh = useCallback(async (
+        filterTool?: string,
+        options: StartRefreshOptions = {}
+    ): Promise<RefreshStartResult> => {
+        const { showFailureToast = true, deferActiveUntilProgress = false } = options;
+
         if (browserMockMode) {
             addToast('Unavailable in browser mock mode.', 'info');
-            return;
+            return { ok: false };
         }
 
         console.log(`[Refresh] Starting backend refresh job${filterTool ? ` (Tool: ${filterTool})` : ''}`);
-        setIsRefreshingMetadata(true);
+        deferStartupVisibilityUntilProcessingRef.current = deferActiveUntilProgress;
+        if (!deferActiveUntilProgress) {
+            startupAnnouncementCountRef.current = null;
+            startupAnnouncementShownRef.current = false;
+            setMetadataRefreshPending(false);
+            setIsRefreshingMetadata(true);
+        }
 
         try {
             const result = await invoke<RefreshResult>('start_reparse_job', {
@@ -102,13 +168,25 @@ export function useMetadataRefresh() {
             });
             console.log('[Refresh] Job returned:', result);
             // Safety reset in case events are missed or job returns immediately
+            setMetadataRefreshPending(false);
             setIsRefreshingMetadata(false);
+            startupAnnouncementCountRef.current = null;
+            startupAnnouncementShownRef.current = false;
+            deferStartupVisibilityUntilProcessingRef.current = false;
+            return { ok: true };
         } catch (err) {
             console.error('[Refresh] Exception:', err);
-            addToast(`Failed to start refresh: ${err}`, 'error');
+            if (showFailureToast) {
+                addToast(`Failed to start refresh: ${getErrorMessage(err)}`, 'error');
+            }
+            setMetadataRefreshPending(false);
             setIsRefreshingMetadata(false);
+            startupAnnouncementCountRef.current = null;
+            startupAnnouncementShownRef.current = false;
+            deferStartupVisibilityUntilProcessingRef.current = false;
+            return { ok: false, error: err };
         }
-    }, [setIsRefreshingMetadata, addToast, browserMockMode]);
+    }, [setMetadataRefreshPending, setIsRefreshingMetadata, addToast, browserMockMode]);
 
     // Cancel refresh job
     const cancelRefresh = useCallback(async () => {
@@ -130,6 +208,10 @@ export function useMetadataRefresh() {
         }
 
         console.log(`[Refresh] Job requested. Root: ${rootPath || 'ALL'}, Force: ${force}${filterTool ? `, Tool: ${filterTool}` : ''}`);
+        deferStartupVisibilityUntilProcessingRef.current = false;
+        startupAnnouncementCountRef.current = null;
+        startupAnnouncementShownRef.current = false;
+        setMetadataRefreshPending(false);
         setIsRefreshingMetadata(true);
 
         try {
@@ -140,36 +222,109 @@ export function useMetadataRefresh() {
             });
             console.log('[Refresh] Job returned:', result);
             // Safety reset in case events are missed or job returns immediately
+            setMetadataRefreshPending(false);
             setIsRefreshingMetadata(false);
+            startupAnnouncementCountRef.current = null;
+            startupAnnouncementShownRef.current = false;
+            deferStartupVisibilityUntilProcessingRef.current = false;
         } catch (err) {
             console.error('[Refresh] Exception:', err);
-            addToast(`Failed to force refresh: ${err}`, 'error');
+            addToast(`Failed to force refresh: ${getErrorMessage(err)}`, 'error');
+            setMetadataRefreshPending(false);
             setIsRefreshingMetadata(false);
+            deferStartupVisibilityUntilProcessingRef.current = false;
         }
-    }, [setIsRefreshingMetadata, addToast, browserMockMode]);
+    }, [setMetadataRefreshPending, setIsRefreshingMetadata, addToast, browserMockMode]);
 
     // Auto-detect stale metadata on startup
     useEffect(() => {
         if (browserMockMode) return;
 
-        // Run after a short delay to allow app to settle after startup maintenance.
-        const timer = setTimeout(async () => {
+        let isCancelled = false;
+        let retryTimer: number | undefined;
+
+        const runStartupRefresh = async (attempt: number) => {
             try {
+                setMetadataRefreshPending(true);
                 const countRes = await invoke<number>('get_reparse_count');
-                if (countRes > 0) {
-                    addToast(
-                        `Parser updated - re-analyzing ${countRes.toLocaleString()} images in the background`,
-                        'info'
-                    );
-                    startRefresh();
+                if (isCancelled) return;
+                if (countRes <= 0) {
+                    setMetadataRefreshPending(false);
+                    startupAnnouncementCountRef.current = null;
+                    startupAnnouncementShownRef.current = false;
+                    deferStartupVisibilityUntilProcessingRef.current = false;
+                    return;
                 }
+
+                const store = useLibraryStore.getState();
+                if (store.isStartupCatchupPending || store.isImporting || store.syncStatus === 'syncing') {
+                    retryTimer = window.setTimeout(() => {
+                        void runStartupRefresh(attempt);
+                    }, STARTUP_REFRESH_RETRY_DELAY_MS);
+                    return;
+                }
+
+                startupAnnouncementCountRef.current = countRes;
+                startupAnnouncementShownRef.current = false;
+                const result = await startRefresh(undefined, {
+                    showFailureToast: false,
+                    deferActiveUntilProgress: true
+                });
+                if (result.ok || isCancelled) return;
+
+                if (isTransientDatabaseLock(result.error) && attempt < STARTUP_REFRESH_MAX_ATTEMPTS) {
+                    setMetadataRefreshPending(true);
+                    console.info(
+                        `[Refresh] Startup refresh is waiting for the database lock to clear (attempt ${attempt + 1}/${STARTUP_REFRESH_MAX_ATTEMPTS})`
+                    );
+                    retryTimer = window.setTimeout(() => {
+                        void runStartupRefresh(attempt + 1);
+                    }, STARTUP_REFRESH_RETRY_DELAY_MS);
+                    return;
+                }
+
+                setMetadataRefreshPending(false);
+                startupAnnouncementCountRef.current = null;
+                startupAnnouncementShownRef.current = false;
+                deferStartupVisibilityUntilProcessingRef.current = false;
+                addToast(`Failed to start refresh: ${getErrorMessage(result.error)}`, 'error');
             } catch (err) {
+                if (isTransientDatabaseLock(err) && attempt < STARTUP_REFRESH_MAX_ATTEMPTS) {
+                    setMetadataRefreshPending(true);
+                    console.info(
+                        `[Refresh] Startup refresh count check is waiting for the database lock to clear (attempt ${attempt + 1}/${STARTUP_REFRESH_MAX_ATTEMPTS})`
+                    );
+                    retryTimer = window.setTimeout(() => {
+                        void runStartupRefresh(attempt + 1);
+                    }, STARTUP_REFRESH_RETRY_DELAY_MS);
+                    return;
+                }
+
+                setMetadataRefreshPending(false);
+                startupAnnouncementCountRef.current = null;
+                startupAnnouncementShownRef.current = false;
+                deferStartupVisibilityUntilProcessingRef.current = false;
                 console.error('[Refresh] Startup check failed:', err);
             }
-        }, 3000);
+        };
 
-        return () => clearTimeout(timer);
-    }, [startRefresh, addToast, browserMockMode]);
+        // Run after a short delay to allow app to settle after startup maintenance.
+        const timer = window.setTimeout(() => {
+            void runStartupRefresh(1);
+        }, STARTUP_REFRESH_INITIAL_DELAY_MS);
+
+        return () => {
+            isCancelled = true;
+            setMetadataRefreshPending(false);
+            startupAnnouncementCountRef.current = null;
+            startupAnnouncementShownRef.current = false;
+            deferStartupVisibilityUntilProcessingRef.current = false;
+            window.clearTimeout(timer);
+            if (retryTimer !== undefined) {
+                window.clearTimeout(retryTimer);
+            }
+        };
+    }, [setMetadataRefreshPending, startRefresh, addToast, browserMockMode]);
 
     return {
         startRefresh,

--- a/src/hooks/useThumbnailQueue.ts
+++ b/src/hooks/useThumbnailQueue.ts
@@ -11,8 +11,7 @@ import { isBrowserMockMode } from '../services/runtime';
 import { unwrap } from '../utils/spectaUtils';
 import {
     formatThumbnailQueueCompleteMessage,
-    formatThumbnailQueueRunningMessage,
-    THUMBNAIL_QUEUE_START_MESSAGE
+    formatThumbnailQueueRunningMessage
 } from './thumbnailQueueProgress';
 import { rebuildThumbnailFacetCache } from '../services/db/imageRepo';
 import { getThumbnailDir } from '../services/thumbnailService';
@@ -47,6 +46,21 @@ type RunningThumbnailConfig = {
 };
 
 const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+const hasVisibleThumbnailProgress = (progress: ThumbnailOptimizationProgress): boolean => (
+    progress.total > 0
+    || progress.checked > 0
+    || progress.optimized > 0
+    || progress.reused > 0
+    || progress.failed > 0
+    || progress.skipped > 0
+);
+const hasVisibleThumbnailResult = (result: ThumbnailOptimizationResult): boolean => (
+    result.checked > 0
+    || result.optimized > 0
+    || result.reused > 0
+    || result.failed > 0
+    || result.skipped > 0
+);
 
 /**
  * Starts and supervises the backend-owned Smart Thumbnail optimization job.
@@ -81,6 +95,8 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
     const isScanningDuplicates = useLibraryStore(s => s.isScanningDuplicates);
     const isScanningMissingFiles = useLibraryStore(s => s.isScanningMissingFiles);
     const isPopulatingThumbnails = useLibraryStore(s => s.isPopulatingThumbnails);
+    const isStartupCatchupPending = useLibraryStore(s => s.isStartupCatchupPending);
+    const isMetadataRefreshPending = useLibraryStore(s => s.isMetadataRefreshPending);
     const isRefreshingMetadata = useLibraryStore(s => s.isRefreshingMetadata);
     const thumbnailMaintenanceOperation = useLibraryStore(s => s.thumbnailMaintenanceOperation);
     const thumbnailOptimizationRetrySignal = useLibraryStore(s => s.thumbnailOptimizationRetrySignal);
@@ -105,6 +121,8 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
         || isScanningDuplicates
         || isScanningMissingFiles
         || isPopulatingThumbnails
+        || isStartupCatchupPending
+        || isMetadataRefreshPending
         || isRefreshingMetadata
         || thumbnailMaintenanceOperation !== null;
 
@@ -122,6 +140,8 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             || store.isScanningDuplicates
             || store.isScanningMissingFiles
             || store.isPopulatingThumbnails
+            || store.isStartupCatchupPending
+            || store.isMetadataRefreshPending
             || store.isRefreshingMetadata
             || store.thumbnailMaintenanceOperation !== null;
     }, []);
@@ -268,6 +288,31 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
         const imagesPerSecond = result.durationMs > 0
             ? result.checked / (result.durationMs / 1000)
             : 0;
+        const visibleResult = hasVisibleThumbnailResult(result);
+        setLastBackgroundHealingRun({
+            checked: result.checked,
+            optimized: result.optimized,
+            reused: result.reused,
+            failed: result.failed,
+            skipped: result.skipped,
+            imagesPerSecond,
+            durationMs: result.durationMs,
+            completedAt: Date.now(),
+            profile: completedConfig?.profile ?? thumbnailOptimizationProfile
+        });
+
+        if (!visibleResult) {
+            setBackgroundHealingActive(false);
+            setBackgroundHealingPaused(false);
+            setBackgroundHealingProgress(null);
+            setBackgroundHealingDetails(null);
+            if (retryAfterCurrentRunRef.current && enableAutoThumbnailHealing) {
+                retryAfterCurrentRunRef.current = false;
+                setPostRunRetrySignal(signal => signal + 1);
+            }
+            return;
+        }
+
         const completeCount = Math.max(result.checked, 1);
         setBackgroundHealingActive(true);
         setBackgroundHealingPaused(false);
@@ -281,17 +326,6 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             })
         });
         setBackgroundHealingDetails(null);
-        setLastBackgroundHealingRun({
-            checked: result.checked,
-            optimized: result.optimized,
-            reused: result.reused,
-            failed: result.failed,
-            skipped: result.skipped,
-            imagesPerSecond,
-            durationMs: result.durationMs,
-            completedAt: Date.now(),
-            profile: completedConfig?.profile ?? thumbnailOptimizationProfile
-        });
 
         void refreshThumbnailConsumers(result.optimized);
 
@@ -327,6 +361,7 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
             'thumbnail-optimization-progress',
             (event) => {
                 if (cancelRequestedRef.current) return;
+                const shouldShowProgress = hasVisibleThumbnailProgress(event.payload);
 
                 jobDiagnosticRef.current?.update({
                     checked: event.payload.checked,
@@ -336,11 +371,13 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
                     phase: event.payload.phase,
                     isThrottled: event.payload.isThrottled
                 });
+                if (!shouldShowProgress) return;
+
                 setBackgroundHealingActive(true);
                 setBackgroundHealingPaused(false);
                 setBackgroundHealingProgress({
                     current: event.payload.checked,
-                    total: 0,
+                    total: event.payload.total > 0 ? event.payload.total : 0,
                     message: formatThumbnailQueueRunningMessage({
                         checked: event.payload.checked,
                         optimized: event.payload.optimized,
@@ -463,27 +500,7 @@ export function useThumbnailQueue(addToast?: ToastFn): void {
         cancelRequestedRef.current = false;
         restartRequestedRef.current = false;
         runningConfigRef.current = optimizerConfig;
-        setBackgroundHealingActive(true);
         setBackgroundHealingPaused(false);
-        setBackgroundHealingProgress({
-            current: 0,
-            total: 0,
-            message: THUMBNAIL_QUEUE_START_MESSAGE
-        });
-        setBackgroundHealingDetails({
-            checked: 0,
-            optimized: 0,
-            reused: 0,
-            failed: 0,
-            skipped: 0,
-            imagesPerSecond: 0,
-            batchMs: 0,
-            dbMs: 0,
-            encodeMs: 0,
-            profile: optimizerConfig.profile,
-            phase: shouldStartThrottled ? 'throttled' : 'running',
-            isThrottled: shouldStartThrottled
-        });
 
         console.log('[ThumbnailQueue] Starting backend thumbnail optimization', {
             includeUpgradeable: optimizerConfig.includeUpgradeable,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import App from './App';
 import './index.css';
 import { ToastProvider } from './contexts/ToastContext';
 import { LibraryProvider } from './contexts/LibraryContext';
+import { StartupMaintenanceGate } from './components/StartupMaintenanceGate';
 
 import { ErrorBoundary } from './components/ui/ErrorBoundary';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -35,11 +36,13 @@ root.render(
   <React.StrictMode>
     <ToastProvider>
       <QueryClientProvider client={queryClient}>
-        <LibraryProvider>
-          <ErrorBoundary>
-            <App />
-          </ErrorBoundary>
-        </LibraryProvider>
+        <StartupMaintenanceGate>
+          <LibraryProvider>
+            <ErrorBoundary>
+              <App />
+            </ErrorBoundary>
+          </LibraryProvider>
+        </StartupMaintenanceGate>
         {import.meta.env.DEV && (
           <React.Suspense fallback={null}>
             <ReactQueryDevtools initialIsOpen={false} />

--- a/src/services/db/connection.ts
+++ b/src/services/db/connection.ts
@@ -2,7 +2,18 @@ import Database from '@tauri-apps/plugin-sql';
 
 let db: Database | null = null;
 let dbInitialized = false;
+let dbLoadPromise: Promise<Database> | null = null;
 const SLOW_STARTUP_PHASE_MS = 1000;
+
+export type StartupDbPhase =
+    | 'Preparing library database'
+    | 'Updating database schema'
+    | 'Optimizing database'
+    | 'Loading library';
+
+interface GetDbOptions {
+    onPhase?: (phase: StartupDbPhase) => void;
+}
 
 const logStartupDbPhase = (phase: string, startedAt: number) => {
     const elapsed = Math.round(performance.now() - startedAt);
@@ -39,10 +50,17 @@ export class Mutex {
 
 export const dbMutex = new Mutex();
 
-export const getDb = async () => {
+export const getDb = async (options: GetDbOptions = {}) => {
     if (!db) {
+        options.onPhase?.('Updating database schema');
         const loadStartedAt = performance.now();
-        db = await Database.load('sqlite:images.db');
+        if (!dbLoadPromise) {
+            dbLoadPromise = Database.load('sqlite:images.db').catch((error) => {
+                dbLoadPromise = null;
+                throw error;
+            });
+        }
+        db = await dbLoadPromise;
         logStartupDbPhase('Database.load', loadStartedAt);
     }
 
@@ -50,6 +68,7 @@ export const getDb = async () => {
         dbInitialized = true;
         // Enable WAL mode and busy timeout for better concurrency
         try {
+            options.onPhase?.('Optimizing database');
             const pragmaStartedAt = performance.now();
             await db.execute('PRAGMA journal_mode=WAL');
             await db.execute('PRAGMA synchronous=NORMAL');
@@ -72,5 +91,6 @@ export const getDb = async () => {
             console.error('[DB] Failed to set PRAGMAs or Indexes', e);
         }
     }
+    options.onPhase?.('Loading library');
     return db;
 };

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -31,6 +31,8 @@ const debugImportRun = (event: string, data: Record<string, unknown>) => {
 export interface SyncProgress {
     current: number;
     total: number;
+    updated?: number;
+    errors?: number;
     message?: string;
     phase?: string;
     mode?: 'determinate' | 'indeterminate' | 'complete';

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -216,6 +216,7 @@ interface LibraryState {
     lastMissingScanResult: MissingFileAuditResult | null;
 
     // Background Auto-Healing State
+    isStartupCatchupPending: boolean;
     isBackgroundHealingActive: boolean;
     backgroundHealingProgress: SyncProgress | null;
     backgroundHealingDetails: ThumbnailOptimizationDetails | null;
@@ -225,6 +226,7 @@ interface LibraryState {
     thumbnailMaintenanceOperation: ThumbnailMaintenanceOperation | null;
 
     // Background Metadata Refresh State
+    isMetadataRefreshPending: boolean;
     isRefreshingMetadata: boolean;
     refreshProgress: SyncProgress | null;
 
@@ -278,6 +280,7 @@ interface LibraryState {
     incrementFacetCacheVersion: () => void;
 
     // Background Healing Actions
+    setStartupCatchupPending: (val: boolean) => void;
     setBackgroundHealingActive: (val: boolean) => void;
     setBackgroundHealingProgress: (progress: SyncProgress | null) => void;
     setBackgroundHealingDetails: (details: ThumbnailOptimizationDetails | null) => void;
@@ -287,6 +290,7 @@ interface LibraryState {
     setThumbnailMaintenanceOperation: (operation: ThumbnailMaintenanceOperation | null) => void;
 
     // Background Metadata Refresh Actions
+    setMetadataRefreshPending: (val: boolean) => void;
     setIsRefreshingMetadata: (val: boolean) => void;
     setRefreshProgress: (progress: SyncProgress | null) => void;
     cancelRefresh: () => void;
@@ -342,6 +346,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     facetCacheVersion: 0,
 
     // Background Healing State
+    isStartupCatchupPending: false,
     isBackgroundHealingActive: false,
     backgroundHealingProgress: null,
     backgroundHealingDetails: null,
@@ -351,6 +356,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     thumbnailMaintenanceOperation: null,
 
     // Background Metadata Refresh State
+    isMetadataRefreshPending: false,
     isRefreshingMetadata: false,
     refreshProgress: null,
 
@@ -560,6 +566,7 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     incrementFacetCacheVersion: () => set((state) => ({ facetCacheVersion: state.facetCacheVersion + 1 })),
 
     // Background Healing Actions
+    setStartupCatchupPending: (val) => set({ isStartupCatchupPending: val }),
     setBackgroundHealingActive: (val) => set({ isBackgroundHealingActive: val }),
     setBackgroundHealingProgress: (progress) => set({ backgroundHealingProgress: progress }),
     setBackgroundHealingDetails: (details) => set({ backgroundHealingDetails: details }),
@@ -571,11 +578,12 @@ export const useLibraryStore = create<LibraryState>((set) => ({
     setThumbnailMaintenanceOperation: (operation) => set({ thumbnailMaintenanceOperation: operation }),
 
     // Background Metadata Refresh Actions
+    setMetadataRefreshPending: (val) => set({ isMetadataRefreshPending: val }),
     setIsRefreshingMetadata: (val) => set({ isRefreshingMetadata: val, isActivityDockDismissed: val ? false : undefined }),
     setRefreshProgress: (progress) => set({ refreshProgress: progress }),
     cancelRefresh: () => {
         invoke('cancel_reparse_job').catch(console.error);
-        set({ isRefreshingMetadata: false, refreshProgress: null });
+        set({ isMetadataRefreshPending: false, isRefreshingMetadata: false, refreshProgress: null });
     },
 
     // Live Watch Session Actions


### PR DESCRIPTION
## Summary
- Show startup maintenance before database migrations make launch feel stalled.
- Coordinate startup catch-up, automatic parser refresh, and smart thumbnail optimization in a stable order.
- Keep no-op, counting, and preparation phases quiet so the Activity Dock appears only for meaningful visible work.

## Why
Large-library startup could look frozen during migrations, and automatic background jobs could appear, disappear, and reappear before doing useful work. This keeps startup honest without adding noise.

## Validation
- corepack pnpm exec vitest run src/hooks/__tests__/useMetadataRefresh.test.tsx src/hooks/__tests__/useThumbnailQueue.test.ts src/contexts/__tests__/LibraryIntegration.test.tsx
- corepack pnpm run typecheck
- git diff --check
- corepack pnpm exec tauri build --ci --no-bundle

## Manual Testing
Confirmed locally with an older images.db requiring migration: startup maintenance appears, the app opens after migration, metadata refresh starts after startup work is clear, and smart thumbnails wait until metadata refresh is no longer pending/running.