### PR TITLE
fix: refresh canonical resource facets after reparse

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/db/commands/filter_commands.rs
+++ b/src-tauri/src/db/commands/filter_commands.rs
@@ -8,6 +8,16 @@ const SEED_BACKFILL_EXPRESSION: &str = "CASE
                     ELSE NULL
                 END";
 
+fn resource_clean_ref_sql(column: &str) -> String {
+    format!(
+        "CASE
+            WHEN instr({column}, ' (') > 0 THEN trim(substr({column}, 1, instr({column}, ' (') - 1))
+            WHEN instr({column}, ':') > 0 THEN trim(substr({column}, 1, instr({column}, ':') - 1))
+            ELSE trim({column})
+        END"
+    )
+}
+
 #[derive(serde::Serialize, specta::Type)]
 pub struct NumericRange {
     pub min: f64,
@@ -42,8 +52,10 @@ fn build_parameter_scope_from_clause(
     }
 
     if let Some(lora) = lora_name {
-        from_clause
-            .push_str(" JOIN image_loras il ON il.image_id = images.id AND il.lora_name = ?");
+        from_clause.push_str(&format!(
+            " JOIN image_loras il ON il.image_id = images.id AND ({}) COLLATE NOCASE = ?",
+            resource_clean_ref_sql("il.lora_name")
+        ));
         join_params.push(Value::Text(lora.to_string()));
     }
 
@@ -154,7 +166,8 @@ mod tests {
             build_parameter_scope_from_clause(Some(collection_id), Some(lora_name));
 
         assert!(from_clause.contains("ci.collection_id = ?"));
-        assert!(from_clause.contains("il.lora_name = ?"));
+        assert!(from_clause.contains("il.lora_name"));
+        assert!(from_clause.contains("COLLATE NOCASE = ?"));
         assert!(!from_clause.contains(collection_id));
         assert!(!from_clause.contains(lora_name));
         assert_eq!(

--- a/src-tauri/src/db/facets.rs
+++ b/src-tauri/src/db/facets.rs
@@ -1450,9 +1450,9 @@ fn push_valid_facet_branch_params(
 fn resource_clean_ref_sql(column: &str) -> String {
     format!(
         "CASE
-            WHEN instr({0}, ' (') > 0 THEN substr({0}, 1, instr({0}, ' (') - 1)
-            WHEN instr({0}, ':') > 0 THEN substr({0}, 1, instr({0}, ':') - 1)
-            ELSE {0}
+            WHEN instr({0}, ' (') > 0 THEN trim(substr({0}, 1, instr({0}, ' (') - 1))
+            WHEN instr({0}, ':') > 0 THEN trim(substr({0}, 1, instr({0}, ':') - 1))
+            ELSE trim({0})
         END",
         column
     )
@@ -1495,11 +1495,14 @@ fn get_valid_facet_names_for_query(
     let collection_join = collection_id
         .map(|_| "JOIN collection_images ci_filter ON ci_filter.image_id = i.id AND ci_filter.collection_id = ?")
         .unwrap_or("");
-    let lora_join = lora_name
-        .map(|_| {
-            "JOIN image_loras il_filter ON il_filter.image_id = i.id AND il_filter.lora_name = ?"
-        })
-        .unwrap_or("");
+    let lora_join = if lora_name.is_some() {
+        let clean_lora = resource_clean_ref_sql("il_filter.lora_name");
+        format!(
+            "JOIN image_loras il_filter ON il_filter.image_id = i.id AND ({clean_lora}) COLLATE NOCASE = ?"
+        )
+    } else {
+        String::new()
+    };
     let prefixed = prefix_valid_facet_where_columns(&base_where);
     let checkpoint_cache_join =
         "JOIN facet_cache fc ON fc.facet_type = 'checkpoints'
@@ -1531,7 +1534,7 @@ fn get_valid_facet_names_for_query(
          UNION ALL
          SELECT 'ip_adapters', fc.resource_name FROM image_ipadapters ip JOIN images i ON i.id = ip.image_id {coll} {lora} {ipadapter_cache} {where}",
         coll = collection_join,
-        lora = lora_join,
+        lora = lora_join.as_str(),
         checkpoint_cache = checkpoint_cache_join,
         lora_cache = lora_cache_join,
         embedding_cache = embedding_cache_join,
@@ -2376,6 +2379,41 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.loras, vec!["CaseLora"]);
+    }
+
+    #[test]
+    fn test_valid_facet_names_lora_filter_matches_weighted_resource_reference() {
+        let conn = create_valid_facet_conn();
+
+        conn.execute(
+            "INSERT INTO images (id, path, timestamp, resolved_model_name, positive_prompt)
+             VALUES ('img-weighted-lora', 'weighted-lora.png', 300, 'CollectionModel', 'weighted lora')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO image_loras (image_id, lora_name)
+             VALUES ('img-weighted-lora', 'detail___add_detail (0.20)')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO facet_cache (facet_type, resource_name, resource_hash, count)
+             VALUES ('loras', 'detail___add_detail', 'lora_detail___add_detail', 1)",
+            [],
+        )
+        .unwrap();
+
+        let result = get_valid_facet_names_for_query(
+            &conn,
+            "WHERE is_deleted = 0 AND positive_prompt LIKE ?",
+            vec![Value::Text("%weighted lora%".to_string())],
+            None,
+            Some("detail___add_detail"),
+        )
+        .unwrap();
+
+        assert_eq!(result.loras, vec!["detail___add_detail"]);
     }
 
     #[test]

--- a/src-tauri/src/db/migrations/m59_canonical_resource_lookup_indexes.rs
+++ b/src-tauri/src/db/migrations/m59_canonical_resource_lookup_indexes.rs
@@ -1,0 +1,172 @@
+use tauri_plugin_sql::{Migration, MigrationKind};
+
+/// Migration 59: Add expression indexes for canonical resource filtering.
+///
+/// Facet rows are displayed by canonical resource name, while older or reparsed
+/// junction rows may still include weight suffixes such as `Name (0.20)` or
+/// `Name:0.20`. These indexes keep canonical filter predicates fast.
+pub fn migration59() -> Migration {
+    Migration {
+        version: 59,
+        description: "add_canonical_resource_lookup_indexes",
+        sql: r#"
+            CREATE INDEX IF NOT EXISTS idx_lora_canonical_name_image_v1
+                ON image_loras (
+                    (CASE
+                        WHEN instr(lora_name, ' (') > 0 THEN trim(substr(lora_name, 1, instr(lora_name, ' (') - 1))
+                        WHEN instr(lora_name, ':') > 0 THEN trim(substr(lora_name, 1, instr(lora_name, ':') - 1))
+                        ELSE trim(lora_name)
+                    END) COLLATE NOCASE,
+                    image_id
+                );
+
+            CREATE INDEX IF NOT EXISTS idx_embedding_canonical_name_image_v1
+                ON image_embeddings (
+                    (CASE
+                        WHEN instr(embedding_name, ' (') > 0 THEN trim(substr(embedding_name, 1, instr(embedding_name, ' (') - 1))
+                        WHEN instr(embedding_name, ':') > 0 THEN trim(substr(embedding_name, 1, instr(embedding_name, ':') - 1))
+                        ELSE trim(embedding_name)
+                    END) COLLATE NOCASE,
+                    image_id
+                );
+
+            CREATE INDEX IF NOT EXISTS idx_hypernetwork_canonical_name_image_v1
+                ON image_hypernetworks (
+                    (CASE
+                        WHEN instr(hypernetwork_name, ' (') > 0 THEN trim(substr(hypernetwork_name, 1, instr(hypernetwork_name, ' (') - 1))
+                        WHEN instr(hypernetwork_name, ':') > 0 THEN trim(substr(hypernetwork_name, 1, instr(hypernetwork_name, ':') - 1))
+                        ELSE trim(hypernetwork_name)
+                    END) COLLATE NOCASE,
+                    image_id
+                );
+
+            CREATE INDEX IF NOT EXISTS idx_controlnet_canonical_name_image_v1
+                ON image_controlnets (
+                    (CASE
+                        WHEN instr(controlnet_name, ' (') > 0 THEN trim(substr(controlnet_name, 1, instr(controlnet_name, ' (') - 1))
+                        WHEN instr(controlnet_name, ':') > 0 THEN trim(substr(controlnet_name, 1, instr(controlnet_name, ':') - 1))
+                        ELSE trim(controlnet_name)
+                    END) COLLATE NOCASE,
+                    image_id
+                );
+
+            CREATE INDEX IF NOT EXISTS idx_ipadapter_canonical_name_image_v1
+                ON image_ipadapters (
+                    (CASE
+                        WHEN instr(ipadapter_name, ' (') > 0 THEN trim(substr(ipadapter_name, 1, instr(ipadapter_name, ' (') - 1))
+                        WHEN instr(ipadapter_name, ':') > 0 THEN trim(substr(ipadapter_name, 1, instr(ipadapter_name, ':') - 1))
+                        ELSE trim(ipadapter_name)
+                    END) COLLATE NOCASE,
+                    image_id
+                );
+
+            ANALYZE image_loras;
+            ANALYZE image_embeddings;
+            ANALYZE image_hypernetworks;
+            ANALYZE image_controlnets;
+            ANALYZE image_ipadapters;
+        "#,
+        kind: MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration59;
+
+    const LORA_CANONICAL_EXPR: &str = "CASE
+                        WHEN instr(lora_name, ' (') > 0 THEN trim(substr(lora_name, 1, instr(lora_name, ' (') - 1))
+                        WHEN instr(lora_name, ':') > 0 THEN trim(substr(lora_name, 1, instr(lora_name, ':') - 1))
+                        ELSE trim(lora_name)
+                    END";
+
+    #[test]
+    fn migration_adds_canonical_resource_expression_indexes() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE image_loras (image_id TEXT NOT NULL, lora_name TEXT NOT NULL);
+            CREATE TABLE image_embeddings (image_id TEXT NOT NULL, embedding_name TEXT NOT NULL);
+            CREATE TABLE image_hypernetworks (image_id TEXT NOT NULL, hypernetwork_name TEXT NOT NULL);
+            CREATE TABLE image_controlnets (image_id TEXT NOT NULL, controlnet_name TEXT NOT NULL);
+            CREATE TABLE image_ipadapters (image_id TEXT NOT NULL, ipadapter_name TEXT NOT NULL);
+            "#,
+        )
+        .expect("setup resource tables");
+
+        conn.execute_batch(migration59().sql)
+            .expect("apply migration");
+
+        for index_name in [
+            "idx_lora_canonical_name_image_v1",
+            "idx_embedding_canonical_name_image_v1",
+            "idx_hypernetwork_canonical_name_image_v1",
+            "idx_controlnet_canonical_name_image_v1",
+            "idx_ipadapter_canonical_name_image_v1",
+        ] {
+            let found: i64 = conn
+                .query_row(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = ?1",
+                    [index_name],
+                    |row| row.get(0),
+                )
+                .expect("query sqlite_master");
+            assert_eq!(found, 1, "{index_name} should be created");
+        }
+    }
+
+    #[test]
+    fn canonical_lora_lookup_uses_expression_index_and_matches_weighted_rows() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE image_loras (image_id TEXT NOT NULL, lora_name TEXT NOT NULL);
+            CREATE TABLE image_embeddings (image_id TEXT NOT NULL, embedding_name TEXT NOT NULL);
+            CREATE TABLE image_hypernetworks (image_id TEXT NOT NULL, hypernetwork_name TEXT NOT NULL);
+            CREATE TABLE image_controlnets (image_id TEXT NOT NULL, controlnet_name TEXT NOT NULL);
+            CREATE TABLE image_ipadapters (image_id TEXT NOT NULL, ipadapter_name TEXT NOT NULL);
+
+            INSERT INTO image_loras (image_id, lora_name) VALUES
+                ('exact', 'detail___add_detail'),
+                ('weighted', 'detail___add_detail (0.20)'),
+                ('colon', 'detail___add_detail:0.20'),
+                ('other', 'different_lora');
+            "#,
+        )
+        .expect("setup resource rows");
+        conn.execute_batch(migration59().sql)
+            .expect("apply migration");
+
+        let matching_images: Vec<String> = conn
+            .prepare(&format!(
+                "SELECT image_id FROM image_loras
+                 WHERE ({LORA_CANONICAL_EXPR}) COLLATE NOCASE = ?1
+                 ORDER BY image_id"
+            ))
+            .expect("prepare canonical lookup")
+            .query_map(["DETAIL___ADD_DETAIL"], |row| row.get(0))
+            .expect("query canonical lookup")
+            .collect::<Result<_, _>>()
+            .expect("collect canonical lookup");
+
+        assert_eq!(matching_images, vec!["colon", "exact", "weighted"]);
+
+        let plan: Vec<String> = conn
+            .prepare(&format!(
+                "EXPLAIN QUERY PLAN
+                 SELECT image_id FROM image_loras
+                 WHERE ({LORA_CANONICAL_EXPR}) COLLATE NOCASE = ?1"
+            ))
+            .expect("prepare query plan")
+            .query_map(["detail___add_detail"], |row| row.get::<_, String>(3))
+            .expect("query plan")
+            .collect::<Result<_, _>>()
+            .expect("collect query plan");
+
+        assert!(
+            plan.iter()
+                .any(|detail| detail.contains("idx_lora_canonical_name_image_v1")),
+            "canonical LoRA lookup should use expression index, plan was: {plan:?}"
+        );
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -25,6 +25,7 @@ pub mod m55_manual_thumbnail_lookup_index;
 pub mod m56_thumbnail_optimization;
 pub mod m57_collection_thumbnail_cache;
 pub mod m58_nullable_seed;
+pub mod m59_canonical_resource_lookup_indexes;
 
 pub fn init_db() -> Vec<Migration> {
     get_migrations()
@@ -59,6 +60,7 @@ pub fn get_migrations() -> Vec<Migration> {
     migrations.push(m56_thumbnail_optimization::migration56());
     migrations.push(m57_collection_thumbnail_cache::migration57());
     migrations.push(m58_nullable_seed::migration58());
+    migrations.push(m59_canonical_resource_lookup_indexes::migration59());
 
     migrations.sort_by_key(|m| m.version);
 
@@ -70,7 +72,7 @@ mod tests {
     use super::get_migrations;
 
     #[test]
-    fn migrations_include_mainline_through_nullable_seed_58() {
+    fn migrations_include_mainline_through_canonical_resource_indexes_59() {
         let versions: Vec<i64> = get_migrations()
             .iter()
             .map(|migration| migration.version)
@@ -86,6 +88,7 @@ mod tests {
         assert!(versions.contains(&56));
         assert!(versions.contains(&57));
         assert!(versions.contains(&58));
+        assert!(versions.contains(&59));
     }
 
     #[test]
@@ -111,7 +114,7 @@ mod tests {
     }
 
     #[test]
-    fn database_at_mainline_49_has_migrations_through_nullable_seed_58_pending() {
+    fn database_at_mainline_49_has_migrations_through_canonical_resource_indexes_59_pending() {
         let migrations = get_migrations();
         let has_49 = migrations.iter().any(|migration| migration.version == 49);
         let pending_after_49: Vec<i64> = migrations
@@ -121,6 +124,6 @@ mod tests {
             .collect();
 
         assert!(has_49);
-        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54, 55, 56, 57, 58]);
+        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54, 55, 56, 57, 58, 59]);
     }
 }

--- a/src/hooks/__tests__/useMetadataRefresh.test.tsx
+++ b/src/hooks/__tests__/useMetadataRefresh.test.tsx
@@ -4,8 +4,9 @@ import { invoke } from '@tauri-apps/api/core';
 import { useMetadataRefresh } from '../useMetadataRefresh';
 import { useLibraryStore } from '../../stores/libraryStore';
 
-const { mockAddToast, listenerCallbacks } = vi.hoisted(() => ({
+const { mockAddToast, mockRebuildFacetCacheIncrementalBatchStrict, listenerCallbacks } = vi.hoisted(() => ({
     mockAddToast: vi.fn(),
+    mockRebuildFacetCacheIncrementalBatchStrict: vi.fn(),
     listenerCallbacks: new Map<string, (event: { payload: unknown }) => void>()
 }));
 
@@ -22,17 +23,29 @@ vi.mock('../../utils/tauriListener', () => ({
     })
 }));
 
+vi.mock('../../services/db/imageRepo', () => ({
+    rebuildFacetCacheIncrementalBatchStrict: mockRebuildFacetCacheIncrementalBatchStrict
+}));
+
+const flushAsyncWork = async () => {
+    await act(async () => {
+        await Promise.resolve();
+    });
+};
+
 describe('useMetadataRefresh', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         vi.useFakeTimers();
         listenerCallbacks.clear();
         useLibraryStore.setState({
+            facetCacheVersion: 0,
             isStartupCatchupPending: false,
             isMetadataRefreshPending: false,
             isRefreshingMetadata: false,
             refreshProgress: null
         });
+        mockRebuildFacetCacheIncrementalBatchStrict.mockResolvedValue(7);
     });
 
     afterEach(() => {
@@ -254,6 +267,229 @@ describe('useMetadataRefresh', () => {
         expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(false);
         expect(useLibraryStore.getState().isRefreshingMetadata).toBe(false);
         expect(useLibraryStore.getState().refreshProgress).toBeNull();
+        await flushAsyncWork();
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).toHaveBeenCalledWith([
+            'checkpoints',
+            'loras',
+            'embeddings',
+            'hypernetworks',
+            'controlNets',
+            'ipAdapters',
+            'tools'
+        ]);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+    });
+
+    it('refreshes parser-derived facets after metadata refresh updates records', async () => {
+        renderHook(() => useMetadataRefresh());
+
+        act(() => {
+            listenerCallbacks.get('refresh-complete')?.({
+                payload: {
+                    processed: 12,
+                    updated: 3,
+                    errors: 0,
+                    wasCancelled: false
+                }
+            });
+        });
+
+        await flushAsyncWork();
+
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).toHaveBeenCalledWith([
+            'checkpoints',
+            'loras',
+            'embeddings',
+            'hypernetworks',
+            'controlNets',
+            'ipAdapters',
+            'tools'
+        ]);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+        expect(mockAddToast).not.toHaveBeenCalledWith(
+            expect.stringContaining('asset counts may be stale'),
+            'warning'
+        );
+    });
+
+    it('skips facet refresh when metadata refresh has no updates', async () => {
+        renderHook(() => useMetadataRefresh());
+
+        act(() => {
+            listenerCallbacks.get('refresh-complete')?.({
+                payload: {
+                    processed: 12,
+                    updated: 0,
+                    errors: 0,
+                    wasCancelled: false
+                }
+            });
+        });
+
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).not.toHaveBeenCalled();
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(0);
+    });
+
+    it('refreshes facets after a cancelled metadata refresh that updated records', async () => {
+        renderHook(() => useMetadataRefresh());
+
+        act(() => {
+            listenerCallbacks.get('refresh-complete')?.({
+                payload: {
+                    processed: 5,
+                    updated: 2,
+                    errors: 0,
+                    wasCancelled: true
+                }
+            });
+        });
+
+        await flushAsyncWork();
+
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).toHaveBeenCalledWith([
+            'checkpoints',
+            'loras',
+            'embeddings',
+            'hypernetworks',
+            'controlNets',
+            'ipAdapters',
+            'tools'
+        ]);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+    });
+
+    it('keeps refresh completion cleanup when facet refresh fails', async () => {
+        mockRebuildFacetCacheIncrementalBatchStrict.mockRejectedValueOnce(new Error('facet refresh failed'));
+        useLibraryStore.setState({
+            isMetadataRefreshPending: true,
+            isRefreshingMetadata: true,
+            refreshProgress: {
+                current: 1,
+                total: 2,
+                updated: 1,
+                errors: 0,
+                phase: 'processing',
+                message: 'Processing'
+            }
+        });
+        renderHook(() => useMetadataRefresh());
+
+        act(() => {
+            listenerCallbacks.get('refresh-complete')?.({
+                payload: {
+                    processed: 2,
+                    updated: 1,
+                    errors: 0,
+                    wasCancelled: false
+                }
+            });
+        });
+
+        await flushAsyncWork();
+
+        expect(mockAddToast).toHaveBeenCalledWith(
+            'Metadata refresh finished, but asset counts may be stale until the next refresh.',
+            'warning'
+        );
+        expect(useLibraryStore.getState().isMetadataRefreshPending).toBe(false);
+        expect(useLibraryStore.getState().isRefreshingMetadata).toBe(false);
+        expect(useLibraryStore.getState().refreshProgress).toBeNull();
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(0);
+    });
+
+    it('refreshes facets from manual start fallback when completion events are missed', async () => {
+        vi.mocked(invoke).mockResolvedValue({
+            processed: 8,
+            updated: 4,
+            errors: 0,
+            wasCancelled: false
+        });
+        const { result } = renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await result.current.startRefresh();
+        });
+        await flushAsyncWork();
+
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).toHaveBeenCalledTimes(1);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+    });
+
+    it('refreshes facets from force refresh fallback when completion events are missed', async () => {
+        vi.mocked(invoke).mockResolvedValue({
+            processed: 8,
+            updated: 4,
+            errors: 0,
+            wasCancelled: false
+        });
+        const { result } = renderHook(() => useMetadataRefresh());
+
+        await act(async () => {
+            await result.current.forceRefresh(undefined, true);
+        });
+        await flushAsyncWork();
+
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).toHaveBeenCalledTimes(1);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
+    });
+
+    it('does not refresh facets twice when completion event and invoke result both report updates', async () => {
+        let resolveStart: ((value: unknown) => void) | undefined;
+        vi.mocked(invoke).mockImplementation((command) => {
+            if (command === 'start_reparse_job') {
+                return new Promise(resolve => {
+                    resolveStart = resolve;
+                });
+            }
+            return Promise.resolve(undefined);
+        });
+        const { result } = renderHook(() => useMetadataRefresh());
+
+        const startPromise = act(async () => {
+            await result.current.startRefresh();
+        });
+
+        act(() => {
+            listenerCallbacks.get('refresh-progress')?.({
+                payload: {
+                    current: 1,
+                    total: 8,
+                    updated: 4,
+                    errors: 0,
+                    phase: 'processing',
+                    message: 'Processed 1/8'
+                }
+            });
+            listenerCallbacks.get('refresh-complete')?.({
+                payload: {
+                    processed: 8,
+                    updated: 4,
+                    errors: 0,
+                    wasCancelled: false
+                }
+            });
+            listenerCallbacks.get('refresh-progress')?.({
+                payload: {
+                    current: 8,
+                    total: 8,
+                    updated: 4,
+                    errors: 0,
+                    phase: 'complete',
+                    message: 'Completed 8 / 8 images'
+                }
+            });
+        });
+        resolveStart?.({
+            processed: 8,
+            updated: 4,
+            errors: 0,
+            wasCancelled: false
+        });
+        await startPromise;
+        await flushAsyncWork();
+
+        expect(mockRebuildFacetCacheIncrementalBatchStrict).toHaveBeenCalledTimes(1);
+        expect(useLibraryStore.getState().facetCacheVersion).toBe(1);
     });
 
     it('still reports manual refresh failures immediately', async () => {

--- a/src/hooks/useMetadataRefresh.ts
+++ b/src/hooks/useMetadataRefresh.ts
@@ -11,6 +11,7 @@ import { useLibraryStore } from '../stores/libraryStore';
 import { useToast } from './useToast';
 import { isBrowserMockMode } from '../services/runtime';
 import { listenWithCleanup } from '../utils/tauriListener';
+import { rebuildFacetCacheIncrementalBatchStrict } from '../services/db/imageRepo';
 
 interface RefreshProgress {
     current: number;
@@ -41,6 +42,16 @@ interface StartRefreshOptions {
 const STARTUP_REFRESH_INITIAL_DELAY_MS = 3000;
 const STARTUP_REFRESH_RETRY_DELAY_MS = 15000;
 const STARTUP_REFRESH_MAX_ATTEMPTS = 20;
+const METADATA_REFRESH_FACET_TYPES = [
+    'checkpoints',
+    'loras',
+    'embeddings',
+    'hypernetworks',
+    'controlNets',
+    'ipAdapters',
+    'tools'
+];
+const ACTIVE_REFRESH_PROGRESS_PHASES = new Set(['counting', 'starting', 'processing']);
 
 const getErrorMessage = (err: unknown): string => (
     err instanceof Error ? err.message : String(err)
@@ -61,12 +72,27 @@ export function useMetadataRefresh() {
     const startupAnnouncementCountRef = useRef<number | null>(null);
     const startupAnnouncementShownRef = useRef(false);
     const deferStartupVisibilityUntilProcessingRef = useRef(false);
+    const metadataFacetRefreshHandledRef = useRef(false);
 
     const {
         setMetadataRefreshPending,
         setIsRefreshingMetadata,
         setRefreshProgress,
     } = useLibraryStore();
+
+    const refreshFacetsAfterMetadataUpdate = useCallback(async (result: RefreshResult) => {
+        if (result.updated <= 0 || metadataFacetRefreshHandledRef.current) return;
+        metadataFacetRefreshHandledRef.current = true;
+
+        try {
+            const refreshed = await rebuildFacetCacheIncrementalBatchStrict(METADATA_REFRESH_FACET_TYPES);
+            useLibraryStore.getState().incrementFacetCacheVersion();
+            console.info(`[Refresh] Refreshed metadata facet cache after reparse: ${refreshed} entries`);
+        } catch (err) {
+            console.error('[Refresh] Failed to refresh metadata facet cache after reparse', err);
+            addToast('Metadata refresh finished, but asset counts may be stale until the next refresh.', 'warning');
+        }
+    }, [addToast]);
 
     // Listen to progress events from backend
     useEffect(() => {
@@ -85,6 +111,9 @@ export function useMetadataRefresh() {
                     return;
                 }
 
+                if (ACTIVE_REFRESH_PROGRESS_PHASES.has(event.payload.phase)) {
+                    metadataFacetRefreshHandledRef.current = false;
+                }
                 deferStartupVisibilityUntilProcessingRef.current = false;
                 setMetadataRefreshPending(false);
                 setIsRefreshingMetadata(true);
@@ -129,6 +158,7 @@ export function useMetadataRefresh() {
                 }
 
                 console.log(`[Refresh] Complete: ${processed} processed, ${updated} updated, ${errors} errors`);
+                void refreshFacetsAfterMetadataUpdate(event.payload);
             },
             'Metadata refresh complete'
         );
@@ -137,7 +167,7 @@ export function useMetadataRefresh() {
             progressListener.cleanup();
             completeListener.cleanup();
         };
-    }, [setMetadataRefreshPending, setIsRefreshingMetadata, setRefreshProgress, addToast, browserMockMode]);
+    }, [setMetadataRefreshPending, setIsRefreshingMetadata, setRefreshProgress, addToast, browserMockMode, refreshFacetsAfterMetadataUpdate]);
 
     // Start refresh job
     const startRefresh = useCallback(async (
@@ -152,6 +182,7 @@ export function useMetadataRefresh() {
         }
 
         console.log(`[Refresh] Starting backend refresh job${filterTool ? ` (Tool: ${filterTool})` : ''}`);
+        metadataFacetRefreshHandledRef.current = false;
         deferStartupVisibilityUntilProcessingRef.current = deferActiveUntilProgress;
         if (!deferActiveUntilProgress) {
             startupAnnouncementCountRef.current = null;
@@ -168,6 +199,7 @@ export function useMetadataRefresh() {
             });
             console.log('[Refresh] Job returned:', result);
             // Safety reset in case events are missed or job returns immediately
+            void refreshFacetsAfterMetadataUpdate(result);
             setMetadataRefreshPending(false);
             setIsRefreshingMetadata(false);
             startupAnnouncementCountRef.current = null;
@@ -208,6 +240,7 @@ export function useMetadataRefresh() {
         }
 
         console.log(`[Refresh] Job requested. Root: ${rootPath || 'ALL'}, Force: ${force}${filterTool ? `, Tool: ${filterTool}` : ''}`);
+        metadataFacetRefreshHandledRef.current = false;
         deferStartupVisibilityUntilProcessingRef.current = false;
         startupAnnouncementCountRef.current = null;
         startupAnnouncementShownRef.current = false;
@@ -222,6 +255,7 @@ export function useMetadataRefresh() {
             });
             console.log('[Refresh] Job returned:', result);
             // Safety reset in case events are missed or job returns immediately
+            void refreshFacetsAfterMetadataUpdate(result);
             setMetadataRefreshPending(false);
             setIsRefreshingMetadata(false);
             startupAnnouncementCountRef.current = null;

--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -835,7 +835,8 @@ describe('searchRepo scoped stats queries', () => {
         expect(statsSql).toContain('JOIN image_loras il ON il.image_id = ci.image_id');
         expect(statsSql).toContain('JOIN images ON images.id = ci.image_id');
         expect(statsSql).toContain('ci.collection_id = ?');
-        expect(statsSql).toContain('il.lora_name = ?');
+        expect(statsSql).toContain("instr(il.lora_name, ' (')");
+        expect(statsSql).toContain('COLLATE NOCASE = ?');
         expect(statsSql).not.toContain(collectionId);
         expect(statsSql).not.toContain(loraName);
         expect(statsParams).toEqual([collectionId, loraName, 0]);
@@ -844,7 +845,8 @@ describe('searchRepo scoped stats queries', () => {
         expect(keywordSql).toContain('JOIN image_loras il ON il.image_id = ci.image_id');
         expect(keywordSql).toContain('JOIN images ON images.id = ci.image_id');
         expect(keywordSql).toContain('ci.collection_id = ?');
-        expect(keywordSql).toContain('il.lora_name = ?');
+        expect(keywordSql).toContain("instr(il.lora_name, ' (')");
+        expect(keywordSql).toContain('COLLATE NOCASE = ?');
         expect(keywordSql).toContain('images.rowid > ?');
         expect(keywordSql).not.toContain('WHERE si.rowid > ?');
         expect(keywordSql).not.toContain(collectionId);
@@ -904,15 +906,64 @@ describe('searchRepo scoped stats queries', () => {
 
         expect(statsSql).toContain('FROM image_loras il');
         expect(statsSql).toContain('CROSS JOIN images ON images.id = il.image_id');
+        expect(statsSql).toContain("instr(il.lora_name, ' (')");
+        expect(statsSql).toContain('COLLATE NOCASE = ?');
         expect(statsSql).not.toContain('FROM images INDEXED BY');
         expect(statsParams).toEqual(['Detailer', 0]);
 
         expect(keywordSql).toContain('FROM image_loras il');
         expect(keywordSql).toContain('CROSS JOIN images ON images.id = il.image_id');
+        expect(keywordSql).toContain("instr(il.lora_name, ' (')");
+        expect(keywordSql).toContain('COLLATE NOCASE = ?');
         expect(keywordSql).toContain('images.rowid > ?');
         expect(keywordSql).not.toContain('WHERE si.rowid > ?');
         expect(keywordSql).not.toContain('FROM images INDEXED BY');
         expect(keywordParams).toEqual(['Detailer', 0, 0]);
+    });
+
+    it('uses canonical LoRA references for optimized image count and search', async () => {
+        const db = {
+            select: vi.fn(async (sql: string) => {
+                const normalizedSql = sql.replace(/\s+/g, ' ').trim();
+                if (normalizedSql.includes('count(*) as count')) return [{ count: 1 }];
+                return [];
+            })
+        };
+        getDbMock.mockResolvedValue(db);
+
+        const { countImages, searchImages } = await import('../searchRepo');
+
+        await countImages('WHERE is_deleted = ?', [0], undefined, 'detail___add_detail');
+        await searchImages('WHERE is_deleted = ?', [0], 100, 'timestamp', 'DESC', false, undefined, 'detail___add_detail');
+
+        const [countSql, countParams] = findSelectCall(db, (value) => value.includes('count(*) as count')) as [string, unknown[]];
+        const [searchSql, searchParams] = findSelectCall(db, (value) => value.includes('SELECT') && value.includes('FROM image_loras il') && !value.includes('count(*) as count')) as [string, unknown[]];
+
+        expect(countSql).toContain("instr(il.lora_name, ' (')");
+        expect(countSql).toContain('COLLATE NOCASE = ?');
+        expect(countParams).toEqual(['detail___add_detail', 0]);
+        expect(searchSql).toContain("instr(il.lora_name, ' (')");
+        expect(searchSql).toContain('COLLATE NOCASE = ?');
+        expect(searchParams).toEqual(['detail___add_detail', 0]);
+    });
+
+    it('groups scoped LoRA facet counts by canonical resource reference', async () => {
+        const db = createFacetDb([
+            {
+                facet_type: 'loras',
+                resource_name: 'detail___add_detail',
+                resource_hash: 'lora_detail___add_detail',
+                count: 1
+            }
+        ]);
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        await getFacets('WHERE is_deleted = 0', [], ['loras'], { assetScope: 'used' });
+
+        const [scopedSql] = findSelectCall(db, (value) => value.includes('FROM scoped_images') && value.includes('JOIN image_loras')) as [string, unknown[]];
+        expect(scopedSql).toContain("instr(il.lora_name, ' (')");
+        expect(scopedSql).toContain('GROUP BY CASE');
     });
 
     it('returns full model names without a top-20 cap for scoped stats', async () => {
@@ -947,7 +998,8 @@ describe('searchRepo scoped stats queries', () => {
         const [modelSql, modelParams] = findSelectCall(db, (value) => value.includes('GROUP BY name')) as [string, unknown[]];
         expect(modelSql).toContain('WITH scoped_images');
         expect(modelSql).toContain('ci.collection_id = ?');
-        expect(modelSql).toContain('il.lora_name = ?');
+        expect(modelSql).toContain("instr(il.lora_name, ' (')");
+        expect(modelSql).toContain('COLLATE NOCASE = ?');
         expect(modelSql).not.toContain('LIMIT 20');
         expect(modelParams).toEqual(['collection-1', 'Detailer', 0]);
     });

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -5,6 +5,7 @@ import { WORD_CLOUD_CONFIG } from '../../config/wordCloud';
 import { getAssetMatchKey, uniqueAssetAliases } from '../../utils/assetIdentity';
 import { describeDbQueryReason, timeDbCall } from '../../utils/dbTiming';
 import { commands } from '../../bindings';
+import { resourceReferenceEqualsSql, resourceReferenceSql } from '../../utils/sqlHelpers';
 
 export interface LibraryStats {
     totalImages: number;
@@ -392,6 +393,8 @@ const appendTrailingPredicate = (whereClause: string, predicate?: string): strin
     predicate ? `${whereClause} AND ${predicate}` : whereClause
 );
 
+const loraReferencePredicate = resourceReferenceEqualsSql('il.lora_name');
+
 export const countImages = async (whereClause: string, params: unknown[], collectionId?: string, loraName?: string): Promise<number> => {
     const db = await getDb();
     const finalWhere = whereClause ? whereClause : DEFAULT_VISIBLE_WHERE;
@@ -404,7 +407,7 @@ export const countImages = async (whereClause: string, params: unknown[], collec
             FROM collection_images ci
             JOIN image_loras il ON il.image_id = ci.image_id
             JOIN images ON images.id = ci.image_id
-            ${finalWhere.replace('WHERE', 'WHERE ci.collection_id = ? AND il.lora_name = ? AND')}
+            ${finalWhere.replace('WHERE', `WHERE ci.collection_id = ? AND ${loraReferencePredicate} AND`)}
         `;
         const result = await timeDbCall('countImages', reason, () => db.select<CountRow[]>(query, [collectionId, loraName, ...params]));
         return result[0]?.count || 0;
@@ -428,7 +431,7 @@ export const countImages = async (whereClause: string, params: unknown[], collec
             SELECT count(*) as count 
             FROM image_loras il
             CROSS JOIN images ON images.id = il.image_id
-            ${finalWhere.replace('WHERE', 'WHERE il.lora_name = ? AND')}
+            ${finalWhere.replace('WHERE', `WHERE ${loraReferencePredicate} AND`)}
         `;
         const result = await timeDbCall('countImages', reason, () => db.select<CountRow[]>(query, [loraName, ...params]));
         return result[0]?.count || 0;
@@ -537,7 +540,7 @@ export const searchImages = async (
             FROM collection_images ci
             JOIN image_loras il ON il.image_id = ci.image_id
             JOIN images ON images.id = ci.image_id
-            ${finalWhere.replace('WHERE', 'WHERE ci.collection_id = ? AND il.lora_name = ? AND')}
+            ${finalWhere.replace('WHERE', `WHERE ci.collection_id = ? AND ${loraReferencePredicate} AND`)}
             ${cursorWhere}
             ${orderBy}
             LIMIT ${limit}
@@ -568,7 +571,7 @@ export const searchImages = async (
             SELECT ${getImageFieldsLight()}
             FROM image_loras il
             CROSS JOIN images ON images.id = il.image_id
-            ${finalWhere.replace('WHERE', 'WHERE il.lora_name = ? AND')}
+            ${finalWhere.replace('WHERE', `WHERE ${loraReferencePredicate} AND`)}
             ${cursorWhere}
             ${orderBy}
             LIMIT ${limit}
@@ -630,7 +633,7 @@ const buildScopedImageSourceParts = (
                 JOIN images ON images.id = ci.image_id
             `,
             scopedWhere: appendTrailingPredicate(
-                finalWhere.replace('WHERE', 'WHERE ci.collection_id = ? AND il.lora_name = ? AND'),
+                finalWhere.replace('WHERE', `WHERE ci.collection_id = ? AND ${loraReferencePredicate} AND`),
                 trailingPredicate
             ),
             queryParams: [collectionId, loraName, ...params, ...trailingParams],
@@ -660,7 +663,7 @@ const buildScopedImageSourceParts = (
                 CROSS JOIN images ON images.id = il.image_id
             `,
             scopedWhere: appendTrailingPredicate(
-                finalWhere.replace('WHERE', 'WHERE il.lora_name = ? AND'),
+                finalWhere.replace('WHERE', `WHERE ${loraReferencePredicate} AND`),
                 trailingPredicate
             ),
             queryParams: [loraName, ...params, ...trailingParams],
@@ -708,46 +711,56 @@ const buildScopedFacetCountSql = (cacheType: string, cteSql: string): string | n
                 FROM scoped_images
                 GROUP BY name
             `;
-        case 'loras':
+        case 'loras': {
+            const nameExpr = resourceReferenceSql('il.lora_name');
             return `
                 ${cteSql}
-                SELECT COALESCE(il.lora_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                SELECT COALESCE(${nameExpr}, 'Unknown') AS name, count(DISTINCT si.id) AS count
                 FROM scoped_images si
                 JOIN image_loras il ON il.image_id = si.id
-                GROUP BY il.lora_name
+                GROUP BY ${nameExpr}
             `;
-        case 'embeddings':
+        }
+        case 'embeddings': {
+            const nameExpr = resourceReferenceSql('ie.embedding_name');
             return `
                 ${cteSql}
-                SELECT COALESCE(ie.embedding_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                SELECT COALESCE(${nameExpr}, 'Unknown') AS name, count(DISTINCT si.id) AS count
                 FROM scoped_images si
                 JOIN image_embeddings ie ON ie.image_id = si.id
-                GROUP BY ie.embedding_name
+                GROUP BY ${nameExpr}
             `;
-        case 'hypernetworks':
+        }
+        case 'hypernetworks': {
+            const nameExpr = resourceReferenceSql('ih.hypernetwork_name');
             return `
                 ${cteSql}
-                SELECT COALESCE(ih.hypernetwork_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                SELECT COALESCE(${nameExpr}, 'Unknown') AS name, count(DISTINCT si.id) AS count
                 FROM scoped_images si
                 JOIN image_hypernetworks ih ON ih.image_id = si.id
-                GROUP BY ih.hypernetwork_name
+                GROUP BY ${nameExpr}
             `;
-        case 'control_nets':
+        }
+        case 'control_nets': {
+            const nameExpr = resourceReferenceSql('ic.controlnet_name');
             return `
                 ${cteSql}
-                SELECT COALESCE(ic.controlnet_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                SELECT COALESCE(${nameExpr}, 'Unknown') AS name, count(DISTINCT si.id) AS count
                 FROM scoped_images si
                 JOIN image_controlnets ic ON ic.image_id = si.id
-                GROUP BY ic.controlnet_name
+                GROUP BY ${nameExpr}
             `;
-        case 'ip_adapters':
+        }
+        case 'ip_adapters': {
+            const nameExpr = resourceReferenceSql('ii.ipadapter_name');
             return `
                 ${cteSql}
-                SELECT COALESCE(ii.ipadapter_name, 'Unknown') AS name, count(DISTINCT si.id) AS count
+                SELECT COALESCE(${nameExpr}, 'Unknown') AS name, count(DISTINCT si.id) AS count
                 FROM scoped_images si
                 JOIN image_ipadapters ii ON ii.image_id = si.id
-                GROUP BY ii.ipadapter_name
+                GROUP BY ${nameExpr}
             `;
+        }
         default:
             return null;
     }

--- a/src/utils/__tests__/sqlHelpers.test.ts
+++ b/src/utils/__tests__/sqlHelpers.test.ts
@@ -86,6 +86,33 @@ describe('sqlHelpers', () => {
             expect(params).toEqual([]);
         });
 
+        it('should canonicalize weighted single LoRA filters for the optimized path', () => {
+            const { where, params, loraName } = buildSqlWhereClause({
+                ...defaultFilters,
+                loras: ['detail___add_detail (0.20)']
+            }, false, 'blur', []);
+
+            expect(loraName).toBe('detail___add_detail');
+            expect(where).not.toContain('image_loras');
+            expect(params).toEqual([]);
+        });
+
+        it('should keep canonical-only weighted LoRA aliases on the optimized path', () => {
+            const { where, params, loraName } = buildSqlWhereClause({
+                ...defaultFilters,
+                loras: ['detail___add_detail'],
+                assetFilterAliases: {
+                    loras: {
+                        detail___add_detail: ['detail___add_detail', 'detail___add_detail (0.20)']
+                    }
+                }
+            }, false, 'blur', []);
+
+            expect(loraName).toBe('detail___add_detail');
+            expect(where).not.toContain('image_loras');
+            expect(params).toEqual([]);
+        });
+
         it('should expand merged LoRA aliases instead of using the single-LoRA optimization', () => {
             const { where, params, loraName } = buildSqlWhereClause({
                 ...defaultFilters,
@@ -98,19 +125,22 @@ describe('sqlHelpers', () => {
             }, false, 'blur', []);
 
             expect(loraName).toBeUndefined();
-            expect(where).toContain("il.lora_name = ? COLLATE NOCASE) OR EXISTS");
+            expect(where).toContain("instr(il.lora_name, ' (')");
+            expect(where).toContain(") OR EXISTS");
             expect(params).toEqual(['Detailer-Style', 'detailer style']);
         });
 
         it('should use junction table for Embedding filters', () => {
             const { where, params } = buildSqlWhereClause({ ...defaultFilters, embeddings: ['EasyNegative'] }, false, 'blur', []);
-            expect(where).toContain("EXISTS (SELECT 1 FROM image_embeddings ie WHERE ie.image_id = id AND ie.embedding_name = ? COLLATE NOCASE)");
+            expect(where).toContain("EXISTS (SELECT 1 FROM image_embeddings ie WHERE ie.image_id = id AND (CASE");
+            expect(where).toContain("ie.embedding_name");
             expect(params).toEqual(['EasyNegative']);
         });
 
         it('should use junction table for Hypernetwork filters', () => {
             const { where, params } = buildSqlWhereClause({ ...defaultFilters, hypernetworks: ['HyperNet'] }, false, 'blur', []);
-            expect(where).toContain("EXISTS (SELECT 1 FROM image_hypernetworks ih WHERE ih.image_id = id AND ih.hypernetwork_name = ? COLLATE NOCASE)");
+            expect(where).toContain("EXISTS (SELECT 1 FROM image_hypernetworks ih WHERE ih.image_id = id AND (CASE");
+            expect(where).toContain("ih.hypernetwork_name");
             expect(params).toEqual(['HyperNet']);
         });
 
@@ -459,7 +489,8 @@ describe('sqlHelpers', () => {
                     }
                 }, false, 'blur', []);
 
-                expect(where).toContain('il.lora_name = ? COLLATE NOCASE) OR EXISTS');
+                expect(where).toContain("instr(il.lora_name, ' (')");
+                expect(where).toContain(') OR EXISTS');
                 expect(where).toContain(') AND EXISTS (');
                 expect(params).toEqual(['Detailer-Style', 'detailer style', 'PortraitBoost']);
             });

--- a/src/utils/sqlHelpers.ts
+++ b/src/utils/sqlHelpers.ts
@@ -17,6 +17,29 @@ interface SearchCondition {
 
 type AssetAliasFilterKey = 'models' | 'loras' | 'embeddings' | 'hypernetworks' | 'controlNets' | 'ipAdapters';
 
+export const normalizeResourceReferenceForFilter = (value: string): string => {
+    const trimmed = value.trim();
+    const weightIndex = trimmed.indexOf(' (');
+    if (weightIndex > 0) return trimmed.slice(0, weightIndex).trim();
+
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex > 0) return trimmed.slice(0, colonIndex).trim();
+
+    return trimmed;
+};
+
+export const resourceReferenceSql = (column: string): string => (
+    `CASE
+        WHEN instr(${column}, ' (') > 0 THEN trim(substr(${column}, 1, instr(${column}, ' (') - 1))
+        WHEN instr(${column}, ':') > 0 THEN trim(substr(${column}, 1, instr(${column}, ':') - 1))
+        ELSE trim(${column})
+    END`
+);
+
+export const resourceReferenceEqualsSql = (column: string): string => (
+    `(${resourceReferenceSql(column)}) COLLATE NOCASE = ?`
+);
+
 const uniqueValues = (values: string[]): string[] => {
     const result: string[] = [];
     const seen = new Set<string>();
@@ -40,6 +63,13 @@ const getAssetAliasGroups = (
 ): string[][] => selectedValues.map(value => (
     uniqueValues([value, ...(filters.assetFilterAliases?.[filterKey]?.[value] || [])])
 ));
+
+const getResourceAliasGroups = (
+    filters: FilterState,
+    filterKey: Exclude<AssetAliasFilterKey, 'models'>,
+    selectedValues: string[]
+): string[][] => getAssetAliasGroups(filters, filterKey, selectedValues)
+    .map(aliases => uniqueValues(aliases.map(normalizeResourceReferenceForFilter)));
 
 const buildAliasGroupCondition = (
     aliases: string[],
@@ -362,13 +392,13 @@ export const buildSqlWhereClause = (
     // LoRAs
     const loraMode = filters.matchModes?.loras || 'any';
     if (!excludeCategories.includes('loras')) {
-        const loraAliasGroups = getAssetAliasGroups(filters, 'loras', filters.loras);
+        const loraAliasGroups = getResourceAliasGroups(filters, 'loras', filters.loras);
         if (filters.loras.length === 1 && loraMode === 'any' && loraAliasGroups[0]?.length === 1) {
             // Handled by searchRepo
         } else if (filters.loras.length > 0) {
             const loraConditions = loraAliasGroups.map(aliases => (
                 buildAliasGroupCondition(aliases, () => (
-                    `EXISTS (SELECT 1 FROM image_loras il WHERE il.image_id = id AND il.lora_name = ? COLLATE NOCASE)`
+                    `EXISTS (SELECT 1 FROM image_loras il WHERE il.image_id = id AND ${resourceReferenceEqualsSql('il.lora_name')})`
                 ), params)
             ));
             conditions.push(`(${loraConditions.join(loraMode === 'all' ? ' AND ' : ' OR ')})`);
@@ -378,9 +408,9 @@ export const buildSqlWhereClause = (
     // Embeddings
     const embMode = filters.matchModes?.embeddings || 'any';
     if (filters.embeddings.length > 0 && !excludeCategories.includes('embeddings')) {
-        const embConditions = getAssetAliasGroups(filters, 'embeddings', filters.embeddings).map(aliases => (
+        const embConditions = getResourceAliasGroups(filters, 'embeddings', filters.embeddings).map(aliases => (
             buildAliasGroupCondition(aliases, () => (
-                `EXISTS (SELECT 1 FROM image_embeddings ie WHERE ie.image_id = id AND ie.embedding_name = ? COLLATE NOCASE)`
+                `EXISTS (SELECT 1 FROM image_embeddings ie WHERE ie.image_id = id AND ${resourceReferenceEqualsSql('ie.embedding_name')})`
             ), params)
         ));
         conditions.push(`(${embConditions.join(embMode === 'all' ? ' AND ' : ' OR ')})`);
@@ -389,9 +419,9 @@ export const buildSqlWhereClause = (
     // Hypernetworks
     const hnMode = filters.matchModes?.hypernetworks || 'any';
     if (filters.hypernetworks.length > 0 && !excludeCategories.includes('hypernetworks')) {
-        const hnConditions = getAssetAliasGroups(filters, 'hypernetworks', filters.hypernetworks).map(aliases => (
+        const hnConditions = getResourceAliasGroups(filters, 'hypernetworks', filters.hypernetworks).map(aliases => (
             buildAliasGroupCondition(aliases, () => (
-                `EXISTS (SELECT 1 FROM image_hypernetworks ih WHERE ih.image_id = id AND ih.hypernetwork_name = ? COLLATE NOCASE)`
+                `EXISTS (SELECT 1 FROM image_hypernetworks ih WHERE ih.image_id = id AND ${resourceReferenceEqualsSql('ih.hypernetwork_name')})`
             ), params)
         ));
         conditions.push(`(${hnConditions.join(hnMode === 'all' ? ' AND ' : ' OR ')})`);
@@ -400,9 +430,9 @@ export const buildSqlWhereClause = (
     // ControlNets
     const cnMode = filters.matchModes?.controlNets || 'any';
     if (filters.controlNets && filters.controlNets.length > 0 && !excludeCategories.includes('controlNets')) {
-        const cnConditions = getAssetAliasGroups(filters, 'controlNets', filters.controlNets).map(aliases => (
+        const cnConditions = getResourceAliasGroups(filters, 'controlNets', filters.controlNets).map(aliases => (
             buildAliasGroupCondition(aliases, () => (
-                `EXISTS (SELECT 1 FROM image_controlnets cn WHERE cn.image_id = id AND cn.controlnet_name = ? COLLATE NOCASE)`
+                `EXISTS (SELECT 1 FROM image_controlnets cn WHERE cn.image_id = id AND ${resourceReferenceEqualsSql('cn.controlnet_name')})`
             ), params)
         ));
         conditions.push(`(${cnConditions.join(cnMode === 'all' ? ' AND ' : ' OR ')})`);
@@ -411,9 +441,9 @@ export const buildSqlWhereClause = (
     // IP-Adapters
     const ipMode = filters.matchModes?.ipAdapters || 'any';
     if (filters.ipAdapters && filters.ipAdapters.length > 0 && !excludeCategories.includes('ipAdapters')) {
-        const ipConditions = getAssetAliasGroups(filters, 'ipAdapters', filters.ipAdapters).map(aliases => (
+        const ipConditions = getResourceAliasGroups(filters, 'ipAdapters', filters.ipAdapters).map(aliases => (
             buildAliasGroupCondition(aliases, () => (
-                `EXISTS (SELECT 1 FROM image_ipadapters ip WHERE ip.image_id = id AND ip.ipadapter_name = ? COLLATE NOCASE)`
+                `EXISTS (SELECT 1 FROM image_ipadapters ip WHERE ip.image_id = id AND ${resourceReferenceEqualsSql('ip.ipadapter_name')})`
             ), params)
         ));
         conditions.push(`(${ipConditions.join(ipMode === 'all' ? ' AND ' : ' OR ')})`);
@@ -478,7 +508,7 @@ export const buildSqlWhereClause = (
 
     const loraModeCheck = filters.matchModes?.loras || 'any';
     const loraExcluded = excludeCategories.includes('loras');
-    const singleLoraAliasGroups = getAssetAliasGroups(filters, 'loras', filters.loras);
+    const singleLoraAliasGroups = getResourceAliasGroups(filters, 'loras', filters.loras);
     const singleLoraName = (!loraExcluded && filters.loras.length === 1 && loraModeCheck === 'any' && singleLoraAliasGroups[0]?.length === 1)
         ? singleLoraAliasGroups[0][0]
         : undefined;


### PR DESCRIPTION
## Summary
- Rebuild parser-derived facet caches after metadata reparse updates records, including cancelled refreshes with partial updates.
- Canonicalize resource filters so weighted references such as `detail___add_detail (0.20)` match the displayed canonical facet.
- Add migration 59 with expression indexes so canonical resource filtering stays fast on large libraries.

## Root Cause
Automatic metadata reparse could update resource junction rows without refreshing facet caches, leaving the Assets sidebar stale. Separately, canonical facet names could disagree with exact gallery filtering when resource rows retained weight suffixes.

## Validation
- `cargo test canonical_resource`
- `cargo test parameter_scope_uses_bound_values_for_collection_and_lora`
- `cargo test test_valid_facet_names_lora_filter_matches_weighted_resource_reference`
- `corepack pnpm run test:run -- src/utils/__tests__/sqlHelpers.test.ts src/services/db/__tests__/searchRepo.test.ts src/hooks/__tests__/useMetadataRefresh.test.tsx`
- `corepack pnpm run typecheck`
- `git diff --check`

Note: `cargo fmt --check` could not run because `rustfmt` is not installed for toolchain `1.96.0-x86_64-pc-windows-msvc`.