### PR TITLE
fix: store library database in local appdata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@ Status: Canonical
 Last reviewed: 2026-05-15
 
 ## System Overview
-Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust backend exposed through Tauri commands. Images and heavy metadata live in SQLite, lightweight app state lives in `library.json` under app-local data, and sensitive secrets such as the Gemini API key live in the OS keyring.
+Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust backend exposed through Tauri commands. Images and heavy metadata live in SQLite under Local AppData, lightweight app state lives in `library.json` under app-local data, and sensitive secrets such as the Gemini API key live in the OS keyring.
 
 ## Major Subsystems
 
@@ -50,7 +50,7 @@ Risks: passive third-party assets or unclear copy can make local-first behavior 
 Related docs: `README.md#privacy-and-network-behavior`, `SECURITY.md`
 
 ## Invariants
-- SQLite is the source of truth for image records and heavy metadata. `library.json` should not become a second image store.
+- SQLite is the source of truth for image records and heavy metadata. On Windows, the main library database lives in Local AppData, with Roaming AppData retained only as a legacy fallback during the public-beta transition. `library.json` should not become a second image store.
 - Rust-exposed command and type changes should flow through Specta into `src/bindings.ts`; do not hand-maintain Rust-backed TypeScript mirrors.
 - Filesystem access must remain local-only and within Tauri-registered or scoped paths.
 - API keys are stored via Rust keyring commands, not persisted in `library.json`.

--- a/docs/manual/getting-started.md
+++ b/docs/manual/getting-started.md
@@ -48,6 +48,8 @@ The main Ambit workspace has a left sidebar, a library area, and an optional fil
 
 Ambit keeps source image files where they already are. It stores a local catalog, metadata, thumbnails, settings, and optional integration configuration so the app can search and maintain the library quickly.
 
+On Windows, the installer folder is only where the Ambit application is installed. The library catalog database is application data and lives under Local AppData, normally `%LOCALAPPDATA%\io.github.asuraace.ambit\images.db`. Installing Ambit to another folder or drive does not move the library database.
+
 Sensitive values such as a Gemini API key are stored locally through the OS keyring path Ambit uses rather than being required in the repository or source code.
 
 ## Next Step

--- a/docs/manual/settings-and-privacy.md
+++ b/docs/manual/settings-and-privacy.md
@@ -61,8 +61,10 @@ Advanced includes:
 - backup settings
 - automatic update controls
 - reset onboarding
-- troubleshooting tools for sync cursors, thumbnails, and library verification
+- support diagnostics, including the active library database location
 - database reset tools
+
+The database location shown in Support Diagnostics is the local catalog path, not the Ambit installer path. On Windows, Ambit stores the catalog under Local AppData and may show a legacy Roaming AppData fallback only for older installs that could not be moved automatically.
 
 Use Purge Database only when you intentionally want to remove all imported metadata and reset application state. The confirmation explains that source image files are not touched, but Ambit's catalog and linked folders are reset.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -16,7 +16,7 @@ Last reviewed: 2026-06-04
 - `verify:release` runs version consistency, binding drift check, lint, TypeScript, guarded production build, coverage-backed frontend tests, Rust tests, and the no-bundle Tauri build before production desktop packaging.
 - `.github/workflows/pr-ci.yml`, `.github/workflows/release-please.yml`, and `.github/workflows/release.yml` automate PR validation, versioning, and packaging; they do not replace task-specific local verification.
 - `src/bindings.ts` is generated from Rust command signatures during debug Tauri runs and should not be hand-edited.
-- Desktop persistence is intentionally split: SQLite stores image records and heavy metadata, `library.json` stores lightweight app settings and recent searches, and the OS keyring stores sensitive API keys.
+- Desktop persistence is intentionally split: SQLite stores image records and heavy metadata under Local AppData, `library.json` stores lightweight app settings and recent searches, and the OS keyring stores sensitive API keys.
 - `src/services/repository.ts` is not the shipping desktop persistence path; treat it as legacy or fallback code unless a dedicated cleanup task explicitly changes that contract.
 - Duplicate detection now treats same SHA-256 file content as an exact duplicate regardless of filename or path, and keeps metadata/dimensions/filesize matches as lower-confidence likely duplicates.
 - Duplicate maintenance scans backfill missing content hashes in the native backend as a cancellable Activity Dock task; imports are not blocked on content hashing and cancel an active duplicate hash pass.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -238,14 +238,14 @@ Status: Deferred
 - `src/services/repository.ts` is not the canonical desktop persistence path today; it exports `TauriFsRepository` for the shipping app while still carrying a LocalStorage or mock fallback.
 - Treat that fallback path as ambiguous legacy surface unless a dedicated task explicitly keeps, validates, or removes non-Tauri mode.
 - `src/services/TauriFsRepository.ts` writes `library.json` to `BaseDirectory.AppLocalData`; `src/services/thumbnailService.ts` stores generated thumbnails under `appLocalDataDir()/.thumbnails`; Tauri fs and asset scopes are centered on `$APPLOCALDATA`.
-- `src-tauri/src/db/mod.rs` currently resolves `images.db` by checking `app_config_dir()` first, then `app_local_data_dir()`, and defaults new databases to `app_config_dir()`. On Windows, Tauri's local path APIs map config/data to Roaming AppData and local-data to Local AppData.
+- `src-tauri/src/db/mod.rs` resolves the production `images.db` by checking Local AppData first, then Roaming AppData as a legacy fallback. Development builds keep the legacy dev-profile SQL URL so local development does not touch production user data.
 - `src-tauri/src/lib.rs` and `src-tauri/src/db/commands/maintenance.rs` already contain reset/purge behavior that accounts for both possible database locations.
 
 ### Current Pain Points
 - It is easy to modify the wrong persistence layer or leave migrations half-finished.
 - Startup, onboarding, folder scope registration, and secure key handling all depend on coordinated changes across TypeScript and Rust.
-- Fresh-profile or reset instructions must mention both the current `io.github.asuraace.ambit` directories and the legacy `com.ambit.app` directories while the public-beta identifier migration remains in the transition window.
-- A naive switch from Roaming to Local would look like data loss for existing users if `images.db`, `images.db-wal`, and `images.db-shm` are not migrated before the SQL plugin opens the database.
+- Fresh-profile or reset instructions must mention the Local AppData database path, the current `io.github.asuraace.ambit` directories, and the legacy `com.ambit.app` directories while the public-beta identifier migration remains in the transition window.
+- The Roaming-to-Local SQLite move is handled before the SQL plugin opens the database. The remaining risk is removing legacy fallback code too early, not the default storage location itself.
 
 ### Safe-Change Warning
 - Persistence changes can silently affect existing user libraries and first-run behavior.
@@ -255,12 +255,12 @@ Status: Deferred
 - Make the production Tauri persistence path the obvious canonical path in the frontend.
 - Keep the storage split explicit and narrow: SQLite for images and metadata, `library.json` for lightweight app state, keyring for secrets.
 - Resolve `src/services/repository.ts` intentionally: either document the fallback as supported, or remove it in a dedicated cleanup once the repo explicitly drops that mode.
-- Prefer Local AppData for Ambit's main SQLite library in a future migration because the DB can be large and contains machine-local absolute image paths. Keep a Roaming fallback or explicit migration path for existing installs.
-- Add an in-app diagnostics/reset surface that shows the resolved Local AppData path, resolved database path, thumbnail path, and any detected legacy Roaming database.
+- Keep Local AppData as Ambit's main SQLite library location because the DB can be large and contains machine-local absolute image paths.
+- Expand diagnostics over time to include the thumbnail path and any detected legacy identifier directories. The current support surface shows the active, Local, and Roaming database paths.
 
 ### Not Part of the Current Task
 - Do not delete web or mock fallbacks unless the repo intentionally drops that mode.
-- Do not move the database as a documentation-only or opportunistic cleanup; it needs a dedicated migration and upgrade test pass.
+- Do not remove the Roaming AppData database fallback until the public-beta upgrade window is intentionally closed.
 
 ### Related Code
 - `src/services/repository.ts`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/app_data_migration.rs
+++ b/src-tauri/src/app_data_migration.rs
@@ -1,8 +1,8 @@
 const PRODUCTION_IDENTIFIER: &str = "io.github.asuraace.ambit";
 const LEGACY_PRODUCTION_IDENTIFIER: &str = "com.ambit.app";
