### PR TITLE
fix: correct resource asset inventory

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/db/migrations/m60_resource_inventory_cleanup.rs
+++ b/src-tauri/src/db/migrations/m60_resource_inventory_cleanup.rs
@@ -1,0 +1,525 @@
+use tauri_plugin_sql::{Migration, MigrationKind};
+
+/// Migration 60: Clean up disk-scanned resource inventory.
+///
+/// Earlier disk scans classified every unknown model-looking file as a
+/// checkpoint, and broad substring matching split IP-adapters/control models
+/// across the wrong resource sections. This is a data cleanup only: image
+/// metadata and embedded raw metadata stay untouched.
+pub fn migration60() -> Migration {
+    Migration {
+        version: 60,
+        description: "cleanup_disk_resource_inventory",
+        sql: r#"
+            DROP TABLE IF EXISTS resource_inventory_paths;
+            CREATE TEMP TABLE resource_inventory_paths AS
+                SELECT
+                    m.hash,
+                    lower(replace(substr(m.hash, 6), char(92), '/')) AS canonical_path,
+                    '/' || lower(replace(substr(m.hash, 6), char(92), '/')) || '/' AS path_key
+                FROM models m
+                WHERE m.lookup_source = 'disk_scan'
+                  AND m.hash LIKE 'file:%';
+
+            DROP TABLE IF EXISTS resource_inventory_unsupported;
+            CREATE TEMP TABLE resource_inventory_unsupported AS
+                SELECT hash
+                FROM resource_inventory_paths
+                WHERE path_key NOT LIKE '%/lora/%'
+                  AND path_key NOT LIKE '%/loras/%'
+                  AND (
+                    path_key LIKE '%/vae/%'
+                    OR path_key LIKE '%/vae_approx/%'
+                    OR path_key LIKE '%/clip/%'
+                    OR path_key LIKE '%/clip_vision/%'
+                    OR path_key LIKE '%/text_encoder/%'
+                    OR path_key LIKE '%/text_encoders/%'
+                    OR path_key LIKE '%/upscale_model/%'
+                    OR path_key LIKE '%/upscale_models/%'
+                    OR path_key LIKE '%/upscaler/%'
+                    OR path_key LIKE '%/upscalers/%'
+                    OR path_key LIKE '%/ultralytics/%'
+                    OR path_key LIKE '%/detector/%'
+                    OR path_key LIKE '%/detectors/%'
+                    OR path_key LIKE '%/bbox/%'
+                    OR path_key LIKE '%/segm/%'
+                    OR path_key LIKE '%/sam/%'
+                    OR path_key LIKE '%/caption/%'
+                    OR path_key LIKE '%/captions/%'
+                    OR path_key LIKE '%/caption_models/%'
+                    OR path_key LIKE '%/joy_caption/%'
+                    OR path_key LIKE '%/wd14_tagger/%'
+                    OR path_key LIKE '%/insightface/%'
+                  );
+
+            DELETE FROM facet_cache
+            WHERE IFNULL(count, 0) = 0
+              AND resource_hash IN (SELECT hash FROM resource_inventory_unsupported);
+
+            DELETE FROM models
+            WHERE lookup_source = 'disk_scan'
+              AND hash IN (SELECT hash FROM resource_inventory_unsupported);
+
+            DELETE FROM scanned_files
+            WHERE hash IN (SELECT hash FROM resource_inventory_unsupported)
+              AND NOT EXISTS (
+                SELECT 1 FROM models m WHERE m.hash = scanned_files.hash
+              );
+
+            DROP TABLE IF EXISTS resource_inventory_ipadapters;
+            CREATE TEMP TABLE resource_inventory_ipadapters AS
+                SELECT p.hash
+                FROM resource_inventory_paths p
+                JOIN models m ON m.hash = p.hash
+                WHERE m.lookup_source = 'disk_scan'
+                  AND p.path_key NOT LIKE '%/lora/%'
+                  AND p.path_key NOT LIKE '%/loras/%'
+                  AND (
+                    p.path_key LIKE '%ipadapter%'
+                    OR p.path_key LIKE '%ip-adapter%'
+                    OR p.path_key LIKE '%ip_adapter%'
+                    OR p.path_key LIKE '%ipadapters%'
+                  );
+
+            DELETE FROM facet_cache
+            WHERE resource_hash IN (SELECT hash FROM resource_inventory_ipadapters)
+              AND facet_type != 'ip_adapters'
+              AND EXISTS (
+                SELECT 1
+                FROM facet_cache target
+                WHERE target.facet_type = 'ip_adapters'
+                  AND target.resource_name = facet_cache.resource_name
+              );
+
+            UPDATE facet_cache
+            SET facet_type = 'ip_adapters'
+            WHERE resource_hash IN (SELECT hash FROM resource_inventory_ipadapters);
+
+            UPDATE models
+            SET resource_type = 'ip_adapters'
+            WHERE hash IN (SELECT hash FROM resource_inventory_ipadapters);
+
+            DROP TABLE IF EXISTS resource_inventory_controlnets;
+            CREATE TEMP TABLE resource_inventory_controlnets AS
+                SELECT p.hash
+                FROM resource_inventory_paths p
+                JOIN models m ON m.hash = p.hash
+                WHERE m.lookup_source = 'disk_scan'
+                  AND p.path_key NOT LIKE '%/lora/%'
+                  AND p.path_key NOT LIKE '%/loras/%'
+                  AND p.hash NOT IN (SELECT hash FROM resource_inventory_ipadapters)
+                  AND (
+                    p.path_key LIKE '%/controlnet/%'
+                    OR p.path_key LIKE '%/control_net/%'
+                    OR p.path_key LIKE '%/control-nets/%'
+                    OR p.path_key LIKE '%/controlnets/%'
+                    OR p.path_key LIKE '%/control_nets/%'
+                    OR p.path_key LIKE '%/t2i_adapter/%'
+                    OR p.path_key LIKE '%/t2i-adapter/%'
+                  );
+
+            DELETE FROM facet_cache
+            WHERE resource_hash IN (SELECT hash FROM resource_inventory_controlnets)
+              AND facet_type != 'control_nets'
+              AND EXISTS (
+                SELECT 1
+                FROM facet_cache target
+                WHERE target.facet_type = 'control_nets'
+                  AND target.resource_name = facet_cache.resource_name
+              );
+
+            UPDATE facet_cache
+            SET facet_type = 'control_nets'
+            WHERE resource_hash IN (SELECT hash FROM resource_inventory_controlnets);
+
+            UPDATE models
+            SET resource_type = 'control_nets'
+            WHERE hash IN (SELECT hash FROM resource_inventory_controlnets);
+
+            DROP TABLE IF EXISTS resource_inventory_ranked;
+            CREATE TEMP TABLE resource_inventory_ranked AS
+                SELECT
+                    p.hash,
+                    FIRST_VALUE(p.hash) OVER (
+                        PARTITION BY p.canonical_path, COALESCE(m.resource_type, '')
+                        ORDER BY
+                            CASE
+                                WHEN NULLIF(m.thumbnail_path, '') IS NOT NULL
+                                  OR NULLIF(m.sidecar_thumbnail_path, '') IS NOT NULL
+                                  OR NULLIF(m.preview_url, '') IS NOT NULL
+                                  OR NULLIF(m.thumbnail_mode, '') IS NOT NULL
+                                  OR m.thumbnail_sensitivity_override IS NOT NULL
+                                  OR NULLIF(m.guidance_category, '') IS NOT NULL
+                                  OR NULLIF(m.guidance_subtype, '') IS NOT NULL
+                                THEN 0 ELSE 1
+                            END,
+                            CASE WHEN instr(substr(p.hash, 6), '/') > 0 THEN 0 ELSE 1 END,
+                            p.hash
+                    ) AS keep_hash,
+                    COUNT(*) OVER (
+                        PARTITION BY p.canonical_path, COALESCE(m.resource_type, '')
+                    ) AS duplicate_count
+                FROM resource_inventory_paths p
+                JOIN models m ON m.hash = p.hash
+                WHERE m.lookup_source = 'disk_scan';
+
+            DROP TABLE IF EXISTS resource_inventory_duplicates;
+            CREATE TEMP TABLE resource_inventory_duplicates AS
+                SELECT hash AS delete_hash, keep_hash
+                FROM resource_inventory_ranked
+                WHERE duplicate_count > 1
+                  AND hash != keep_hash;
+
+            UPDATE models
+            SET
+                thumbnail_path = COALESCE(
+                    NULLIF(thumbnail_path, ''),
+                    (
+                        SELECT NULLIF(d.thumbnail_path, '')
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND NULLIF(d.thumbnail_path, '') IS NOT NULL
+                        LIMIT 1
+                    )
+                ),
+                sidecar_thumbnail_path = COALESCE(
+                    NULLIF(sidecar_thumbnail_path, ''),
+                    (
+                        SELECT NULLIF(d.sidecar_thumbnail_path, '')
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND NULLIF(d.sidecar_thumbnail_path, '') IS NOT NULL
+                        LIMIT 1
+                    )
+                ),
+                preview_url = COALESCE(
+                    NULLIF(preview_url, ''),
+                    (
+                        SELECT NULLIF(d.preview_url, '')
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND NULLIF(d.preview_url, '') IS NOT NULL
+                        LIMIT 1
+                    )
+                ),
+                thumbnail_mode = COALESCE(
+                    NULLIF(thumbnail_mode, ''),
+                    (
+                        SELECT NULLIF(d.thumbnail_mode, '')
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND NULLIF(d.thumbnail_mode, '') IS NOT NULL
+                        LIMIT 1
+                    )
+                ),
+                thumbnail_sensitivity_override = COALESCE(
+                    thumbnail_sensitivity_override,
+                    (
+                        SELECT d.thumbnail_sensitivity_override
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND d.thumbnail_sensitivity_override IS NOT NULL
+                        LIMIT 1
+                    )
+                ),
+                guidance_category = COALESCE(
+                    NULLIF(guidance_category, ''),
+                    (
+                        SELECT NULLIF(d.guidance_category, '')
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND NULLIF(d.guidance_category, '') IS NOT NULL
+                        LIMIT 1
+                    )
+                ),
+                guidance_subtype = COALESCE(
+                    NULLIF(guidance_subtype, ''),
+                    (
+                        SELECT NULLIF(d.guidance_subtype, '')
+                        FROM models d
+                        JOIN resource_inventory_duplicates dup ON dup.delete_hash = d.hash
+                        WHERE dup.keep_hash = models.hash
+                          AND NULLIF(d.guidance_subtype, '') IS NOT NULL
+                        LIMIT 1
+                    )
+                )
+            WHERE hash IN (
+                SELECT DISTINCT keep_hash FROM resource_inventory_duplicates
+            );
+
+            UPDATE facet_cache
+            SET resource_hash = (
+                SELECT dup.keep_hash
+                FROM resource_inventory_duplicates dup
+                WHERE dup.delete_hash = facet_cache.resource_hash
+            )
+            WHERE resource_hash IN (
+                SELECT delete_hash FROM resource_inventory_duplicates
+            );
+
+            DELETE FROM models
+            WHERE hash IN (
+                SELECT delete_hash FROM resource_inventory_duplicates
+            );
+
+            DELETE FROM scanned_files
+            WHERE hash IN (
+                SELECT delete_hash FROM resource_inventory_duplicates
+            )
+              AND NOT EXISTS (
+                SELECT 1 FROM models m WHERE m.hash = scanned_files.hash
+              );
+
+            DROP TABLE IF EXISTS resource_inventory_duplicates;
+            DROP TABLE IF EXISTS resource_inventory_ranked;
+            DROP TABLE IF EXISTS resource_inventory_controlnets;
+            DROP TABLE IF EXISTS resource_inventory_ipadapters;
+            DROP TABLE IF EXISTS resource_inventory_unsupported;
+            DROP TABLE IF EXISTS resource_inventory_paths;
+
+            ANALYZE models;
+            ANALYZE facet_cache;
+        "#,
+        kind: MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration60;
+
+    fn setup_conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE models (
+                hash TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                filename TEXT,
+                lookup_source TEXT,
+                civitai_version_id INTEGER,
+                scanned_at INTEGER,
+                thumbnail_path TEXT,
+                preview_url TEXT,
+                resource_type TEXT,
+                guidance_category TEXT,
+                guidance_subtype TEXT,
+                sidecar_thumbnail_path TEXT,
+                thumbnail_mode TEXT,
+                thumbnail_sensitivity_override INTEGER
+            );
+
+            CREATE TABLE scanned_files (
+                path TEXT PRIMARY KEY,
+                size INTEGER,
+                modified INTEGER,
+                hash TEXT
+            );
+
+            CREATE TABLE facet_cache (
+                facet_type TEXT NOT NULL,
+                resource_name TEXT NOT NULL,
+                resource_hash TEXT,
+                count INTEGER DEFAULT 0,
+                thumbnail_path TEXT,
+                preview_url TEXT,
+                last_used_at INTEGER,
+                created_at INTEGER,
+                is_manual INTEGER DEFAULT 0,
+                has_sidecar INTEGER DEFAULT 0,
+                is_user_override INTEGER DEFAULT 0,
+                guidance_subtype TEXT,
+                safe_thumbnail_path TEXT,
+                thumbnail_image_id TEXT,
+                thumbnail_is_sensitive INTEGER DEFAULT 0,
+                thumbnail_sensitivity_override INTEGER,
+                PRIMARY KEY (facet_type, resource_name)
+            );
+            "#,
+        )
+        .expect("create test schema");
+        conn
+    }
+
+    fn insert_disk_model(conn: &rusqlite::Connection, path: &str, name: &str, resource_type: &str) {
+        let hash = format!("file:{path}");
+        conn.execute(
+            "INSERT INTO models (hash, name, filename, lookup_source, scanned_at, resource_type)
+             VALUES (?1, ?2, ?3, 'disk_scan', 100, ?4)",
+            rusqlite::params![hash, name, format!("{name}.safetensors"), resource_type],
+        )
+        .expect("insert model");
+        conn.execute(
+            "INSERT INTO scanned_files (path, size, modified, hash)
+             VALUES (?1, 10, 20, ?2)",
+            rusqlite::params![path, hash],
+        )
+        .expect("insert scanned file");
+    }
+
+    fn insert_zero_count_facet(
+        conn: &rusqlite::Connection,
+        facet_type: &str,
+        name: &str,
+        hash: &str,
+    ) {
+        conn.execute(
+            "INSERT INTO facet_cache (facet_type, resource_name, resource_hash, count)
+             VALUES (?1, ?2, ?3, 0)",
+            rusqlite::params![facet_type, name, hash],
+        )
+        .expect("insert facet row");
+    }
+
+    #[test]
+    fn migration_removes_unsupported_checkpoint_pollution() {
+        let conn = setup_conn();
+        let vae_path = "C:/ComfyUI/models/vae/sdxl_vae.safetensors";
+        let vae_hash = format!("file:{vae_path}");
+        insert_disk_model(&conn, vae_path, "sdxl_vae", "checkpoint");
+        insert_zero_count_facet(&conn, "checkpoints", "sdxl_vae", &vae_hash);
+
+        conn.execute_batch(migration60().sql)
+            .expect("apply migration");
+
+        let model_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM models", [], |row| row.get(0))
+            .expect("count models");
+        let facet_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM facet_cache", [], |row| row.get(0))
+            .expect("count facets");
+        let scanned_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM scanned_files", [], |row| row.get(0))
+            .expect("count scanned files");
+
+        assert_eq!(model_count, 0);
+        assert_eq!(facet_count, 0);
+        assert_eq!(scanned_count, 0);
+    }
+
+    #[test]
+    fn migration_reclassifies_ip_adapters_and_control_models_without_touching_lora_variants() {
+        let conn = setup_conn();
+        let ip_path = "C:/ComfyUI/models/controlnet/ip-adapter-faceid.safetensors";
+        let ip_hash = format!("file:{ip_path}");
+        let control_lora_path = "C:/ComfyUI/models/controlnet/control-lora-canny.safetensors";
+        let control_lora_hash = format!("file:{control_lora_path}");
+        let lora_ip_path = "C:/ComfyUI/models/loras/ip-adapter-faceid-lora.safetensors";
+        let lora_ip_hash = format!("file:{lora_ip_path}");
+
+        insert_disk_model(&conn, ip_path, "ip-adapter-faceid", "control_nets");
+        insert_zero_count_facet(&conn, "control_nets", "ip-adapter-faceid", &ip_hash);
+        insert_disk_model(&conn, control_lora_path, "control-lora-canny", "loras");
+        insert_zero_count_facet(&conn, "loras", "control-lora-canny", &control_lora_hash);
+        insert_disk_model(&conn, lora_ip_path, "ip-adapter-faceid-lora", "loras");
+        insert_zero_count_facet(&conn, "loras", "ip-adapter-faceid-lora", &lora_ip_hash);
+
+        conn.execute_batch(migration60().sql)
+            .expect("apply migration");
+
+        let ip_type: String = conn
+            .query_row(
+                "SELECT resource_type FROM models WHERE hash = ?1",
+                [&ip_hash],
+                |row| row.get(0),
+            )
+            .expect("ip resource type");
+        let ip_facet: String = conn
+            .query_row(
+                "SELECT facet_type FROM facet_cache WHERE resource_hash = ?1",
+                [&ip_hash],
+                |row| row.get(0),
+            )
+            .expect("ip facet type");
+        let control_type: String = conn
+            .query_row(
+                "SELECT resource_type FROM models WHERE hash = ?1",
+                [&control_lora_hash],
+                |row| row.get(0),
+            )
+            .expect("control resource type");
+        let lora_type: String = conn
+            .query_row(
+                "SELECT resource_type FROM models WHERE hash = ?1",
+                [&lora_ip_hash],
+                |row| row.get(0),
+            )
+            .expect("lora resource type");
+
+        assert_eq!(ip_type, "ip_adapters");
+        assert_eq!(ip_facet, "ip_adapters");
+        assert_eq!(control_type, "control_nets");
+        assert_eq!(lora_type, "loras");
+    }
+
+    #[test]
+    fn migration_collapses_slash_variant_disk_rows_and_preserves_customization() {
+        let conn = setup_conn();
+        let first_path = "D:/AI/models/loras/Detailer.safetensors";
+        let second_path = "D:/AI/models\\loras\\Detailer.safetensors";
+        let first_hash = format!("file:{first_path}");
+        let second_hash = format!("file:{second_path}");
+
+        insert_disk_model(&conn, first_path, "Detailer", "loras");
+        insert_disk_model(&conn, second_path, "Detailer", "loras");
+        conn.execute(
+            "UPDATE models
+             SET thumbnail_path = 'C:/thumbs/detailer.webp',
+                 sidecar_thumbnail_path = 'D:/AI/models/loras/Detailer.preview.png',
+                 thumbnail_sensitivity_override = 1
+             WHERE hash = ?1",
+            [&second_hash],
+        )
+        .expect("customize duplicate");
+        insert_zero_count_facet(&conn, "loras", "Detailer", &second_hash);
+
+        conn.execute_batch(migration60().sql)
+            .expect("apply migration");
+
+        let rows: Vec<(String, Option<String>, Option<String>, Option<i64>)> = conn
+            .prepare(
+                "SELECT hash, thumbnail_path, sidecar_thumbnail_path, thumbnail_sensitivity_override
+                 FROM models WHERE name = 'Detailer'",
+            )
+            .expect("prepare detailer query")
+            .query_map([], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })
+            .expect("query detailer rows")
+            .collect::<Result<_, _>>()
+            .expect("collect detailer rows");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].1.as_deref(), Some("C:/thumbs/detailer.webp"));
+        assert_eq!(
+            rows[0].2.as_deref(),
+            Some("D:/AI/models/loras/Detailer.preview.png")
+        );
+        assert_eq!(rows[0].3, Some(1));
+
+        let facet_hash: String = conn
+            .query_row(
+                "SELECT resource_hash FROM facet_cache WHERE facet_type = 'loras' AND resource_name = 'Detailer'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("facet hash");
+        assert_eq!(facet_hash, rows[0].0);
+
+        let scanned_hashes: Vec<String> = conn
+            .prepare("SELECT hash FROM scanned_files ORDER BY hash")
+            .expect("prepare scanned query")
+            .query_map([], |row| row.get(0))
+            .expect("query scanned rows")
+            .collect::<Result<_, _>>()
+            .expect("collect scanned rows");
+        assert_eq!(scanned_hashes, vec![rows[0].0.clone()]);
+        assert!(rows[0].0 == first_hash || rows[0].0 == second_hash);
+    }
+}