-#[cfg(not(test))]
-const THUMBNAIL_PATH_REPAIR_MARKER: &str = ".thumbnail-path-repair-v1";
-#[cfg(not(test))]
+const MAIN_DATABASE_FILES: [&str; 3] = ["images.db", "images.db-wal", "images.db-shm"];
+const PURGE_MARKER_FILE: &str = ".purge_on_restart";
+const PRODUCTION_IDENTIFIER_PATHS: [&str; 2] = [PRODUCTION_IDENTIFIER, LEGACY_PRODUCTION_IDENTIFIER];
 const APP_IDENTIFIER_PATHS: [&str; 5] = [
     PRODUCTION_IDENTIFIER,
     LEGACY_PRODUCTION_IDENTIFIER,
@@ -10,6 +10,8 @@ const APP_IDENTIFIER_PATHS: [&str; 5] = [
     "com.ambit.alpha",
     "com.tauri.dev",
 ];
+#[cfg(not(test))]
+const THUMBNAIL_PATH_REPAIR_MARKER: &str = ".thumbnail-path-repair-v1";
 
 #[derive(Debug, PartialEq, Eq)]
 enum IdentifierMigrationOutcome {
@@ -18,6 +20,28 @@ enum IdentifierMigrationOutcome {
     MergedLegacyEntries,
     SkippedExistingProfile,
     Failed,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DatabaseLocalMigrationOutcome {
+    SourceMissing,
+    Moved,
+    Copied,
+    SkippedExistingLocal,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+struct DatabaseFileMove {
+    name: &'static str,
+    source: std::path::PathBuf,
+    destination: std::path::PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct AppProfileDir {
+    identifier: &'static str,
+    path: std::path::PathBuf,
 }
 
 #[cfg(not(test))]
@@ -50,6 +74,427 @@ pub(crate) fn migrate_legacy_identifier_data() {
     if let (Some(config_dir), Some(data_local_dir)) = (&config_dir, &data_local_dir) {
         repair_legacy_production_thumbnail_paths(config_dir, data_local_dir);
     }
+}
+
+#[cfg(not(test))]
+pub(crate) fn migrate_current_database_to_local_app_data() {
+    let Some(config_dir) = dirs::config_dir() else {
+        eprintln!("[DatabaseLocalMigration] Failed to resolve Roaming AppData config directory");
+        return;
+    };
+    let Some(data_local_dir) = dirs::data_local_dir() else {
+        eprintln!("[DatabaseLocalMigration] Failed to resolve Local AppData directory");
+        return;
+    };
+
+    let roaming_dir = config_dir.join(PRODUCTION_IDENTIFIER);
+    let local_dir = data_local_dir.join(PRODUCTION_IDENTIFIER);
+    let _ = migrate_database_files_to_local(&roaming_dir, &local_dir);
+}
+
+fn migrate_database_files_to_local(
+    roaming_dir: &std::path::Path,
+    local_dir: &std::path::Path,
+) -> DatabaseLocalMigrationOutcome {
+    let roaming_db = roaming_dir.join("images.db");
+    let local_db = local_dir.join("images.db");
+
+    if local_db.exists() {
+        if roaming_db.exists() {
+            println!(
+                "[DatabaseLocalMigration] Local database already exists at {}; leaving legacy Roaming database at {} for manual recovery",
+                local_db.display(),
+                roaming_db.display()
+            );
+        }
+        return DatabaseLocalMigrationOutcome::SkippedExistingLocal;
+    }
+
+    if !roaming_db.exists() {
+        if let Err(error) = std::fs::create_dir_all(local_dir) {
+            eprintln!(
+                "[DatabaseLocalMigration] Failed to prepare Local AppData directory {}: {error}",
+                local_dir.display()
+            );
+            return DatabaseLocalMigrationOutcome::Failed;
+        }
+        println!(
+            "[DatabaseLocalMigration] No legacy Roaming database found at {}; fresh databases will use {}",
+            roaming_db.display(),
+            local_dir.display()
+        );
+        return DatabaseLocalMigrationOutcome::SourceMissing;
+    }
+
+    if let Err(error) = std::fs::create_dir_all(local_dir) {
+        eprintln!(
+            "[DatabaseLocalMigration] Failed to create Local AppData directory {}: {error}",
+            local_dir.display()
+        );
+        return DatabaseLocalMigrationOutcome::Failed;
+    }
+
+    let files = existing_database_file_moves(roaming_dir, local_dir);
+    if let Some(existing_target) = files
+        .iter()
+        .find(|file| file.destination.exists())
+        .map(|file| file.destination.clone())
+    {
+        eprintln!(
+            "[DatabaseLocalMigration] Skipped moving database because Local AppData already contains {}; Roaming database remains active",
+            existing_target.display()
+        );
+        return DatabaseLocalMigrationOutcome::SkippedExistingLocal;
+    }
+
+    match rename_database_files(&files) {
+        Ok(()) => {
+            println!(
+                "[DatabaseLocalMigration] Moved database from {} to {}",
+                roaming_dir.display(),
+                local_dir.display()
+            );
+            DatabaseLocalMigrationOutcome::Moved
+        }
+        Err(error) => {
+            eprintln!(
+                "[DatabaseLocalMigration] Rename failed; trying copy fallback from {} to {}: {error}",
+                roaming_dir.display(),
+                local_dir.display()
+            );
+            match copy_database_files_to_local(&files) {
+                Ok(()) => {
+                    println!(
+                        "[DatabaseLocalMigration] Copied database from {} to {} after rename fallback",
+                        roaming_dir.display(),
+                        local_dir.display()
+                    );
+                    DatabaseLocalMigrationOutcome::Copied
+                }
+                Err(copy_error) => {
+                    eprintln!(
+                        "[DatabaseLocalMigration] Failed to move database to Local AppData; Ambit will keep using Roaming database at {}: {copy_error}",
+                        roaming_db.display()
+                    );
+                    DatabaseLocalMigrationOutcome::Failed
+                }
+            }
+        }
+    }
+}
+
+fn existing_database_file_moves(
+    roaming_dir: &std::path::Path,
+    local_dir: &std::path::Path,
+) -> Vec<DatabaseFileMove> {
+    MAIN_DATABASE_FILES
+        .iter()
+        .filter_map(|name| {
+            let source = roaming_dir.join(name);
+            if !source.exists() {
+                return None;
+            }
+
+            Some(DatabaseFileMove {
+                name: *name,
+                source,
+                destination: local_dir.join(name),
+            })
+        })
+        .collect()
+}
+
+fn rename_database_files(files: &[DatabaseFileMove]) -> Result<(), String> {
+    let mut renamed: Vec<DatabaseFileMove> = Vec::new();
+
+    for file in files {
+        if let Err(error) = std::fs::rename(&file.source, &file.destination) {
+            for previous in renamed.iter().rev() {
+                let _ = std::fs::rename(&previous.destination, &previous.source);
+            }
+            return Err(format!(
+                "could not rename {} to {}: {error}",
+                file.source.display(),
+                file.destination.display()
+            ));
+        }
+        renamed.push(file.clone());
+    }
+
+    Ok(())
+}
+
+fn copy_database_files_to_local(files: &[DatabaseFileMove]) -> Result<(), String> {
+    let temp_suffix = format!(
+        "ambit-db-local-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| e.to_string())?
+            .as_nanos()
+    );
+    let mut temp_files: Vec<(std::path::PathBuf, std::path::PathBuf)> = Vec::new();
+    let mut committed: Vec<std::path::PathBuf> = Vec::new();
+
+    for file in files {
+        if file.destination.exists() {
+            cleanup_paths(temp_files.iter().map(|(temp, _)| temp));
+            return Err(format!(
+                "destination already exists: {}",
+                file.destination.display()
+            ));
+        }
+
+        let temp_destination = file
+            .destination
+            .with_file_name(format!("{}.{}", file.name, temp_suffix));
+        std::fs::copy(&file.source, &temp_destination).map_err(|error| {
+            cleanup_paths(temp_files.iter().map(|(temp, _)| temp));
+            format!(
+                "could not copy {} to {}: {error}",
+                file.source.display(),
+                temp_destination.display()
+            )
+        })?;
+
+        let source_len = std::fs::metadata(&file.source)
+            .map_err(|error| format!("could not read {}: {error}", file.source.display()))?
+            .len();
+        let copied_len = std::fs::metadata(&temp_destination)
+            .map_err(|error| format!("could not read {}: {error}", temp_destination.display()))?
+            .len();
+        if source_len != copied_len {
+            cleanup_paths(temp_files.iter().map(|(temp, _)| temp));
+            let _ = std::fs::remove_file(&temp_destination);
+            return Err(format!(
+                "copy verification failed for {}: source {} bytes, copy {} bytes",
+                file.name, source_len, copied_len
+            ));
+        }
+
+        temp_files.push((temp_destination, file.destination.clone()));
+    }
+
+    for (temp, destination) in &temp_files {
+        if let Err(error) = std::fs::rename(temp, destination) {
+            cleanup_paths(temp_files.iter().map(|(temp, _)| temp));
+            cleanup_paths(committed.iter());
+            return Err(format!(
+                "could not promote {} to {}: {error}",
+                temp.display(),
+                destination.display()
+            ));
+        }
+        committed.push(destination.clone());
+    }
+
+    for file in files {
+        if let Err(error) = std::fs::remove_file(&file.source) {
+            eprintln!(
+                "[DatabaseLocalMigration] Copied {}, but could not remove legacy source {}: {error}",
+                file.name,
+                file.source.display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn cleanup_paths<'a>(paths: impl Iterator<Item = &'a std::path::PathBuf>) {
+    for path in paths {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct DeferredPurgeOutcome {
+    profiles_purged: usize,
+    database_files_deleted: usize,
+    markers_deleted: usize,
+    failures: usize,
+}
+
+#[cfg(not(test))]
+pub(crate) fn check_and_execute_deferred_purge() {
+    let roots = app_data_roots_to_check();
+    let outcome = execute_deferred_purge_for_roots(&roots);
+    if outcome.profiles_purged > 0 {
+        println!(
+            "[Purge] Completed deferred purge: {} profiles, {} database files, {} markers, {} failures",
+            outcome.profiles_purged,
+            outcome.database_files_deleted,
+            outcome.markers_deleted,
+            outcome.failures
+        );
+    }
+}
+
+fn execute_deferred_purge_for_roots(roots: &[std::path::PathBuf]) -> DeferredPurgeOutcome {
+    let profile_dirs = profile_dirs_for_roots(roots);
+    let marked_profiles: Vec<AppProfileDir> = profile_dirs
+        .iter()
+        .filter(|profile| profile.path.join(PURGE_MARKER_FILE).exists())
+        .cloned()
+        .collect();
+
+    if marked_profiles.is_empty() {
+        return DeferredPurgeOutcome::default();
+    }
+
+    let has_production_marker = marked_profiles
+        .iter()
+        .any(|profile| is_production_identifier(profile.identifier));
+    let mut purge_targets: Vec<AppProfileDir> = Vec::new();
+
+    if has_production_marker {
+        for profile in profile_dirs
+            .iter()
+            .filter(|profile| is_production_identifier(profile.identifier))
+        {
+            push_unique_profile(&mut purge_targets, profile.clone());
+        }
+    }
+
+    for profile in marked_profiles {
+        if !has_production_marker || !is_production_identifier(profile.identifier) {
+            push_unique_profile(&mut purge_targets, profile);
+        }
+    }
+
+    let mut outcome = DeferredPurgeOutcome::default();
+    let mut touched_profiles: Vec<std::path::PathBuf> = Vec::new();
+
+    for target in &purge_targets {
+        println!(
+            "[Purge] Processing deferred purge for {} at {}",
+            target.identifier,
+            target.path.display()
+        );
+        let target_outcome = purge_database_files(&target.path);
+        if target_outcome.database_files_deleted > 0 {
+            push_unique_path(&mut touched_profiles, target.path.clone());
+        }
+        outcome.database_files_deleted += target_outcome.database_files_deleted;
+        outcome.failures += target_outcome.failures;
+    }
+
+    if outcome.failures == 0 {
+        for target in &purge_targets {
+            let target_outcome = purge_purge_marker(&target.path);
+            if target_outcome.markers_deleted > 0 {
+                push_unique_path(&mut touched_profiles, target.path.clone());
+            }
+            outcome.markers_deleted += target_outcome.markers_deleted;
+            outcome.failures += target_outcome.failures;
+        }
+    } else {
+        eprintln!(
+            "[Purge] Deferred purge did not fully clear database files; leaving purge markers for retry on next startup"
+        );
+    }
+
+    outcome.profiles_purged = touched_profiles.len();
+    outcome
+}
+
+fn profile_dirs_for_roots(roots: &[std::path::PathBuf]) -> Vec<AppProfileDir> {
+    let mut profiles = Vec::new();
+    for root in roots {
+        for identifier in APP_IDENTIFIER_PATHS {
+            profiles.push(AppProfileDir {
+                identifier,
+                path: root.join(identifier),
+            });
+        }
+    }
+    profiles
+}
+
+fn is_production_identifier(identifier: &str) -> bool {
+    PRODUCTION_IDENTIFIER_PATHS.contains(&identifier)
+}
+
+fn push_unique_profile(profiles: &mut Vec<AppProfileDir>, profile: AppProfileDir) {
+    if profiles.iter().any(|existing| existing.path == profile.path) {
+        return;
+    }
+    profiles.push(profile);
+}
+
+fn push_unique_path(paths: &mut Vec<std::path::PathBuf>, path: std::path::PathBuf) {
+    if paths.iter().any(|existing| existing == &path) {
+        return;
+    }
+    paths.push(path);
+}
+
+fn purge_database_files(profile_dir: &std::path::Path) -> DeferredPurgeOutcome {
+    let mut outcome = DeferredPurgeOutcome::default();
+
+    for name in MAIN_DATABASE_FILES {
+        let path = profile_dir.join(name);
+        match remove_existing_file_with_retry(&path) {
+            Ok(true) => {
+                println!("[Purge] Deleted {}", path.display());
+                outcome.database_files_deleted += 1;
+            }
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!("[Purge] Failed to delete {}: {error}", path.display());
+                outcome.failures += 1;
+            }
+        }
+    }
+
+    outcome
+}
+
+fn purge_purge_marker(profile_dir: &std::path::Path) -> DeferredPurgeOutcome {
+    let mut outcome = DeferredPurgeOutcome::default();
+    let marker_path = profile_dir.join(PURGE_MARKER_FILE);
+
+    match remove_existing_file_with_retry(&marker_path) {
+        Ok(true) => outcome.markers_deleted += 1,
+        Ok(false) => {}
+        Err(error) => {
+            eprintln!("[Purge] Failed to delete purge marker: {error}");
+            outcome.failures += 1;
+        }
+    }
+
+    outcome
+}
+
+fn remove_existing_file_with_retry(path: &std::path::Path) -> Result<bool, String> {
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    if std::fs::symlink_metadata(path)
+        .map_err(|error| format!("could not inspect {}: {error}", path.display()))?
+        .is_dir()
+    {
+        return Err(format!("refusing to delete directory {}", path.display()));
+    }
+
+    let max_attempts = 5;
+    for attempt in 1..=max_attempts {
+        match std::fs::remove_file(path) {
+            Ok(()) => return Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) if attempt == max_attempts => {
+                return Err(format!(
+                    "could not delete {} after {} attempts: {error}",
+                    path.display(),
+                    max_attempts
+                ));
+            }
+            Err(_) => std::thread::sleep(std::time::Duration::from_millis(500)),
+        }
+    }
+
+    Ok(false)
 }
 
 #[cfg(not(test))]
@@ -525,23 +970,22 @@ fn escape_sql_like(value: &str) -> String {
 
 #[cfg(not(test))]
 pub(crate) fn app_identifier_dirs_to_check() -> Vec<std::path::PathBuf> {
-    let mut paths_to_check = Vec::new();
-
-    if let Some(config_dir) = dirs::config_dir() {
-        push_identifier_dirs(&mut paths_to_check, &config_dir);
-    }
-    if let Some(data_local_dir) = dirs::data_local_dir() {
-        push_identifier_dirs(&mut paths_to_check, &data_local_dir);
-    }
-
-    paths_to_check
+    profile_dirs_for_roots(&app_data_roots_to_check())
+        .into_iter()
+        .map(|profile| profile.path)
+        .collect()
 }
 
 #[cfg(not(test))]
-fn push_identifier_dirs(paths: &mut Vec<std::path::PathBuf>, root: &std::path::Path) {
-    for identifier in APP_IDENTIFIER_PATHS {
-        paths.push(root.join(identifier));
+fn app_data_roots_to_check() -> Vec<std::path::PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(config_dir) = dirs::config_dir() {
+        roots.push(config_dir);
     }
+    if let Some(data_local_dir) = dirs::data_local_dir() {
+        roots.push(data_local_dir);
+    }
+    roots
 }
 
 #[cfg(test)]
@@ -571,6 +1015,28 @@ mod identifier_migration_tests {
 
     fn cleanup(root: &Path) {
         let _ = fs::remove_dir_all(root);
+    }
+
+    fn write_db_triplet(profile_dir: &Path, label: &str) {
+        write_file(&profile_dir.join("images.db"), &format!("{label}-db"));
+        write_file(&profile_dir.join("images.db-wal"), &format!("{label}-wal"));
+        write_file(&profile_dir.join("images.db-shm"), &format!("{label}-shm"));
+    }
+
+    fn write_purge_marker(profile_dir: &Path) {
+        write_file(&profile_dir.join(PURGE_MARKER_FILE), "purge requested");
+    }
+
+    fn assert_db_triplet_missing(profile_dir: &Path) {
+        assert!(!profile_dir.join("images.db").exists());
+        assert!(!profile_dir.join("images.db-wal").exists());
+        assert!(!profile_dir.join("images.db-shm").exists());
+    }
+
+    fn assert_db_triplet_exists(profile_dir: &Path) {
+        assert!(profile_dir.join("images.db").exists());
+        assert!(profile_dir.join("images.db-wal").exists());
+        assert!(profile_dir.join("images.db-shm").exists());
     }
 
     fn create_test_db(path: &Path) -> rusqlite::Connection {
@@ -646,6 +1112,313 @@ mod identifier_migration_tests {
             fs::read_to_string(current.join("images.db")).expect("migrated db should exist"),
             "legacy-db"
         );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn database_local_migration_moves_db_wal_and_shm_together() {
+        let root = unique_temp_root("db-local-move");
+        let roaming = root.join("Roaming").join(PRODUCTION_IDENTIFIER);
+        let local = root.join("Local").join(PRODUCTION_IDENTIFIER);
+        write_file(&roaming.join("images.db"), "db");
+        write_file(&roaming.join("images.db-wal"), "wal");
+        write_file(&roaming.join("images.db-shm"), "shm");
+
+        let outcome = migrate_database_files_to_local(&roaming, &local);
+
+        assert_eq!(outcome, DatabaseLocalMigrationOutcome::Moved);
+        assert!(!roaming.join("images.db").exists());
+        assert!(!roaming.join("images.db-wal").exists());
+        assert!(!roaming.join("images.db-shm").exists());
+        assert_eq!(
+            fs::read_to_string(local.join("images.db")).expect("local db should exist"),
+            "db"
+        );
+        assert_eq!(
+            fs::read_to_string(local.join("images.db-wal")).expect("local wal should exist"),
+            "wal"
+        );
+        assert_eq!(
+            fs::read_to_string(local.join("images.db-shm")).expect("local shm should exist"),
+            "shm"
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn database_local_migration_does_not_overwrite_existing_local_db() {
+        let root = unique_temp_root("db-local-conflict");
+        let roaming = root.join("Roaming").join(PRODUCTION_IDENTIFIER);
+        let local = root.join("Local").join(PRODUCTION_IDENTIFIER);
+        write_file(&roaming.join("images.db"), "roaming-db");
+        write_file(&local.join("images.db"), "local-db");
+
+        let outcome = migrate_database_files_to_local(&roaming, &local);
+
+        assert_eq!(outcome, DatabaseLocalMigrationOutcome::SkippedExistingLocal);
+        assert_eq!(
+            fs::read_to_string(roaming.join("images.db")).expect("roaming db should remain"),
+            "roaming-db"
+        );
+        assert_eq!(
+            fs::read_to_string(local.join("images.db")).expect("local db should remain"),
+            "local-db"
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn database_local_migration_failure_leaves_roaming_db_usable() {
+        let root = unique_temp_root("db-local-failure");
+        let roaming = root.join("Roaming").join(PRODUCTION_IDENTIFIER);
+        let local = root.join("Local").join(PRODUCTION_IDENTIFIER);
+        write_file(&roaming.join("images.db"), "roaming-db");
+        write_file(&local, "not-a-directory");
+
+        let outcome = migrate_database_files_to_local(&roaming, &local);
+
+        assert_eq!(outcome, DatabaseLocalMigrationOutcome::Failed);
+        assert_eq!(
+            fs::read_to_string(roaming.join("images.db")).expect("roaming db should remain"),
+            "roaming-db"
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn database_copy_fallback_copies_and_verifies_existing_files() {
+        let root = unique_temp_root("db-copy-fallback");
+        let roaming = root.join("Roaming").join(PRODUCTION_IDENTIFIER);
+        let local = root.join("Local").join(PRODUCTION_IDENTIFIER);
+        write_file(&roaming.join("images.db"), "db");
+        write_file(&roaming.join("images.db-wal"), "wal");
+        fs::create_dir_all(&local).expect("local test directory should be created");
+        let files = existing_database_file_moves(&roaming, &local);
+
+        copy_database_files_to_local(&files).expect("copy fallback should succeed");
+
+        assert_eq!(
+            fs::read_to_string(local.join("images.db")).expect("local db should exist"),
+            "db"
+        );
+        assert_eq!(
+            fs::read_to_string(local.join("images.db-wal")).expect("local wal should exist"),
+            "wal"
+        );
+        assert!(!roaming.join("images.db").exists());
+        assert!(!roaming.join("images.db-wal").exists());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn database_local_migration_prepares_local_dir_for_fresh_profile() {
+        let root = unique_temp_root("db-local-fresh");
+        let roaming = root.join("Roaming").join(PRODUCTION_IDENTIFIER);
+        let local = root.join("Local").join(PRODUCTION_IDENTIFIER);
+
+        let outcome = migrate_database_files_to_local(&roaming, &local);
+
+        assert_eq!(outcome, DatabaseLocalMigrationOutcome::SourceMissing);
+        assert!(local.is_dir());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_production_purge_removes_local_and_roaming_catalogs() {
+        let root = unique_temp_root("purge-prod-current");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        let roaming_profile = roaming_root.join(PRODUCTION_IDENTIFIER);
+        let dev_profile = local_root.join("com.ambit.dev");
+        write_purge_marker(&local_profile);
+        write_purge_marker(&roaming_profile);
+        write_db_triplet(&local_profile, "local");
+        write_db_triplet(&roaming_profile, "roaming");
+        write_db_triplet(&dev_profile, "dev");
+        write_file(&local_profile.join("library.json"), "{}");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 6);
+        assert_eq!(outcome.markers_deleted, 2);
+        assert_db_triplet_missing(&local_profile);
+        assert_db_triplet_missing(&roaming_profile);
+        assert_db_triplet_exists(&dev_profile);
+        assert_eq!(
+            fs::read_to_string(local_profile.join("library.json"))
+                .expect("library settings should not be purged"),
+            "{}"
+        );
+        assert!(!local_profile.join(PURGE_MARKER_FILE).exists());
+        assert!(!roaming_profile.join(PURGE_MARKER_FILE).exists());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_roaming_fallback_purge_prevents_local_migration_restore() {
+        let root = unique_temp_root("purge-roaming-fallback");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let roaming_profile = roaming_root.join(PRODUCTION_IDENTIFIER);
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        write_purge_marker(&roaming_profile);
+        write_db_triplet(&roaming_profile, "roaming");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+        let migration_outcome = migrate_database_files_to_local(&roaming_profile, &local_profile);
+
+        assert_eq!(outcome.database_files_deleted, 3);
+        assert_eq!(outcome.markers_deleted, 1);
+        assert_eq!(migration_outcome, DatabaseLocalMigrationOutcome::SourceMissing);
+        assert_db_triplet_missing(&roaming_profile);
+        assert!(!local_profile.join("images.db").exists());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_production_purge_removes_legacy_catalog_copies() {
+        let root = unique_temp_root("purge-prod-legacy");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let current_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        let legacy_local_profile = local_root.join(LEGACY_PRODUCTION_IDENTIFIER);
+        let legacy_roaming_profile = roaming_root.join(LEGACY_PRODUCTION_IDENTIFIER);
+        write_purge_marker(&current_profile);
+        write_db_triplet(&legacy_local_profile, "legacy-local");
+        write_db_triplet(&legacy_roaming_profile, "legacy-roaming");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 6);
+        assert_db_triplet_missing(&legacy_local_profile);
+        assert_db_triplet_missing(&legacy_roaming_profile);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_non_production_purge_is_limited_to_marked_profile() {
+        let root = unique_temp_root("purge-dev-only");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let dev_profile = local_root.join("com.ambit.dev");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        let roaming_profile = roaming_root.join(PRODUCTION_IDENTIFIER);
+        write_purge_marker(&dev_profile);
+        write_db_triplet(&dev_profile, "dev");
+        write_db_triplet(&local_profile, "local");
+        write_db_triplet(&roaming_profile, "roaming");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 3);
+        assert_eq!(outcome.markers_deleted, 1);
+        assert_db_triplet_missing(&dev_profile);
+        assert_db_triplet_exists(&local_profile);
+        assert_db_triplet_exists(&roaming_profile);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_production_purge_keeps_marker_when_database_delete_fails() {
+        let root = unique_temp_root("purge-prod-failure-keeps-marker");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        write_purge_marker(&local_profile);
+        fs::create_dir_all(local_profile.join("images.db"))
+            .expect("directory-shaped db sentinel should be created");
+        write_file(&local_profile.join("images.db-wal"), "wal");
+        write_file(&local_profile.join("images.db-shm"), "shm");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 2);
+        assert_eq!(outcome.markers_deleted, 0);
+        assert_eq!(outcome.failures, 1);
+        assert!(local_profile.join(PURGE_MARKER_FILE).exists());
+        assert!(local_profile.join("images.db").is_dir());
+        assert!(!local_profile.join("images.db-wal").exists());
+        assert!(!local_profile.join("images.db-shm").exists());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_unmarked_roaming_failure_keeps_only_production_marker() {
+        let root = unique_temp_root("purge-roaming-failure-keeps-marker");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        let roaming_profile = roaming_root.join(PRODUCTION_IDENTIFIER);
+        write_purge_marker(&local_profile);
+        fs::create_dir_all(roaming_profile.join("images.db"))
+            .expect("directory-shaped roaming db sentinel should be created");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 0);
+        assert_eq!(outcome.markers_deleted, 0);
+        assert_eq!(outcome.failures, 1);
+        assert!(local_profile.join(PURGE_MARKER_FILE).exists());
+        assert!(roaming_profile.join("images.db").is_dir());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_non_production_failure_keeps_only_its_marker() {
+        let root = unique_temp_root("purge-dev-failure-keeps-marker");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let dev_profile = local_root.join("com.ambit.dev");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        write_purge_marker(&dev_profile);
+        fs::create_dir_all(dev_profile.join("images.db"))
+            .expect("directory-shaped dev db sentinel should be created");
+        write_db_triplet(&local_profile, "local");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 0);
+        assert_eq!(outcome.markers_deleted, 0);
+        assert_eq!(outcome.failures, 1);
+        assert!(dev_profile.join(PURGE_MARKER_FILE).exists());
+        assert!(dev_profile.join("images.db").is_dir());
+        assert_db_triplet_exists(&local_profile);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_marker_only_purge_removes_stale_marker() {
+        let root = unique_temp_root("purge-marker-only");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        write_purge_marker(&local_profile);
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome.database_files_deleted, 0);
+        assert_eq!(outcome.markers_deleted, 1);
+        assert_eq!(outcome.failures, 0);
+        assert!(!local_profile.join(PURGE_MARKER_FILE).exists());
+        cleanup(&root);
+    }
+
+    #[test]
+    fn deferred_purge_without_marker_leaves_database_files() {
+        let root = unique_temp_root("purge-no-marker");
+        let roaming_root = root.join("Roaming");
+        let local_root = root.join("Local");
+        let local_profile = local_root.join(PRODUCTION_IDENTIFIER);
+        let roaming_profile = roaming_root.join(PRODUCTION_IDENTIFIER);
+        write_db_triplet(&local_profile, "local");
+        write_db_triplet(&roaming_profile, "roaming");
+
+        let outcome = execute_deferred_purge_for_roots(&[roaming_root, local_root]);
+
+        assert_eq!(outcome, DeferredPurgeOutcome::default());
+        assert_db_triplet_exists(&local_profile);
+        assert_db_triplet_exists(&roaming_profile);
         cleanup(&root);
     }
 

--- a/src-tauri/src/db/commands/maintenance.rs
+++ b/src-tauri/src/db/commands/maintenance.rs
@@ -1,5 +1,5 @@
 use super::run_blocking;
-use crate::db::resolve_db_path;
+use crate::db::{resolve_db_path, resolve_db_path_info, resolve_main_database_url};
 use rusqlite::params;
 use sha2::{Digest, Sha256};
 use std::fs::File;
@@ -24,6 +24,10 @@ impl Default for FileHashBackfillState {
 #[serde(rename_all = "camelCase")]
 pub struct DbDiagnostics {
     pub db_path: String,
+    pub active_db_path: String,
+    pub local_db_path: String,
+    pub roaming_db_path: String,
+    pub is_using_roaming_fallback: bool,
     pub image_count: i64,
     pub deleted_count: i64,
     pub model_count: i64,
@@ -69,10 +73,17 @@ fn hash_file_sha256(path: &str) -> Result<String, String> {
 
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
+pub fn get_main_database_url(app: AppHandle) -> Result<String, String> {
+    resolve_main_database_url(&app)
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
 pub async fn get_db_diagnostics(app: AppHandle) -> Result<DbDiagnostics, String> {
     let app_clone = app.clone();
     run_blocking(app, move |conn| {
-        let db_path = resolve_db_path(&app_clone)?;
+        let path_info = resolve_db_path_info(&app_clone)?;
+        let db_path = path_info.active_path.clone();
         let image_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM images", [], |r| r.get(0))
             .unwrap_or(0);
@@ -99,6 +110,10 @@ pub async fn get_db_diagnostics(app: AppHandle) -> Result<DbDiagnostics, String>
 
         Ok(DbDiagnostics {
             db_path: db_path.to_string_lossy().to_string(),
+            active_db_path: path_info.active_path.to_string_lossy().to_string(),
+            local_db_path: path_info.local_path.to_string_lossy().to_string(),
+            roaming_db_path: path_info.roaming_path.to_string_lossy().to_string(),
+            is_using_roaming_fallback: path_info.is_using_roaming_fallback,
             image_count,
             deleted_count,
             model_count,

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -1,5 +1,5 @@
 use rusqlite::Connection;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::Manager;
 
 pub mod backup;
@@ -8,6 +8,11 @@ pub mod error;
 pub mod facets;
 pub mod migrations;
 pub mod reparse;
+
+#[cfg(any(test, all(windows, not(debug_assertions))))]
+const PRODUCTION_IDENTIFIER: &str = "io.github.asuraace.ambit";
+pub const MAIN_DB_FILE_NAME: &str = "images.db";
+pub const LEGACY_MAIN_DB_URL: &str = "sqlite:images.db";
 
 /// Apply performance-optimized PRAGMAs to a SQLite connection.
 /// Should be called immediately after opening any rusqlite connection.
@@ -134,26 +139,346 @@ pub struct ProgressPayload {
     pub message: String,
 }
 
-// Helper to resolve the correct DB path used by tauri-plugin-sql
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbPathInfo {
+    pub active_path: PathBuf,
+    pub local_path: PathBuf,
+    pub roaming_path: PathBuf,
+    pub is_using_roaming_fallback: bool,
+}
+
+#[cfg(all(windows, not(debug_assertions)))]
+pub fn main_database_migration_urls() -> Vec<String> {
+    production_database_migration_urls()
+}
+
+#[cfg(not(all(windows, not(debug_assertions))))]
+pub fn main_database_migration_urls() -> Vec<String> {
+    vec![LEGACY_MAIN_DB_URL.to_string()]
+}
+
+pub fn resolve_db_path_info(app: &tauri::AppHandle) -> Result<DbPathInfo, String> {
+    let roaming_path = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| e.to_string())?
+        .join(MAIN_DB_FILE_NAME);
+    let local_path = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| e.to_string())?
+        .join(MAIN_DB_FILE_NAME);
+
+    let prefer_local = should_prefer_local_app_data();
+    let (active_path, is_using_roaming_fallback) =
+        choose_active_db_path(&local_path, &roaming_path, prefer_local);
+
+    if let Some(parent) = active_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+
+    Ok(DbPathInfo {
+        active_path,
+        local_path,
+        roaming_path,
+        is_using_roaming_fallback,
+    })
+}
+
+pub fn resolve_main_database_url(app: &tauri::AppHandle) -> Result<String, String> {
+    let info = resolve_db_path_info(app)?;
+    Ok(database_url_for_active_path(
+        &info.active_path,
+        should_use_local_sql_url(),
+    ))
+}
+
+// Helper to resolve the correct DB path used by native rusqlite maintenance commands.
 pub fn resolve_db_path(app: &tauri::AppHandle) -> Result<PathBuf, String> {
-    // 1. Prioritize Roaming (app_config_dir/app_data_dir) - This is where 6GB db lives
-    if let Ok(mut path) = app.path().app_config_dir() {
-        path.push("images.db");
-        if path.exists() {
-            return Ok(path);
+    Ok(resolve_db_path_info(app)?.active_path)
+}
+
+fn should_prefer_local_app_data() -> bool {
+    cfg!(all(windows, not(debug_assertions)))
+}
+
+fn should_use_local_sql_url() -> bool {
+    cfg!(all(windows, not(debug_assertions)))
+}
+
+fn choose_active_db_path(
+    local_path: &Path,
+    roaming_path: &Path,
+    prefer_local: bool,
+) -> (PathBuf, bool) {
+    if prefer_local {
+        if local_path.exists() {
+            return (local_path.to_path_buf(), false);
         }
+        if roaming_path.exists() {
+            return (roaming_path.to_path_buf(), true);
+        }
+        return (local_path.to_path_buf(), false);
     }
 
-    // 2. Fallback to Local (app_local_data_dir)
-    if let Ok(mut path) = app.path().app_local_data_dir() {
-        path.push("images.db");
-        if path.exists() {
-            return Ok(path);
-        }
+    if roaming_path.exists() {
+        return (roaming_path.to_path_buf(), false);
+    }
+    if local_path.exists() {
+        return (local_path.to_path_buf(), false);
+    }
+    (roaming_path.to_path_buf(), false)
+}
+
+fn database_url_for_active_path(active_path: &Path, use_local_sql_url: bool) -> String {
+    if !use_local_sql_url {
+        return LEGACY_MAIN_DB_URL.to_string();
     }
 
-    // 3. Absolute default
-    let mut path = app.path().app_config_dir().map_err(|e| e.to_string())?;
-    path.push("images.db");
-    Ok(path)
+    sqlite_url_for_path(active_path)
+}
+
+fn sqlite_url_for_path(path: &Path) -> String {
+    format!("sqlite:{}", path.to_string_lossy().replace('\\', "/"))
+}
+
+#[cfg(any(test, all(windows, not(debug_assertions))))]
+fn push_unique_url(urls: &mut Vec<String>, url: String) {
+    if urls.iter().any(|existing| existing == &url) {
+        return;
+    }
+    urls.push(url);
+}
+
+#[cfg(all(windows, not(debug_assertions)))]
+fn production_database_migration_urls() -> Vec<String> {
+    let mut urls = Vec::new();
+
+    if let Some(local_root) = dirs::data_local_dir() {
+        push_unique_url(
+            &mut urls,
+            sqlite_url_for_path(
+                &local_root
+                    .join(PRODUCTION_IDENTIFIER)
+                    .join(MAIN_DB_FILE_NAME),
+            ),
+        );
+    }
+
+    if let Some(roaming_root) = dirs::config_dir() {
+        push_unique_url(
+            &mut urls,
+            sqlite_url_for_path(
+                &roaming_root
+                    .join(PRODUCTION_IDENTIFIER)
+                    .join(MAIN_DB_FILE_NAME),
+            ),
+        );
+    }
+
+    push_unique_url(&mut urls, LEGACY_MAIN_DB_URL.to_string());
+    urls
+}
+
+#[cfg(test)]
+fn production_database_migration_urls_for_roots(
+    local_root: &Path,
+    roaming_root: &Path,
+) -> Vec<String> {
+    let mut urls = Vec::new();
+
+    push_unique_url(
+        &mut urls,
+        sqlite_url_for_path(
+            &local_root
+                .join(PRODUCTION_IDENTIFIER)
+                .join(MAIN_DB_FILE_NAME),
+        ),
+    );
+    push_unique_url(
+        &mut urls,
+        sqlite_url_for_path(
+            &roaming_root
+                .join(PRODUCTION_IDENTIFIER)
+                .join(MAIN_DB_FILE_NAME),
+        ),
+    );
+    push_unique_url(&mut urls, LEGACY_MAIN_DB_URL.to_string());
+    urls
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_root(test_name: &str) -> PathBuf {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be after unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "ambit-db-path-{test_name}-{}-{timestamp}",
+            std::process::id()
+        ))
+    }
+
+    fn write_file(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("test parent directory should be created");
+        }
+        fs::write(path, contents).expect("test file should be written");
+    }
+
+    fn cleanup(root: &Path) {
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn local_db_is_preferred_when_requested_and_present() {
+        let root = unique_temp_root("local-present");
+        let local = root.join("Local").join(MAIN_DB_FILE_NAME);
+        let roaming = root.join("Roaming").join(MAIN_DB_FILE_NAME);
+        write_file(&local, "local");
+        write_file(&roaming, "roaming");
+
+        let (active, using_roaming_fallback) = choose_active_db_path(&local, &roaming, true);
+
+        assert_eq!(active, local);
+        assert!(!using_roaming_fallback);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn roaming_db_is_used_only_as_local_fallback() {
+        let root = unique_temp_root("roaming-fallback");
+        let local = root.join("Local").join(MAIN_DB_FILE_NAME);
+        let roaming = root.join("Roaming").join(MAIN_DB_FILE_NAME);
+        write_file(&roaming, "roaming");
+
+        let (active, using_roaming_fallback) = choose_active_db_path(&local, &roaming, true);
+
+        assert_eq!(active, roaming);
+        assert!(using_roaming_fallback);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn fresh_db_defaults_to_local_when_requested() {
+        let root = unique_temp_root("fresh-local");
+        let local = root.join("Local").join(MAIN_DB_FILE_NAME);
+        let roaming = root.join("Roaming").join(MAIN_DB_FILE_NAME);
+
+        let (active, using_roaming_fallback) = choose_active_db_path(&local, &roaming, true);
+
+        assert_eq!(active, local);
+        assert!(!using_roaming_fallback);
+        cleanup(&root);
+    }
+
+    #[test]
+    fn dev_profile_defaults_to_legacy_sql_url() {
+        let local_path = Path::new(
+            "C:\\Users\\Artemis\\AppData\\Local\\io.github.asuraace.ambit\\images.db",
+        );
+
+        assert_eq!(
+            database_url_for_active_path(local_path, false),
+            LEGACY_MAIN_DB_URL
+        );
+    }
+
+    #[test]
+    fn sqlite_url_for_path_normalizes_windows_separators() {
+        let local_path = Path::new(
+            "C:\\Users\\Artemis\\AppData\\Local\\io.github.asuraace.ambit\\images.db",
+        );
+
+        assert_eq!(
+            sqlite_url_for_path(local_path),
+            "sqlite:C:/Users/Artemis/AppData/Local/io.github.asuraace.ambit/images.db"
+        );
+    }
+
+    #[test]
+    fn non_production_migration_urls_use_legacy_sql_url() {
+        assert_eq!(
+            main_database_migration_urls(),
+            vec![LEGACY_MAIN_DB_URL.to_string()]
+        );
+    }
+
+    #[test]
+    fn production_sql_url_uses_resolved_local_path_when_local_is_active() {
+        let root = unique_temp_root("production-local-url");
+        let local = root
+            .join("redirected-local")
+            .join(PRODUCTION_IDENTIFIER)
+            .join(MAIN_DB_FILE_NAME);
+        write_file(&local, "local");
+
+        assert_eq!(
+            database_url_for_active_path(&local, true),
+            sqlite_url_for_path(&local)
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn production_sql_url_uses_resolved_roaming_path_when_roaming_is_active() {
+        let root = unique_temp_root("production-roaming-url");
+        let roaming = root
+            .join("redirected-roaming")
+            .join(PRODUCTION_IDENTIFIER)
+            .join(MAIN_DB_FILE_NAME);
+        write_file(&roaming, "roaming");
+
+        assert_eq!(
+            database_url_for_active_path(&roaming, true),
+            sqlite_url_for_path(&roaming)
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn production_sql_url_defaults_to_resolved_local_path_for_fresh_profiles() {
+        let root = unique_temp_root("production-fresh-url");
+        let local = root
+            .join("local")
+            .join(PRODUCTION_IDENTIFIER)
+            .join(MAIN_DB_FILE_NAME);
+
+        assert_eq!(
+            database_url_for_active_path(&local, true),
+            sqlite_url_for_path(&local)
+        );
+        cleanup(&root);
+    }
+
+    #[test]
+    fn production_migration_urls_include_dynamic_local_roaming_and_legacy_urls() {
+        let root = unique_temp_root("production-migration-urls");
+        let local_root = root.join("Local");
+        let roaming_root = root.join("Redirected").join("Roaming");
+        let expected_local = sqlite_url_for_path(
+            &local_root
+                .join(PRODUCTION_IDENTIFIER)
+                .join(MAIN_DB_FILE_NAME),
+        );
+        let expected_roaming = sqlite_url_for_path(
+            &roaming_root
+                .join(PRODUCTION_IDENTIFIER)
+                .join(MAIN_DB_FILE_NAME),
+        );
+
+        let urls = production_database_migration_urls_for_roots(&local_root, &roaming_root);
+
+        assert_eq!(
+            urls,
+            vec![expected_local, expected_roaming, LEGACY_MAIN_DB_URL.to_string()]
+        );
+        cleanup(&root);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,7 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         // db commands
         db::commands::image_commands::save_images_batch,
         db::commands::image_commands::move_image_path_identities,
+        db::commands::maintenance::get_main_database_url,
         db::commands::maintenance::get_db_diagnostics,
         db::commands::maintenance::backfill_image_file_hashes,
         db::commands::maintenance::cancel_image_file_hash_backfill,
@@ -110,8 +111,21 @@ pub fn run() {
     }
 
     // Check for deferred purge request BEFORE initializing the database.
-    check_and_execute_deferred_purge();
+    app_data_migration::check_and_execute_deferred_purge();
+
+    // Move the production SQLite catalog from Roaming AppData to Local AppData
+    // before tauri-plugin-sql can open images.db.
+    if cfg!(all(windows, not(debug_assertions))) {
+        app_data_migration::migrate_current_database_to_local_app_data();
+    }
+
     repair_known_migration_metadata();
+
+    let sql_builder = db::main_database_migration_urls()
+        .into_iter()
+        .fold(tauri_plugin_sql::Builder::default(), |builder, db_url| {
+            builder.add_migrations(&db_url, db::migrations::init_db())
+        });
 
     let log_level = std::env::var("RUST_LOG")
         .unwrap_or_else(|_| "info".to_string())
@@ -125,9 +139,7 @@ pub fn run() {
                 .build(),
         )
         .plugin(
-            tauri_plugin_sql::Builder::default()
-                .add_migrations("sqlite:images.db", db::migrations::init_db())
-                .build(),
+            sql_builder.build(),
         )
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
@@ -185,70 +197,6 @@ pub fn run() {
                 }
             }
         });
-}
-
-/// Check for and execute any pending database purge request.
-/// This runs BEFORE the SQL plugin initializes, so the DB file isn't locked yet.
-#[cfg(not(test))]
-fn check_and_execute_deferred_purge() {
-    // Check current and transitional identifiers in both Roaming and Local AppData.
-    for app_dir in app_data_migration::app_identifier_dirs_to_check() {
-        let marker_path = app_dir.join(".purge_on_restart");
-
-        if marker_path.exists() {
-            println!(
-                "[Purge] Found purge marker at {:?}! Proceeding to delete database...",
-                marker_path
-            );
-
-            // Delete the marker first
-            let _ = std::fs::remove_file(&marker_path);
-
-            // Delete database files with retry loop for Windows file locking
-            let db_path = app_dir.join("images.db");
-            let wal_path = app_dir.join("images.db-wal");
-            let shm_path = app_dir.join("images.db-shm");
-
-            if db_path.exists() {
-                let mut attempts = 0;
-                let max_attempts = 5;
-                let mut success = false;
-
-                while attempts < max_attempts && !success {
-                    match std::fs::remove_file(&db_path) {
-                        Ok(_) => {
-                            println!(
-                                "[Purge] SUCCESS: Database deleted. Fresh DB will be created."
-                            );
-                            success = true;
-                        }
-                        Err(e) => {
-                            attempts += 1;
-                            eprintln!(
-                                "[Purge] Attempt {}/{} failed to delete database: {}",
-                                attempts, max_attempts, e
-                            );
-                            if attempts < max_attempts {
-                                std::thread::sleep(std::time::Duration::from_millis(500));
-                            }
-                        }
-                    }
-                }
-
-                if !success {
-                    eprintln!("[Purge] FATAL: Could not delete database after {} attempts. Manual intervention may be required.", max_attempts);
-                }
-            }
-
-            // Best effort cleanup for WAL/SHM files
-            if wal_path.exists() {
-                let _ = std::fs::remove_file(&wal_path);
-            }
-            if shm_path.exists() {
-                let _ = std::fs::remove_file(&shm_path);
-            }
-        }
-    }
 }
 
 /// Repair historical migration metadata for a known development/mainline collision.

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -45,6 +45,14 @@ async moveImagePathIdentities(moves: ImagePathIdentityMove[]) : Promise<Result<I
     else return { status: "error", error: e  as any };
 }
 },
+async getMainDatabaseUrl() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_main_database_url") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getDbDiagnostics() : Promise<Result<DbDiagnostics, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_db_diagnostics") };
@@ -549,7 +557,7 @@ async getInvokeDbSnapshot(rootPath: string) : Promise<Result<InvokeDbSnapshot, s
 export type A1111DiscoveryCandidate = { path: string; name: string; imageCount: number; inferredType: string; isPriority: boolean; variant: string }
 export type A1111DiscoveryResult = { detectedVariant: string; candidates: A1111DiscoveryCandidate[]; logs: string[]; warnings: string[] }
 export type BackupInfo = { name: string; path: string; createdAt: string; sizeBytes: number }
-export type DbDiagnostics = { dbPath: string; imageCount: number; deletedCount: number; modelCount: number; cacheCount: number; toolNullCount: number }
+export type DbDiagnostics = { dbPath: string; activeDbPath: string; localDbPath: string; roamingDbPath: string; isUsingRoamingFallback: boolean; imageCount: number; deletedCount: number; modelCount: number; cacheCount: number; toolNullCount: number }
 export type FacetResourceTouches = { checkpoints: string[]; loras: string[]; embeddings: string[]; hypernetworks: string[]; controlNets: string[]; ipAdapters: string[]; tools: string[] }
 export type FileEntry = { path: string; modified: number; size: number }
 export type FileHashBackfillResult = { scanned: number; updated: number; missing: number; errors: number; remaining: number; wasCancelled: boolean }

--- a/src/features/settings/components/AdvancedTab.tsx
+++ b/src/features/settings/components/AdvancedTab.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useState } from 'react';
 import { Trash2, History as HistoryIcon, Loader2, Database, AlertTriangle, Monitor, RefreshCw, ExternalLink } from 'lucide-react';
 import { AppSettings, LogLevel } from '../../../types';
+import { commands, type DbDiagnostics } from '../../../bindings';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
 import { useLibraryContext } from '../../../hooks/useLibraryContext';
 import { useLibraryStore } from '../../../stores/libraryStore';
@@ -9,6 +10,7 @@ import { BackupSettings } from './BackupSettings';
 import { useToast } from '../../../hooks/useToast';
 import { APP_NAME } from '../../../constants/app';
 import { AppUpdaterStatus } from '../../../hooks/useAppUpdater';
+import { unwrap } from '../../../utils/spectaUtils';
 
 interface TabProps {
     settings: AppSettings;
@@ -44,6 +46,8 @@ export const AdvancedTab: React.FC<TabProps> = ({
     const { addToast } = useToast();
 
     const [isPurging, setIsPurging] = useState(false);
+    const [dbDiagnostics, setDbDiagnostics] = useState<DbDiagnostics | null>(null);
+    const [dbDiagnosticsError, setDbDiagnosticsError] = useState<string | null>(null);
 
     const [activeTab, setActiveTab] = useState<'database' | 'interface' | 'support'>('database');
 
@@ -117,6 +121,25 @@ export const AdvancedTab: React.FC<TabProps> = ({
         onNavigateToMaintenance();
         onClose?.();
     };
+
+    React.useEffect(() => {
+        if (activeTab !== 'support' || dbDiagnostics || dbDiagnosticsError) return;
+
+        let isMounted = true;
+        unwrap(commands.getDbDiagnostics())
+            .then((diagnostics) => {
+                if (isMounted) setDbDiagnostics(diagnostics);
+            })
+            .catch((error) => {
+                if (isMounted) {
+                    setDbDiagnosticsError(error instanceof Error ? error.message : String(error));
+                }
+            });
+
+        return () => {
+            isMounted = false;
+        };
+    }, [activeTab, dbDiagnostics, dbDiagnosticsError]);
 
     return (
         <div className="space-y-6 max-w-2xl animate-in fade-in slide-in-from-bottom-2 duration-300">
@@ -284,6 +307,52 @@ export const AdvancedTab: React.FC<TabProps> = ({
                                 Debug logging can be noisy. Use it when collecting information for an issue, then switch back to Info or Warn.
                             </div>
                         )}
+
+                        <div className="p-6 space-y-3">
+                            <div>
+                                <div className="text-sm font-bold text-gray-900 dark:text-gray-200">Library Database Location</div>
+                                <div className="text-xs text-gray-500 mt-1">
+                                    Ambit stores the library catalog in Local AppData. This is separate from the folder where the app itself is installed.
+                                </div>
+                            </div>
+
+                            {dbDiagnostics ? (
+                                <div className="space-y-2 text-xs">
+                                    {dbDiagnostics.isUsingRoamingFallback && (
+                                        <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 font-medium text-amber-800 dark:border-amber-400/20 dark:bg-amber-500/10 dark:text-amber-200">
+                                            Ambit is using the legacy Roaming AppData database because no Local AppData database is available.
+                                        </div>
+                                    )}
+                                    <div className="rounded-lg bg-gray-50 p-3 dark:bg-black/20">
+                                        <div className="font-bold uppercase tracking-wider text-gray-400">Active catalog</div>
+                                        <div className="mt-1 break-all font-mono text-gray-700 dark:text-gray-300">
+                                            {dbDiagnostics.activeDbPath || dbDiagnostics.dbPath}
+                                        </div>
+                                    </div>
+                                    <div className="rounded-lg bg-gray-50 p-3 dark:bg-black/20">
+                                        <div className="font-bold uppercase tracking-wider text-gray-400">Local AppData target</div>
+                                        <div className="mt-1 break-all font-mono text-gray-700 dark:text-gray-300">
+                                            {dbDiagnostics.localDbPath}
+                                        </div>
+                                    </div>
+                                    <div className="rounded-lg bg-gray-50 p-3 dark:bg-black/20">
+                                        <div className="font-bold uppercase tracking-wider text-gray-400">Legacy Roaming fallback</div>
+                                        <div className="mt-1 break-all font-mono text-gray-700 dark:text-gray-300">
+                                            {dbDiagnostics.roamingDbPath}
+                                        </div>
+                                    </div>
+                                </div>
+                            ) : dbDiagnosticsError ? (
+                                <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-xs font-medium text-rose-800 dark:border-rose-400/20 dark:bg-rose-500/10 dark:text-rose-200">
+                                    Could not load database location: {dbDiagnosticsError}
+                                </div>
+                            ) : (
+                                <div className="flex items-center gap-2 text-xs font-medium text-gray-500">
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                    Loading database location...
+                                </div>
+                            )}
+                        </div>
 
                         <div className="p-6 flex items-center justify-between gap-4">
                             <div>

--- a/src/features/settings/components/__tests__/AdvancedTab.test.tsx
+++ b/src/features/settings/components/__tests__/AdvancedTab.test.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '../../../../test/testUtils';
+import { fireEvent, render, screen, waitFor } from '../../../../test/testUtils';
 import { AppSettings } from '../../../../types';
 import { AdvancedTab } from '../AdvancedTab';
 
 const addToastMock = vi.hoisted(() => vi.fn());
+const getDbDiagnosticsMock = vi.hoisted(() => vi.fn());
 const libraryContextMock = vi.hoisted(() => ({
     setSettings: vi.fn(),
     cleanLibrary: vi.fn().mockResolvedValue(undefined),
@@ -22,6 +23,12 @@ vi.mock('../../../../hooks/useLibraryContext', () => ({
 
 vi.mock('../BackupSettings', () => ({
     BackupSettings: () => <div>Backup settings</div>,
+}));
+
+vi.mock('../../../../bindings', () => ({
+    commands: {
+        getDbDiagnostics: getDbDiagnosticsMock,
+    },
 }));
 
 const createSettings = (overrides: Partial<AppSettings> = {}): AppSettings => ({
@@ -61,6 +68,21 @@ const renderAdvanced = (settings = createSettings(), onClose = vi.fn(), onNaviga
 describe('AdvancedTab', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        getDbDiagnosticsMock.mockResolvedValue({
+            status: 'ok',
+            data: {
+                dbPath: 'C:\\Users\\Artemis\\AppData\\Local\\io.github.asuraace.ambit\\images.db',
+                activeDbPath: 'C:\\Users\\Artemis\\AppData\\Local\\io.github.asuraace.ambit\\images.db',
+                localDbPath: 'C:\\Users\\Artemis\\AppData\\Local\\io.github.asuraace.ambit\\images.db',
+                roamingDbPath: 'C:\\Users\\Artemis\\AppData\\Roaming\\io.github.asuraace.ambit\\images.db',
+                isUsingRoamingFallback: false,
+                imageCount: 12,
+                deletedCount: 1,
+                modelCount: 2,
+                cacheCount: 3,
+                toolNullCount: 0,
+            },
+        });
     });
 
     it('does not expose the removed troubleshooting repair actions', () => {
@@ -81,6 +103,22 @@ describe('AdvancedTab', () => {
 
         expect(screen.getByText('Support Diagnostics')).not.toBeNull();
         expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('info');
+    });
+
+    it('renders the active library database location separately from the install location', async () => {
+        renderAdvanced();
+
+        fireEvent.click(screen.getByRole('button', { name: /support/i }));
+
+        expect(screen.getByText('Library Database Location')).not.toBeNull();
+        expect(screen.getByText(/separate from the folder where the app itself is installed/i)).not.toBeNull();
+
+        await waitFor(() => {
+            expect(screen.getByText('Active catalog')).not.toBeNull();
+            expect(screen.getByText('Local AppData target')).not.toBeNull();
+            expect(screen.getByText('Legacy Roaming fallback')).not.toBeNull();
+            expect(screen.getAllByText(/AppData\\Local\\io\.github\.asuraace\.ambit\\images\.db/)).toHaveLength(2);
+        });
     });
 
     it('warns when debug logging is selected', () => {

--- a/src/services/db/__tests__/connection.test.ts
+++ b/src/services/db/__tests__/connection.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const databaseLoadMock = vi.hoisted(() => vi.fn());
+const getMainDatabaseUrlMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@tauri-apps/plugin-sql', () => ({
+    default: {
+        load: databaseLoadMock,
+    },
+}));
+
+vi.mock('../../../bindings', () => ({
+    commands: {
+        getMainDatabaseUrl: getMainDatabaseUrlMock,
+    },
+}));
+
+const createDatabaseMock = () => ({
+    execute: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('database connection', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        getMainDatabaseUrlMock.mockResolvedValue({
+            status: 'ok',
+            data: 'sqlite:C:/Users/Artemis/AppData/Local/io.github.asuraace.ambit/images.db',
+        });
+        databaseLoadMock.mockResolvedValue(createDatabaseMock());
+    });
+
+    it('loads the backend-selected main database URL', async () => {
+        const { getDb } = await import('../connection');
+
+        await getDb();
+
+        expect(getMainDatabaseUrlMock).toHaveBeenCalledTimes(1);
+        expect(databaseLoadMock).toHaveBeenCalledWith(
+            'sqlite:C:/Users/Artemis/AppData/Local/io.github.asuraace.ambit/images.db'
+        );
+    });
+
+    it('shares one database URL lookup across concurrent startup loads', async () => {
+        const { getDb } = await import('../connection');
+
+        await Promise.all([getDb(), getDb()]);
+
+        expect(getMainDatabaseUrlMock).toHaveBeenCalledTimes(1);
+        expect(databaseLoadMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/services/db/connection.ts
+++ b/src/services/db/connection.ts
@@ -1,8 +1,11 @@
 import Database from '@tauri-apps/plugin-sql';
+import { commands } from '../../bindings';
+import { unwrap } from '../../utils/spectaUtils';
 
 let db: Database | null = null;
 let dbInitialized = false;
 let dbLoadPromise: Promise<Database> | null = null;
+let dbUrlPromise: Promise<string> | null = null;
 const SLOW_STARTUP_PHASE_MS = 1000;
 
 export type StartupDbPhase =
@@ -50,15 +53,27 @@ export class Mutex {
 
 export const dbMutex = new Mutex();
 
+const getMainDatabaseUrl = () => {
+    if (!dbUrlPromise) {
+        dbUrlPromise = unwrap(commands.getMainDatabaseUrl()).catch((error) => {
+            dbUrlPromise = null;
+            throw error;
+        });
+    }
+    return dbUrlPromise;
+};
+
 export const getDb = async (options: GetDbOptions = {}) => {
     if (!db) {
         options.onPhase?.('Updating database schema');
         const loadStartedAt = performance.now();
         if (!dbLoadPromise) {
-            dbLoadPromise = Database.load('sqlite:images.db').catch((error) => {
-                dbLoadPromise = null;
-                throw error;
-            });
+            dbLoadPromise = getMainDatabaseUrl()
+                .then((databaseUrl) => Database.load(databaseUrl))
+                .catch((error) => {
+                    dbLoadPromise = null;
+                    throw error;
+                });
         }
         db = await dbLoadPromise;
         logStartupDbPhase('Database.load', loadStartedAt);


### PR DESCRIPTION
## Summary
- move the production Ambit library database from Roaming AppData to Local AppData before SQL opens it
- keep Roaming as a legacy fallback/recovery path and avoid overwriting an existing Local database
- align frontend SQL loading, Rust maintenance commands, diagnostics, and docs around the resolved active database path
- make deferred purge clear all production catalog copies before removing purge markers, so old Roaming data cannot be restored after reset

## Validation
- `git diff --check`
- focused Rust DB path and purge/migration tests were run before commit
- focused frontend DB connection test was run before commit
- `corepack pnpm run typecheck` and `corepack pnpm run verify:release` were run before commit
- local production build smoke-tested against this branch by Artemis

## Manual Notes
After a successful upgrade, Ambit should actively use `%LOCALAPPDATA%\io.github.asuraace.ambit\images.db`. The Roaming database path is retained only as a fallback or manual recovery source during the transition.