--- a/src-tauri/src/db/migrations/m61_auxiliary_resource_inventory_cleanup.rs
+++ b/src-tauri/src/db/migrations/m61_auxiliary_resource_inventory_cleanup.rs
@@ -1,0 +1,250 @@
+use tauri_plugin_sql::{Migration, MigrationKind};
+
+/// Migration 61: Remove additional auxiliary model files from Assets inventory.
+///
+/// Migration 60 removed the first wave of unsupported disk-scan rows, but real
+/// ComfyUI libraries also store face restore, upscaler, caption/VLM, LLM, and
+/// similar utility models in folders whose filenames look checkpoint-like.
+/// Those rows should not appear as local-only checkpoints.
+pub fn migration61() -> Migration {
+    Migration {
+        version: 61,
+        description: "cleanup_auxiliary_resource_inventory",
+        sql: r#"
+            DROP TABLE IF EXISTS auxiliary_resource_inventory_paths;
+            CREATE TEMP TABLE auxiliary_resource_inventory_paths AS
+                SELECT
+                    m.hash,
+                    '/' || lower(replace(substr(m.hash, 6), char(92), '/')) || '/' AS path_key
+                FROM models m
+                WHERE m.lookup_source = 'disk_scan'
+                  AND m.hash LIKE 'file:%';
+
+            DROP TABLE IF EXISTS auxiliary_resource_inventory_unsupported;
+            CREATE TEMP TABLE auxiliary_resource_inventory_unsupported AS
+                SELECT hash
+                FROM auxiliary_resource_inventory_paths
+                WHERE path_key NOT LIKE '%/lora/%'
+                  AND path_key NOT LIKE '%/loras/%'
+                  AND (
+                    path_key LIKE '%/facedetection/%'
+                    OR path_key LIKE '%/face_detection/%'
+                    OR path_key LIKE '%/facerestore/%'
+                    OR path_key LIKE '%/face_restore/%'
+                    OR path_key LIKE '%/florence2/%'
+                    OR path_key LIKE '%/florence-2/%'
+                    OR path_key LIKE '%/florence_2/%'
+                    OR path_key LIKE '%/gfpgan/%'
+                    OR path_key LIKE '%/ldsr/%'
+                    OR path_key LIKE '%/llm/%'
+                    OR path_key LIKE '%/omnisr/%'
+                    OR path_key LIKE '%/pulid/%'
+                    OR path_key LIKE '%/realesrgan/%'
+                    OR path_key LIKE '%/real-esrgan/%'
+                    OR path_key LIKE '%/real_esrgan/%'
+                    OR path_key LIKE '%/sams/%'
+                    OR path_key LIKE '%/seedvr2/%'
+                    OR path_key LIKE '%/swinir/%'
+                    OR path_key LIKE '%/t2iadapter/%'
+                  );
+
+            DELETE FROM facet_cache
+            WHERE IFNULL(count, 0) = 0
+              AND resource_hash IN (SELECT hash FROM auxiliary_resource_inventory_unsupported);
+
+            DELETE FROM models
+            WHERE lookup_source = 'disk_scan'
+              AND hash IN (SELECT hash FROM auxiliary_resource_inventory_unsupported);
+
+            DELETE FROM scanned_files
+            WHERE hash IN (SELECT hash FROM auxiliary_resource_inventory_unsupported)
+              AND NOT EXISTS (
+                SELECT 1 FROM models m WHERE m.hash = scanned_files.hash
+              );
+
+            DROP TABLE IF EXISTS auxiliary_resource_inventory_unsupported;
+            DROP TABLE IF EXISTS auxiliary_resource_inventory_paths;
+
+            ANALYZE models;
+            ANALYZE facet_cache;
+        "#,
+        kind: MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration61;
+
+    fn setup_conn() -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE models (
+                hash TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                filename TEXT,
+                lookup_source TEXT,
+                civitai_version_id INTEGER,
+                scanned_at INTEGER,
+                thumbnail_path TEXT,
+                preview_url TEXT,
+                resource_type TEXT
+            );
+
+            CREATE TABLE scanned_files (
+                path TEXT PRIMARY KEY,
+                size INTEGER,
+                modified INTEGER,
+                hash TEXT
+            );
+
+            CREATE TABLE facet_cache (
+                facet_type TEXT NOT NULL,
+                resource_name TEXT NOT NULL,
+                resource_hash TEXT,
+                count INTEGER DEFAULT 0,
+                PRIMARY KEY (facet_type, resource_name)
+            );
+            "#,
+        )
+        .expect("create test schema");
+        conn
+    }
+
+    fn insert_disk_model(conn: &rusqlite::Connection, path: &str, name: &str, resource_type: &str) {
+        let hash = format!("file:{path}");
+        conn.execute(
+            "INSERT INTO models (hash, name, filename, lookup_source, scanned_at, resource_type)
+             VALUES (?1, ?2, ?3, 'disk_scan', 100, ?4)",
+            rusqlite::params![hash, name, format!("{name}.safetensors"), resource_type],
+        )
+        .expect("insert model");
+        conn.execute(
+            "INSERT INTO scanned_files (path, size, modified, hash)
+             VALUES (?1, 10, 20, ?2)",
+            rusqlite::params![path, hash],
+        )
+        .expect("insert scanned file");
+        conn.execute(
+            "INSERT INTO facet_cache (facet_type, resource_name, resource_hash, count)
+             VALUES (?1, ?2, ?3, 0)",
+            rusqlite::params![
+                if resource_type == "checkpoint" {
+                    "checkpoints"
+                } else {
+                    resource_type
+                },
+                name,
+                hash
+            ],
+        )
+        .expect("insert facet row");
+    }
+
+    #[test]
+    fn migration_removes_additional_auxiliary_checkpoint_pollution() {
+        let conn = setup_conn();
+        let unsupported = [
+            (
+                "D:/AI/models/facerestore/GFPGANv1.4.pth",
+                "GFPGANv1.4",
+            ),
+            (
+                "D:/AI/models/facedetection/detection_mobilenet0.25_Final.pth",
+                "detection_mobilenet0.25_Final",
+            ),
+            (
+                "D:/AI/models/RealESRGAN/RealESRGAN_x4plus.pth",
+                "RealESRGAN_x4plus",
+            ),
+            ("D:/AI/models/SwinIR/SwinIR_4x.pth", "SwinIR_4x"),
+            (
+                "D:/AI/models/LLM/LLaVA/model-00001-of-00004.safetensors",
+                "model-00001-of-00004",
+            ),
+            (
+                "D:/AI/models/florence2/base/pytorch_model.bin",
+                "pytorch_model",
+            ),
+            (
+                "D:/AI/models/T2IAdapter/t2i-adapter-canny-sdxl-1.0/diffusion_pytorch_model.safetensors",
+                "diffusion_pytorch_model",
+            ),
+            ("D:/AI/models/pulid/pulid_flux_v0.9.1.safetensors", "pulid_flux_v0.9.1"),
+            ("D:/AI/models/sams/sam_hq_vit_b.pth", "sam_hq_vit_b"),
+            (
+                "D:/AI/models/SEEDVR2/ema_vae_fp16.safetensors",
+                "ema_vae_fp16",
+            ),
+        ];
+
+        for (path, name) in unsupported {
+            insert_disk_model(&conn, path, name, "checkpoint");
+        }
+        insert_disk_model(
+            &conn,
+            "D:/AI/models/checkpoints/real_checkpoint.safetensors",
+            "real_checkpoint",
+            "checkpoint",
+        );
+        insert_disk_model(
+            &conn,
+            "D:/AI/models/loras/real_lora.safetensors",
+            "real_lora",
+            "loras",
+        );
+
+        conn.execute_batch(migration61().sql)
+            .expect("apply migration");
+
+        let disk_rows: Vec<String> = conn
+            .prepare("SELECT name FROM models ORDER BY name")
+            .expect("prepare model query")
+            .query_map([], |row| row.get(0))
+            .expect("query models")
+            .collect::<Result<_, _>>()
+            .expect("collect models");
+
+        assert_eq!(disk_rows, vec!["real_checkpoint", "real_lora"]);
+
+        let facet_rows: Vec<String> = conn
+            .prepare("SELECT resource_name FROM facet_cache ORDER BY resource_name")
+            .expect("prepare facet query")
+            .query_map([], |row| row.get(0))
+            .expect("query facets")
+            .collect::<Result<_, _>>()
+            .expect("collect facets");
+
+        assert_eq!(facet_rows, vec!["real_checkpoint", "real_lora"]);
+
+        let scanned_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM scanned_files", [], |row| row.get(0))
+            .expect("count scanned files");
+        assert_eq!(scanned_count, 2);
+    }
+
+    #[test]
+    fn migration_preserves_lora_assets_inside_matching_auxiliary_names() {
+        let conn = setup_conn();
+        insert_disk_model(
+            &conn,
+            "D:/AI/models/loras/facerestore_style.safetensors",
+            "facerestore_style",
+            "loras",
+        );
+
+        conn.execute_batch(migration61().sql)
+            .expect("apply migration");
+
+        let model_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM models", [], |row| row.get(0))
+            .expect("count models");
+        let facet_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM facet_cache", [], |row| row.get(0))
+            .expect("count facets");
+
+        assert_eq!(model_count, 1);
+        assert_eq!(facet_count, 1);
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -26,6 +26,8 @@ pub mod m56_thumbnail_optimization;
 pub mod m57_collection_thumbnail_cache;
 pub mod m58_nullable_seed;
 pub mod m59_canonical_resource_lookup_indexes;
+pub mod m60_resource_inventory_cleanup;
+pub mod m61_auxiliary_resource_inventory_cleanup;
 
 pub fn init_db() -> Vec<Migration> {
     get_migrations()
@@ -61,6 +63,8 @@ pub fn get_migrations() -> Vec<Migration> {
     migrations.push(m57_collection_thumbnail_cache::migration57());
     migrations.push(m58_nullable_seed::migration58());
     migrations.push(m59_canonical_resource_lookup_indexes::migration59());
+    migrations.push(m60_resource_inventory_cleanup::migration60());
+    migrations.push(m61_auxiliary_resource_inventory_cleanup::migration61());
 
     migrations.sort_by_key(|m| m.version);
 
@@ -72,7 +76,7 @@ mod tests {
     use super::get_migrations;
 
     #[test]
-    fn migrations_include_mainline_through_canonical_resource_indexes_59() {
+    fn migrations_include_mainline_through_auxiliary_resource_inventory_cleanup_61() {
         let versions: Vec<i64> = get_migrations()
             .iter()
             .map(|migration| migration.version)
@@ -89,6 +93,8 @@ mod tests {
         assert!(versions.contains(&57));
         assert!(versions.contains(&58));
         assert!(versions.contains(&59));
+        assert!(versions.contains(&60));
+        assert!(versions.contains(&61));
     }
 
     #[test]
@@ -114,7 +120,7 @@ mod tests {
     }
 
     #[test]
-    fn database_at_mainline_49_has_migrations_through_canonical_resource_indexes_59_pending() {
+    fn database_at_mainline_49_has_migrations_through_auxiliary_resource_inventory_cleanup_61_pending() {
         let migrations = get_migrations();
         let has_49 = migrations.iter().any(|migration| migration.version == 49);
         let pending_after_49: Vec<i64> = migrations
@@ -124,6 +130,9 @@ mod tests {
             .collect();
 
         assert!(has_49);
-        assert_eq!(pending_after_49, vec![50, 51, 52, 53, 54, 55, 56, 57, 58, 59]);
+        assert_eq!(
+            pending_after_49,
+            vec![50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61]
+        );
     }
 }

--- a/src-tauri/src/metadata/thumbs_scan.rs
+++ b/src-tauri/src/metadata/thumbs_scan.rs
@@ -80,6 +80,7 @@ fn resource_count_detail(found: usize, updated: usize) -> String {
 struct ModelRegistrationOutcome {
     cached: bool,
     registered_models: usize,
+    skipped: bool,
     filename: String,
     hash: String,
 }
@@ -125,7 +126,15 @@ fn register_discovered_model_file(
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("");
-    let resource_type = resource_type_for_model_path(model_path);
+    let Some(resource_type) = resource_type_for_model_path(model_path) else {
+        return Ok(ModelRegistrationOutcome {
+            cached: false,
+            registered_models: 0,
+            skipped: true,
+            filename,
+            hash: String::new(),
+        });
+    };
 
     touch_resource(touched_resources, resource_type, stem);
 
@@ -173,6 +182,7 @@ fn register_discovered_model_file(
     Ok(ModelRegistrationOutcome {
         cached,
         registered_models,
+        skipped: false,
         filename,
         hash,
     })
@@ -231,29 +241,130 @@ fn truncate_middle(value: &str, max_chars: usize) -> String {
     format!("{start}...{end}")
 }
 
-fn resource_type_for_model_path(model_path: &str) -> &'static str {
-    let path_lower = model_path.to_lowercase();
-    if path_lower.contains("lora") {
-        "loras"
-    } else if path_lower.contains("embedding") || path_lower.contains("textual_inversion") {
-        "embeddings"
-    } else if path_lower.contains("hypernetwork") {
-        "hypernetworks"
-    } else if path_lower.contains("controlnet")
-        || path_lower.contains("control_net")
-        || path_lower.contains("control-nets")
-        || path_lower.contains("controlnets")
-    {
-        "control_nets"
-    } else if path_lower.contains("ipadapter")
-        || path_lower.contains("ip-adapter")
-        || path_lower.contains("ip_adapter")
-        || path_lower.contains("ipadapters")
-    {
-        "ip_adapters"
-    } else {
-        "checkpoint"
+fn normalized_model_path_parts(model_path: &str) -> (String, Vec<String>) {
+    let normalized = model_path.replace('\\', "/").to_lowercase();
+    let parts = normalized
+        .split('/')
+        .filter(|part| !part.trim().is_empty())
+        .map(ToString::to_string)
+        .collect();
+    (normalized, parts)
+}
+
+fn path_has_segment(parts: &[String], candidates: &[&str]) -> bool {
+    parts
+        .iter()
+        .any(|part| candidates.iter().any(|candidate| part.as_str() == *candidate))
+}
+
+fn path_or_filename_contains(normalized_path: &str, candidates: &[&str]) -> bool {
+    let filename = normalized_path.rsplit('/').next().unwrap_or(normalized_path);
+    candidates
+        .iter()
+        .any(|candidate| normalized_path.contains(candidate) || filename.contains(candidate))
+}
+
+fn resource_type_for_model_path(model_path: &str) -> Option<&'static str> {
+    let (normalized_path, parts) = normalized_model_path_parts(model_path);
+
+    if path_has_segment(&parts, &["lora", "loras"]) {
+        return Some("loras");
     }
+
+    if path_has_segment(
+        &parts,
+        &[
+            "vae",
+            "vae_approx",
+            "clip",
+            "clip_vision",
+            "text_encoder",
+            "text_encoders",
+            "upscale_model",
+            "upscale_models",
+            "upscaler",
+            "upscalers",
+            "ultralytics",
+            "detector",
+            "detectors",
+            "facedetection",
+            "face_detection",
+            "bbox",
+            "segm",
+            "sam",
+            "sams",
+            "caption",
+            "captions",
+            "caption_models",
+            "joy_caption",
+            "wd14_tagger",
+            "insightface",
+            "facerestore",
+            "face_restore",
+            "florence2",
+            "florence-2",
+            "florence_2",
+            "gfpgan",
+            "ldsr",
+            "llm",
+            "omnisr",
+            "pulid",
+            "realesrgan",
+            "real-esrgan",
+            "real_esrgan",
+            "seedvr2",
+            "swinir",
+            "t2iadapter",
+        ],
+    ) {
+        return None;
+    }
+
+    if path_has_segment(&parts, &["embedding", "embeddings", "textual_inversion"]) {
+        return Some("embeddings");
+    }
+
+    if path_has_segment(&parts, &["hypernetwork", "hypernetworks"]) {
+        return Some("hypernetworks");
+    }
+
+    if path_or_filename_contains(
+        &normalized_path,
+        &["ipadapter", "ip-adapter", "ip_adapter", "ipadapters"],
+    ) {
+        return Some("ip_adapters");
+    }
+
+    if path_has_segment(
+        &parts,
+        &[
+            "controlnet",
+            "control_net",
+            "control-nets",
+            "controlnets",
+            "control_nets",
+            "t2i_adapter",
+            "t2i-adapter",
+        ],
+    ) {
+        return Some("control_nets");
+    }
+
+    if path_has_segment(
+        &parts,
+        &[
+            "checkpoint",
+            "checkpoints",
+            "diffusion_model",
+            "diffusion_models",
+            "unet",
+            "unets",
+        ],
+    ) {
+        return Some("checkpoint");
+    }
+
+    None
 }
 
 fn push_unique_resource_name(values: &mut Vec<String>, name: &str) {
@@ -452,8 +563,10 @@ where
             let resource_type = resource_type
                 .as_deref()
                 .filter(|value| !value.trim().is_empty())
-                .unwrap_or_else(|| resource_type_for_model_path(path));
-            touch_resource(&mut resources, resource_type, resource_name);
+                .or_else(|| resource_type_for_model_path(path));
+            if let Some(resource_type) = resource_type {
+                touch_resource(&mut resources, resource_type, resource_name);
+            }
             let has_thumbnail_override = thumbnail_path
                 .as_deref()
                 .map(|value| !value.trim().is_empty())
@@ -729,13 +842,15 @@ pub async fn scan_model_thumbnails(
 
             let outcome =
                 register_discovered_model_file(&conn, model_path, now, &mut touched_resources)?;
-            if outcome.cached {
-                cached_files += 1;
-            } else {
-                new_or_changed_files += 1;
+            if !outcome.skipped {
+                if outcome.cached {
+                    cached_files += 1;
+                } else {
+                    new_or_changed_files += 1;
+                }
+                registered_hashes.insert(model_path.to_string(), outcome.hash.clone());
             }
             registered_models += outcome.registered_models;
-            registered_hashes.insert(model_path.to_string(), outcome.hash.clone());
 
             if last_emit.elapsed().as_millis() > 200 || i == models_found.len() - 1 {
                 if state.is_cancelled.load(Ordering::SeqCst) {
@@ -891,7 +1006,7 @@ fn scan_dir_for_resources(
                     .unwrap_or("")
                     .to_lowercase();
 
-                if is_model_resource_ext(&ext) {
+                if is_model_resource_ext(&ext) && resource_type_for_model_path(&path.to_string_lossy()).is_some() {
                     models.push(path.to_string_lossy().to_string());
                 } else if is_sidecar_image_ext(&ext) {
                     images.insert(path.to_string_lossy().to_string());
@@ -1064,7 +1179,7 @@ mod tests {
     #[test]
     fn scan_dir_for_resources_reports_live_counters() {
         let root = temp_resource_dir("scan_counters");
-        let nested = root.join("nested");
+        let nested = root.join("checkpoints");
         fs::create_dir_all(&nested).unwrap();
         fs::write(nested.join("ponyDiffusionV6XL.safetensors"), b"model").unwrap();
         fs::write(nested.join("ponyDiffusionV6XL.preview.png"), b"image").unwrap();
@@ -1126,6 +1241,74 @@ mod tests {
     }
 
     #[test]
+    fn resource_type_for_model_path_uses_generation_model_folders() {
+        let cases = [
+            (
+                "C:/ComfyUI/models/checkpoints/Pony Diffusion V6 XL.safetensors",
+                Some("checkpoint"),
+            ),
+            (
+                "C:/ComfyUI/models/diffusion_models/FluxDev.safetensors",
+                Some("checkpoint"),
+            ),
+            ("C:/ComfyUI/models/unet/HunyuanVideo.safetensors", Some("checkpoint")),
+            ("C:/ComfyUI/models/loras/CinematicDetail.safetensors", Some("loras")),
+            (
+                "C:/ComfyUI/models/loras/ip-adapter-faceid-lora.safetensors",
+                Some("loras"),
+            ),
+            ("C:/ComfyUI/models/embeddings/EasyNegative.pt", Some("embeddings")),
+            (
+                "C:/ComfyUI/models/textual_inversion/EasyNegative.pt",
+                Some("embeddings"),
+            ),
+            (
+                "C:/ComfyUI/models/hypernetworks/InkStyle.pt",
+                Some("hypernetworks"),
+            ),
+            (
+                "C:/ComfyUI/models/controlnet/OpenPose.safetensors",
+                Some("control_nets"),
+            ),
+            (
+                "C:/ComfyUI/models/controlnet/control-lora-canny.safetensors",
+                Some("control_nets"),
+            ),
+            (
+                "C:/ComfyUI/models/controlnet/ip-adapter-faceid.safetensors",
+                Some("ip_adapters"),
+            ),
+            ("C:/ComfyUI/models/ipadapter/FaceID.bin", Some("ip_adapters")),
+            ("C:/ComfyUI/models/vae/sdxl_vae.safetensors", None),
+            ("C:/ComfyUI/models/clip/clip_l.safetensors", None),
+            ("C:/ComfyUI/models/clip_vision/clip_vision.safetensors", None),
+            ("C:/ComfyUI/models/text_encoders/t5xxl.safetensors", None),
+            ("C:/ComfyUI/models/upscale_models/4x-UltraSharp.pth", None),
+            ("C:/ComfyUI/models/ultralytics/bbox/face_yolov8m.pt", None),
+            ("C:/ComfyUI/models/facedetection/detection_mobilenet.pth", None),
+            ("C:/ComfyUI/models/facerestore/GFPGANv1.4.pth", None),
+            ("C:/ComfyUI/models/RealESRGAN/RealESRGAN_x4plus.pth", None),
+            ("C:/ComfyUI/models/SwinIR/SwinIR_4x.pth", None),
+            ("C:/ComfyUI/models/OmniSR/epoch994_OmniSR.pth", None),
+            ("C:/ComfyUI/models/florence2/base/pytorch_model.bin", None),
+            ("C:/ComfyUI/models/LLM/LLaVA/model.safetensors", None),
+            ("C:/ComfyUI/models/pulid/pulid_v1.1.safetensors", None),
+            ("C:/ComfyUI/models/sams/sam_hq_vit_b.pth", None),
+            ("C:/ComfyUI/models/SEEDVR2/ema_vae_fp16.safetensors", None),
+            (
+                "C:/ComfyUI/models/T2IAdapter/t2i-adapter-canny-sdxl-1.0/diffusion_pytorch_model.safetensors",
+                None,
+            ),
+            ("C:/ComfyUI/models/Joy_caption/clip_model.pt", None),
+            ("C:/ComfyUI/models/mystery/unknown.safetensors", None),
+        ];
+
+        for (path, expected) in cases {
+            assert_eq!(resource_type_for_model_path(path), expected, "{path}");
+        }
+    }
+
+    #[test]
     fn resource_touches_are_grouped_by_comfyui_model_folders() {
         let mut resources = FacetResourceTouches::default();
         let paths = [
@@ -1143,7 +1326,7 @@ mod tests {
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap();
-            touch_resource(&mut resources, resource_type_for_model_path(path), stem);
+            touch_resource(&mut resources, resource_type_for_model_path(path).unwrap(), stem);
         }
 
         assert_eq!(resources.checkpoints, vec!["Pony Diffusion V6 XL"]);
@@ -1188,6 +1371,37 @@ mod tests {
             .unwrap();
         assert_eq!(scan_rows, 1);
         assert_eq!(disk_rows, 1);
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn register_discovered_model_skips_unsupported_assets_without_touching_facets() {
+        let root = temp_resource_dir("registration_unsupported");
+        let vae_dir = root.join("vae");
+        fs::create_dir_all(&vae_dir).unwrap();
+        let model_path = vae_dir.join("sdxl_vae.safetensors");
+        fs::write(&model_path, b"model").unwrap();
+        let model_path = model_path.to_string_lossy().to_string();
+        let conn = registration_test_conn();
+        let mut resources = FacetResourceTouches::default();
+
+        let result =
+            register_discovered_model_file(&conn, &model_path, 100, &mut resources).unwrap();
+
+        assert!(result.skipped);
+        assert_eq!(result.registered_models, 0);
+        assert!(resources.checkpoints.is_empty());
+        assert!(resources.loras.is_empty());
+
+        let scan_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM scanned_files", [], |row| row.get(0))
+            .unwrap();
+        let disk_rows: i64 = conn
+            .query_row("SELECT COUNT(*) FROM models", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(scan_rows, 0);
+        assert_eq!(disk_rows, 0);
 
         let _ = fs::remove_dir_all(root);
     }

--- a/src/features/filters/components/ResourceSection.tsx
+++ b/src/features/filters/components/ResourceSection.tsx
@@ -336,9 +336,9 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
         const isInventoryOnly = item.count === 0 && item.isLocalDisk;
         const thumbUrl = item.thumbnailPath || item.previewUrl;
         const hasSidecarPreview = item.thumbnailSource === 'sidecar';
-        const unusedTitle = hasSidecarPreview
-            ? 'Unused: local asset has no matching library images. Preview from sidecar image.'
-            : 'Unused: local asset has no matching library images.';
+        const localOnlyTitle = hasSidecarPreview
+            ? 'Local only: no indexed library images. Preview from sidecar image.'
+            : 'Local only: no indexed library images.';
         const localTitle = hasSidecarPreview
             ? 'Local asset on disk. Preview from sidecar image.'
             : 'Local asset on disk';
@@ -348,7 +348,7 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                 key={`${item.name}-${item.hash || 'no-hash'}`}
                 onClick={() => toggleItem(item)}
                 onContextMenu={(e) => handleContextMenu(e, item)}
-                title={isInventoryOnly ? `${item.name} has no images in the library yet` : item.name}
+                title={isInventoryOnly ? `${item.name} has no indexed library images` : item.name}
                 className={`group relative aspect-square rounded-xl overflow-hidden border transition-all duration-300 ease-spring ${isInventoryOnly ? 'cursor-default' : 'cursor-pointer'} ${isSelected
                     ? 'border-sage-500 ring-2 ring-sage-500/20 shadow-lg shadow-sage-500/10'
                     : 'border-gray-200 dark:border-white/10 hover:border-sage-400/50 hover:shadow-md'
@@ -393,8 +393,8 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                     <div className={`absolute top-1.5 right-1.5 transition-opacity z-10 ${isInventoryOnly ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
                         <div
                             role={isInventoryOnly ? 'img' : undefined}
-                            aria-label={isInventoryOnly ? unusedTitle : undefined}
-                            title={isInventoryOnly ? unusedTitle : `${item.count.toLocaleString()} total images`}
+                            aria-label={isInventoryOnly ? localOnlyTitle : undefined}
+                            title={isInventoryOnly ? localOnlyTitle : `${item.count.toLocaleString()} total images`}
                             className={`px-1.5 py-0.5 rounded-md backdrop-blur-sm text-[9px] font-bold shadow-sm ${isInventoryOnly ? 'bg-blue-500/80 text-white' : 'bg-black/40 text-white/90'}`}
                         >
                             {isInventoryOnly ? <ImageOff className="h-3 w-3" aria-hidden="true" /> : formatCountCompact(item.count)}
@@ -423,9 +423,9 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
         const isInventoryOnly = item.count === 0 && item.isLocalDisk;
         const thumbUrl = item.thumbnailPath || item.previewUrl;
         const hasSidecarPreview = item.thumbnailSource === 'sidecar';
-        const unusedTitle = hasSidecarPreview
-            ? 'Unused: local asset has no matching library images. Preview from sidecar image.'
-            : 'Unused: local asset has no matching library images.';
+        const localOnlyTitle = hasSidecarPreview
+            ? 'Local only: no indexed library images. Preview from sidecar image.'
+            : 'Local only: no indexed library images.';
         const localTitle = hasSidecarPreview
             ? 'Local asset on disk. Preview from sidecar image.'
             : 'Local asset on disk';
@@ -469,9 +469,9 @@ export const ResourceSection: React.FC<ResourceSectionProps> = ({
                 <div className="flex items-center gap-2 flex-shrink-0">
                     <span
                         role={isInventoryOnly ? 'img' : undefined}
-                        aria-label={isInventoryOnly ? unusedTitle : undefined}
+                        aria-label={isInventoryOnly ? localOnlyTitle : undefined}
                         className={`text-[10px] px-1.5 py-0.5 rounded-md transition-opacity group-hover:opacity-100 ${isInventoryOnly ? 'bg-blue-50 dark:bg-blue-500/15 text-blue-700 dark:text-blue-300 opacity-100' : `bg-gray-100 dark:bg-white/10 ${validNames != null ? 'opacity-30' : 'opacity-60'}`}`}
-                        title={isInventoryOnly ? unusedTitle : `${item.count.toLocaleString()} total images`}
+                        title={isInventoryOnly ? localOnlyTitle : `${item.count.toLocaleString()} total images`}
                     >
                         {isInventoryOnly ? <ImageOff className="h-3 w-3" aria-hidden="true" /> : formatCountCompact(item.count)}
                     </span>

--- a/src/features/filters/components/__tests__/ResourceSection.test.tsx
+++ b/src/features/filters/components/__tests__/ResourceSection.test.tsx
@@ -202,13 +202,13 @@ describe('ResourceSection asset scope filtering', () => {
 
         expect(screen.getByText('UnusedLocal')).toBeTruthy();
         expect(screen.queryByText('Unused', { exact: true })).toBeNull();
-        expect(screen.getByLabelText('Unused: local asset has no matching library images.')).toBeTruthy();
+        expect(screen.getByLabelText('Local only: no indexed library images.')).toBeTruthy();
         expect(screen.getByText('UsedLocal')).toBeTruthy();
         expect(screen.getByLabelText('Local asset on disk')).toBeTruthy();
         expect(screen.queryByText('HarvestedOnly')).toBeNull();
     });
 
-    it('does not toggle filters when an unused local asset is clicked', () => {
+    it('does not toggle filters when a local-only asset is clicked', () => {
         const setFilters = vi.fn();
         renderScopedSection({ assetScope: 'local', setFilters });
 
@@ -264,6 +264,37 @@ describe('ResourceSection asset scope filtering', () => {
         expect(nextFilters.assetFilterAliases?.loras?.['Detailer-Style']).toEqual(['Detailer-Style', 'detailer style']);
     });
 
+    it('matches merged resource aliases in the local search box', () => {
+        render(
+            <ResourceSection
+                title="Resources"
+                type="loras"
+                filters={filters}
+                setFilters={vi.fn()}
+                data={[{
+                    name: 'Flux Style - watercolor_flux_v1.1_rank_16_bf16',
+                    hash: 'lora_Flux Style - watercolor_flux_v1.1_rank_16_bf16',
+                    count: 2,
+                    isLocalDisk: true,
+                    filterAliases: [
+                        'Flux Style - watercolor_flux_v1.1_rank_16_bf16',
+                        'watercolor_flux_v1.1_rank_16_bf16'
+                    ]
+                }]}
+                isOpen
+                onToggle={vi.fn()}
+                assetScope="used"
+            />
+        );
+
+        fireEvent.click(screen.getByTitle('Search LoRAs'));
+        fireEvent.change(screen.getByPlaceholderText('Search LoRAs...'), {
+            target: { value: 'watercolor_flu' }
+        });
+
+        expect(screen.getByText('Flux Style - watercolor_flux_v1.1_rank_16_bf16')).toBeTruthy();
+    });
+
     it('keeps merged aliases visible when a valid alias exists in the current result set', () => {
         render(
             <ResourceSection
@@ -288,7 +319,7 @@ describe('ResourceSection asset scope filtering', () => {
         expect(screen.getByText('Detailer-Style')).toBeTruthy();
     });
 
-    it('explains sidecar previews on unused local asset badges', () => {
+    it('explains sidecar previews on local-only asset badges', () => {
         render(
             <ResourceSection
                 title="Resources"
@@ -310,7 +341,7 @@ describe('ResourceSection asset scope filtering', () => {
             />
         );
 
-        expect(screen.getByLabelText('Unused: local asset has no matching library images. Preview from sidecar image.')).toBeTruthy();
+        expect(screen.getByLabelText('Local only: no indexed library images. Preview from sidecar image.')).toBeTruthy();
     });
 
     it('does not describe an available sidecar when a manual preview is displayed', () => {
@@ -336,7 +367,7 @@ describe('ResourceSection asset scope filtering', () => {
             />
         );
 
-        expect(screen.getByLabelText('Unused: local asset has no matching library images.')).toBeTruthy();
+        expect(screen.getByLabelText('Local only: no indexed library images.')).toBeTruthy();
         expect(screen.queryByLabelText(/Preview from sidecar image/)).toBeNull();
     });
 });
@@ -412,7 +443,7 @@ describe('ResourceSection asset sorting', () => {
         />
     );
 
-    it('sorts all-scope unused local assets by local modified date for Newest Added', () => {
+    it('sorts all-scope local-only assets by local modified date for Newest Added', () => {
         setResourceSort('added_desc');
 
         renderSortingSection({

--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -184,6 +184,143 @@ describe('searchRepo getFacets', () => {
         });
     });
 
+    it('merges InvokeAI display labels with matching local disk resource suffixes', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'loras',
+                    resource_name: 'Flux Style - watercolor_flux_v1.1_rank_16_bf16 ',
+                    resource_hash: 'lora_Flux Style - watercolor_flux_v1.1_rank_16_bf16 ',
+                    count: 2,
+                    thumbnail_path: 'used.webp',
+                    is_local_disk: 0
+                },
+                {
+                    facet_type: 'loras',
+                    resource_name: 'watercolor_flux_v1.1_rank_16_bf16 ',
+                    resource_hash: 'file:C:/models/watercolor_flux_v1.1_rank_16_bf16.safetensors',
+                    count: 0,
+                    thumbnail_path: 'local.webp',
+                    has_sidecar: 1,
+                    is_manual: 1,
+                    is_local_disk: 1
+                }
+            ],
+            [
+                {
+                    resource_type: 'loras',
+                    name: 'watercolor_flux_v1.1_rank_16_bf16 ',
+                    hash: 'file:C:/models/watercolor_flux_v1.1_rank_16_bf16.safetensors'
+                }
+            ]
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('', [], ['loras'], { assetScope: 'all' });
+
+        expect(facets.loras).toHaveLength(1);
+        expect(facets.loras[0]).toMatchObject({
+            name: 'Flux Style - watercolor_flux_v1.1_rank_16_bf16 ',
+            count: 2,
+            isLocalDisk: true,
+            assetMatchKey: 'watercolorfluxv11rank16bf16',
+            thumbnailPath: 'used.webp',
+            hasSidecar: 1,
+            filterAliases: [
+                'Flux Style - watercolor_flux_v1.1_rank_16_bf16',
+                'watercolor_flux_v1.1_rank_16_bf16'
+            ]
+        });
+    });
+
+    it('uses merged aliases when overlaying filtered counts', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'loras',
+                    resource_name: 'Pony Style - Gothic Neon, g0th1cPXL',
+                    resource_hash: 'lora_Pony Style - Gothic Neon, g0th1cPXL',
+                    count: 38,
+                    is_local_disk: 0
+                },
+                {
+                    facet_type: 'loras',
+                    resource_name: 'g0th1cPXL',
+                    resource_hash: 'file:C:/models/g0th1cPXL.safetensors',
+                    count: 0,
+                    is_local_disk: 1
+                }
+            ],
+            [
+                {
+                    resource_type: 'loras',
+                    name: 'g0th1cPXL',
+                    hash: 'file:C:/models/g0th1cPXL.safetensors'
+                }
+            ],
+            {
+                loras: [{ name: 'Pony Style - Gothic Neon, g0th1cPXL', count: 5 }]
+            }
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('WHERE resolved_model_name = ?', ['Flux'], ['loras'], { assetScope: 'used' });
+
+        expect(facets.loras).toHaveLength(1);
+        expect(facets.loras[0]).toMatchObject({
+            name: 'Pony Style - Gothic Neon, g0th1cPXL',
+            count: 5,
+            isLocalDisk: true,
+            assetMatchKey: 'g0th1cpxl'
+        });
+    });
+
+    it('merges comma display labels with multi-word local disk suffixes', async () => {
+        const db = createFacetDb(
+            [
+                {
+                    facet_type: 'loras',
+                    resource_name: 'Pony Style - Gothic Neon, g0th1cPXL',
+                    resource_hash: 'lora_Pony Style - Gothic Neon, g0th1cPXL',
+                    count: 6,
+                    is_local_disk: 0
+                },
+                {
+                    facet_type: 'loras',
+                    resource_name: 'Gothic_Neon_g0th1cPXL',
+                    resource_hash: 'file:C:/models/Gothic_Neon_g0th1cPXL.safetensors',
+                    count: 0,
+                    is_local_disk: 1
+                }
+            ],
+            [
+                {
+                    resource_type: 'loras',
+                    name: 'Gothic_Neon_g0th1cPXL',
+                    hash: 'file:C:/models/Gothic_Neon_g0th1cPXL.safetensors'
+                }
+            ]
+        );
+        getDbMock.mockResolvedValue(db);
+
+        const { getFacets } = await import('../searchRepo');
+        const facets = await getFacets('', [], ['loras'], { assetScope: 'all' });
+
+        expect(facets.loras).toHaveLength(1);
+        expect(facets.loras[0]).toMatchObject({
+            name: 'Pony Style - Gothic Neon, g0th1cPXL',
+            count: 6,
+            isLocalDisk: true,
+            assetMatchKey: 'gothicneong0th1cpxl',
+            filterAliases: [
+                'Pony Style - Gothic Neon, g0th1cPXL',
+                'Gothic_Neon_g0th1cPXL'
+            ]
+        });
+    });
+
     it('keeps thumbnail provenance paired with the thumbnail selected during alias merging', async () => {
         const db = createFacetDb([
             {

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -2,7 +2,7 @@ import { AIImage, AssetScope, FacetType } from '../../types';
 import { getDb } from './connection';
 import { mapRowToImage, getImageFieldsLight, type ImageRow } from './repoUtils';
 import { WORD_CLOUD_CONFIG } from '../../config/wordCloud';
-import { getAssetMatchKey, uniqueAssetAliases } from '../../utils/assetIdentity';
+import { getAssetMatchKey, resolveAssetMatchKey, uniqueAssetAliases } from '../../utils/assetIdentity';
 import { describeDbQueryReason, timeDbCall } from '../../utils/dbTiming';
 import { commands } from '../../bindings';
 import { resourceReferenceEqualsSql, resourceReferenceSql } from '../../utils/sqlHelpers';
@@ -244,6 +244,26 @@ const sortFacetItems = (items: FacetItem[]): FacetItem[] => (
 const normalizeFacetCountKey = (value: string | null | undefined): string => (
     getAssetMatchKey(value) || (value || 'Unknown').toLowerCase()
 );
+
+const getScopedCountForGroup = (
+    group: FacetMergeGroup,
+    scopedCountMap: Map<string, number> | undefined
+): number => {
+    if (!scopedCountMap) return 0;
+
+    const keys = new Set<string>();
+    if (group.item.assetMatchKey) keys.add(group.item.assetMatchKey);
+    keys.add(normalizeFacetCountKey(group.item.name));
+    for (const alias of group.usedAliases) {
+        keys.add(normalizeFacetCountKey(alias));
+    }
+
+    let count = 0;
+    for (const key of keys) {
+        count += scopedCountMap.get(key) ?? 0;
+    }
+    return count;
+};
 
 const cacheTypeToDiskResourceType = (cacheType: string): string | null => {
     if (cacheType === 'tools') return null;
@@ -1098,7 +1118,10 @@ export const getFacets = async (
                 continue;
             }
 
-            const assetMatchKey = getAssetMatchKey(row.resource_name) || (row.resource_name || 'Unknown').toLowerCase();
+            const assetMatchKey = resolveAssetMatchKey(
+                row.resource_name,
+                diskLookups.matchKeysByCacheType.get(row.facet_type)
+            ) || (row.resource_name || 'Unknown').toLowerCase();
             const isLocalDisk = isDiskBackedFacetRow(row, assetMatchKey, diskLookups);
             const localModifiedAt = isLocalDisk
                 ? getDiskModifiedAtForFacetRow(row, assetMatchKey, diskLookups)
@@ -1154,7 +1177,7 @@ export const getFacets = async (
                     ...group.item,
                     count: assetScope === 'local' || !shouldUseScopedFacetOverlay
                         ? group.item.count
-                        : (scopedCountMap?.get(group.item.assetMatchKey || normalizeFacetCountKey(group.item.name)) ?? 0),
+                        : getScopedCountForGroup(group, scopedCountMap),
                     filterAliases: uniqueAssetAliases([group.item.name, ...group.usedAliases]),
                 })).filter(shouldIncludeFacetItem)
             );

--- a/src/utils/__tests__/assetIdentity.test.ts
+++ b/src/utils/__tests__/assetIdentity.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getAssetMatchKey, stripAssetExtension, uniqueAssetAliases } from '../assetIdentity';
+import {
+    getAssetMatchKey,
+    getAssetMatchKeyCandidates,
+    resolveAssetMatchKey,
+    stripAssetExtension,
+    uniqueAssetAliases
+} from '../assetIdentity';
 
 describe('assetIdentity', () => {
     it('builds the same match key for display names and local filenames', () => {
@@ -15,6 +21,31 @@ describe('assetIdentity', () => {
         expect(getAssetMatchKey('Realistic_Vision-v5.1')).toBe('realisticvisionv51');
         expect(getAssetMatchKey('realistic vision v5 1')).toBe('realisticvisionv51');
         expect(getAssetMatchKey('RealisticVisionV6')).not.toBe(getAssetMatchKey('RealisticVisionV5'));
+    });
+
+    it('derives suffix candidates for InvokeAI display labels', () => {
+        expect(getAssetMatchKeyCandidates('Flux Style - watercolor_flux_v1.1_rank_16_bf16')).toEqual([
+            'fluxstylewatercolorfluxv11rank16bf16',
+            'watercolorfluxv11rank16bf16'
+        ]);
+
+        expect(getAssetMatchKeyCandidates('Pony Style - Gothic Neon, g0th1cPXL')).toEqual([
+            'ponystylegothicneong0th1cpxl',
+            'gothicneong0th1cpxl',
+            'g0th1cpxl'
+        ]);
+    });
+
+    it('resolves display labels to a local disk key only when that key is known', () => {
+        expect(resolveAssetMatchKey(
+            'Flux Style - watercolor_flux_v1.1_rank_16_bf16',
+            new Set(['watercolorfluxv11rank16bf16'])
+        )).toBe('watercolorfluxv11rank16bf16');
+
+        expect(resolveAssetMatchKey(
+            'Flux Style - watercolor_flux_v1.1_rank_16_bf16',
+            new Set(['differentlora'])
+        )).toBe('fluxstylewatercolorfluxv11rank16bf16');
     });
 
     it('dedupes aliases case-insensitively while preserving display order', () => {

--- a/src/utils/assetIdentity.ts
+++ b/src/utils/assetIdentity.ts
@@ -1,5 +1,6 @@
 const ASSET_EXTENSION_RE = /\.(safetensors|ckpt|pt|bin|pth)$/i;
-const ASSET_SEPARATOR_RE = /[\s_.-]+/g;
+const ASSET_SEPARATOR_RE = /[\s_.,-]+/g;
+const LABEL_SUFFIX_SEPARATOR_RE = /\s+-\s+|,\s*/g;
 
 export const getAssetBasename = (value: string): string => {
     const trimmed = value.trim();
@@ -13,6 +14,38 @@ export const stripAssetExtension = (value: string): string => (
 export const getAssetMatchKey = (value: string | null | undefined): string => {
     if (!value) return '';
     return stripAssetExtension(value).toLowerCase().replace(ASSET_SEPARATOR_RE, '');
+};
+
+export const getAssetMatchKeyCandidates = (value: string | null | undefined): string[] => {
+    if (!value) return [];
+
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+    const addCandidate = (candidate: string) => {
+        const key = getAssetMatchKey(candidate);
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        candidates.push(key);
+    };
+
+    const stripped = stripAssetExtension(value);
+    addCandidate(stripped);
+
+    for (const match of stripped.matchAll(LABEL_SUFFIX_SEPARATOR_RE)) {
+        addCandidate(stripped.slice(match.index + match[0].length));
+    }
+
+    return candidates;
+};
+
+export const resolveAssetMatchKey = (
+    value: string | null | undefined,
+    knownMatchKeys?: ReadonlySet<string>
+): string => {
+    const [primary = '', ...candidates] = getAssetMatchKeyCandidates(value);
+    if (!knownMatchKeys || knownMatchKeys.size === 0) return primary;
+    if (knownMatchKeys.has(primary)) return primary;
+    return candidates.find(candidate => knownMatchKeys.has(candidate)) ?? primary;
 };
 
 export const uniqueAssetAliases = (values: Array<string | null | undefined>): string[] => {


### PR DESCRIPTION
## Summary
- merge InvokeAI display-label resource references with matching local disk model files using deterministic aliases
- make local resource scanning directory-aware and skip unsupported auxiliary model folders
- add cleanup migrations for stale/misclassified disk inventory rows
- rename zero-count local asset copy from "Unused" to a more truthful "Local only" state

## Root Cause
Ambit was treating some generator metadata labels and local filenames as separate assets, and the disk scanner was also classifying auxiliary model files too broadly. That made Assets show misleading local-only entries and, in some cases, split used resources from their local files.

## Validation
- `cargo test thumbs_scan`
- `cargo test m61_auxiliary_resource_inventory_cleanup`
- `cargo test auxiliary_resource_inventory_cleanup_61`
- `node_modules\.bin\vitest.cmd run src/utils/__tests__/assetIdentity.test.ts src/services/db/__tests__/searchRepo.test.ts src/features/filters/components/__tests__/ResourceSection.test.tsx`
- `corepack pnpm run typecheck`
- `git diff --check`
- `corepack pnpm exec tauri build --ci --no-bundle`

Note: `cargo fmt --check` could not run because `rustfmt` is not installed for the local Rust `1.96.0` toolchain.
