### PR TITLE
fix: enforce local file boundaries

### DIFF
--- a/src-tauri/src/scanner/traversal.rs
+++ b/src-tauri/src/scanner/traversal.rs
@@ -406,23 +406,97 @@ mod tests {
     }
 
     #[cfg(unix)]
-    fn symlink_dir(target: &Path, link: &Path) -> io::Result<()> {
+    fn create_directory_link(target: &Path, link: &Path) -> io::Result<()> {
         std::os::unix::fs::symlink(target, link)
     }
 
     #[cfg(windows)]
-    fn symlink_dir(target: &Path, link: &Path) -> io::Result<()> {
-        std::os::windows::fs::symlink_dir(target, link)
+    fn create_directory_link(target: &Path, link: &Path) -> io::Result<()> {
+        match std::os::windows::fs::symlink_dir(target, link) {
+            Ok(()) => Ok(()),
+            Err(symlink_error) => {
+                let output = std::process::Command::new("cmd")
+                    .arg("/C")
+                    .arg("mklink")
+                    .arg("/J")
+                    .arg(link)
+                    .arg(target)
+                    .output();
+
+                match output {
+                    Ok(output) if output.status.success() => Ok(()),
+                    Ok(output) => Err(io::Error::new(
+                        symlink_error.kind(),
+                        format!(
+                            "symlink_dir failed: {symlink_error}; mklink /J failed: {}{}",
+                            String::from_utf8_lossy(&output.stdout),
+                            String::from_utf8_lossy(&output.stderr)
+                        ),
+                    )),
+                    Err(junction_error) => Err(io::Error::new(
+                        symlink_error.kind(),
+                        format!(
+                            "symlink_dir failed: {symlink_error}; mklink /J failed: {junction_error}"
+                        ),
+                    )),
+                }
+            }
+        }
     }
 
     #[cfg(unix)]
-    fn symlink_file(target: &Path, link: &Path) -> io::Result<()> {
+    fn create_file_link(target: &Path, link: &Path) -> io::Result<()> {
         std::os::unix::fs::symlink(target, link)
     }
 
     #[cfg(windows)]
-    fn symlink_file(target: &Path, link: &Path) -> io::Result<()> {
+    fn create_file_link(target: &Path, link: &Path) -> io::Result<()> {
         std::os::windows::fs::symlink_file(target, link)
+    }
+
+    fn assert_scanners_only_return(root: &Path, expected_absolute: &[String]) {
+        let mut stats = FolderStats::default();
+        scan_dir_recursive(root, root, &mut stats);
+        assert_eq!(stats.image_files, expected_absolute.len());
+
+        let mut relative = Vec::new();
+        collect_images_recursive(root, root, &mut relative);
+        relative.sort();
+        assert_eq!(relative, vec!["inside.png", "nested/inner.webp"]);
+
+        let mut absolute = Vec::new();
+        collect_images_recursive_absolute(root, root, &mut absolute);
+        absolute.sort();
+        assert_eq!(absolute, expected_absolute);
+
+        let mut with_stats = Vec::new();
+        collect_images_with_stats_recursive(root, &mut with_stats);
+        let mut with_stats_paths: Vec<_> = with_stats.iter().map(|entry| entry.path.clone()).collect();
+        with_stats_paths.sort();
+        assert_eq!(with_stats_paths, expected_absolute);
+
+        let mut since = Vec::new();
+        collect_images_with_stats_since_recursive(root, 0, &mut since);
+        let mut since_paths: Vec<_> = since.iter().map(|entry| entry.path.clone()).collect();
+        since_paths.sort();
+        assert_eq!(since_paths, expected_absolute);
+    }
+
+    fn create_link_fixture(name: &str) -> (TestDir, TestDir, PathBuf, Vec<String>) {
+        let root = TestDir::new(name);
+        let outside = TestDir::new(&format!("{name}-outside"));
+
+        let inside = root.path.join("inside.png");
+        let nested = root.path.join("nested").join("inner.webp");
+        let outside_image = outside.path.join("outside.png");
+        write_file(&inside);
+        write_file(&nested);
+        write_file(&outside_image);
+
+        let mut expected_absolute = vec![normalized(&inside), normalized(&nested)];
+        expected_absolute.sort();
+
+        (root, outside, outside_image, expected_absolute)
     }
 
     #[test]
@@ -445,52 +519,31 @@ mod tests {
     }
 
     #[test]
-    fn traversal_skips_linked_outside_entries_for_all_scanners() {
-        let root = TestDir::new("linked-root");
-        let outside = TestDir::new("linked-outside");
-
-        let inside = root.path.join("inside.png");
-        let nested = root.path.join("nested").join("inner.webp");
-        let outside_image = outside.path.join("outside.png");
-        write_file(&inside);
-        write_file(&nested);
-        write_file(&outside_image);
+    fn traversal_skips_linked_outside_directories_for_all_scanners() {
+        let (root, outside, _outside_image, expected_absolute) =
+            create_link_fixture("linked-dir-root");
 
         let linked_dir = root.path.join("linked-outside");
+        create_directory_link(&outside.path, &linked_dir).expect(
+            "directory symlink or junction should be available for traversal security coverage",
+        );
+
+        assert_scanners_only_return(&root.path, &expected_absolute);
+    }
+
+    #[test]
+    fn traversal_skips_linked_outside_files_for_all_scanners() {
+        let (root, _outside, outside_image, expected_absolute) =
+            create_link_fixture("linked-file-root");
+
         let linked_file = root.path.join("linked-file.png");
-        let _ = symlink_dir(&outside.path, &linked_dir);
-        let _ = symlink_file(&outside_image, &linked_file);
+        if let Err(error) = create_file_link(&outside_image, &linked_file) {
+            eprintln!(
+                "Skipping file symlink traversal coverage because file link creation failed: {error}"
+            );
+            return;
+        }
 
-        let mut stats = FolderStats::default();
-        scan_dir_recursive(&root.path, &root.path, &mut stats);
-        assert_eq!(stats.image_files, 2);
-
-        let mut relative = Vec::new();
-        collect_images_recursive(&root.path, &root.path, &mut relative);
-        relative.sort();
-        assert_eq!(relative, vec!["inside.png", "nested/inner.webp"]);
-
-        let expected_absolute = {
-            let mut values = vec![normalized(&inside), normalized(&nested)];
-            values.sort();
-            values
-        };
-
-        let mut absolute = Vec::new();
-        collect_images_recursive_absolute(&root.path, &root.path, &mut absolute);
-        absolute.sort();
-        assert_eq!(absolute, expected_absolute);
-
-        let mut with_stats = Vec::new();
-        collect_images_with_stats_recursive(&root.path, &mut with_stats);
-        let mut with_stats_paths: Vec<_> = with_stats.iter().map(|entry| entry.path.clone()).collect();
-        with_stats_paths.sort();
-        assert_eq!(with_stats_paths, expected_absolute);
-
-        let mut since = Vec::new();
-        collect_images_with_stats_since_recursive(&root.path, 0, &mut since);
-        let mut since_paths: Vec<_> = since.iter().map(|entry| entry.path.clone()).collect();
-        since_paths.sort();
-        assert_eq!(since_paths, expected_absolute);
+        assert_scanners_only_return(&root.path, &expected_absolute);
     }
 }

--- a/src-tauri/src/scanner/traversal.rs
+++ b/src-tauri/src/scanner/traversal.rs
@@ -1,37 +1,99 @@
-use super::models::FolderStats;
-use std::path::Path;
+use super::models::{FileEntry, FolderStats};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+const IMAGE_EXTENSIONS: [&str; 4] = ["png", "jpg", "jpeg", "webp"];
+
+fn canonical_root(root: &Path) -> Option<PathBuf> {
+    root.canonicalize().ok()
+}
+
+fn canonical_inside_root(root: &Path, path: &Path) -> Option<PathBuf> {
+    let canonical = path.canonicalize().ok()?;
+    if canonical.starts_with(root) {
+        Some(canonical)
+    } else {
+        None
+    }
+}
+
+fn is_thumbnail_dir(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.eq_ignore_ascii_case("thumbnails"))
+        .unwrap_or(false)
+}
+
+fn is_image_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .map(|ext| IMAGE_EXTENSIONS.contains(&ext.to_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+fn is_thumbnail_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| name.to_lowercase().ends_with("thumbnail.png"))
+        .unwrap_or(false)
+}
+
+fn safe_file(root: &Path, path: &Path, file_type: std::fs::FileType) -> bool {
+    !file_type.is_symlink() && file_type.is_file() && canonical_inside_root(root, path).is_some()
+}
+
+fn safe_dir(root: &Path, path: &Path, file_type: std::fs::FileType) -> bool {
+    !file_type.is_symlink() && file_type.is_dir() && canonical_inside_root(root, path).is_some()
+}
 
 pub fn scan_dir_recursive(root: &Path, current: &Path, stats: &mut FolderStats) {
+    let Some(root_canonical) = canonical_root(root) else {
+        return;
+    };
+    let mut visited = HashSet::new();
+    scan_dir_recursive_inner(root, &root_canonical, current, stats, &mut visited);
+}
+
+fn scan_dir_recursive_inner(
+    root: &Path,
+    root_canonical: &Path,
+    current: &Path,
+    stats: &mut FolderStats,
+    visited: &mut HashSet<PathBuf>,
+) {
+    let Some(current_canonical) = canonical_inside_root(root_canonical, current) else {
+        return;
+    };
+    if !visited.insert(current_canonical) {
+        return;
+    }
+
     if let Ok(entries) = std::fs::read_dir(current) {
         for entry in entries.flatten() {
             let p = entry.path();
-            if p.is_dir() {
-                if p.ends_with("thumbnails") {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+
+            if safe_dir(root_canonical, &p, file_type) {
+                if is_thumbnail_dir(&p) {
                     if let Ok(sub_entries) = std::fs::read_dir(&p) {
                         for sub_entry in sub_entries.flatten() {
-                            if sub_entry.path().is_file() {
-                                stats.thumbnail_files += 1;
+                            let sub_path = sub_entry.path();
+                            if let Ok(sub_type) = sub_entry.file_type() {
+                                if safe_file(root_canonical, &sub_path, sub_type) {
+                                    stats.thumbnail_files += 1;
+                                }
                             }
                         }
                     }
                 } else {
-                    scan_dir_recursive(root, &p, stats);
+                    scan_dir_recursive_inner(root, root_canonical, &p, stats, visited);
                 }
-            } else if p.is_file() {
+            } else if safe_file(root_canonical, &p, file_type) {
                 stats.total_files += 1;
-                let ext = p
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-                if ["png", "jpg", "jpeg", "webp"].contains(&ext.as_str()) {
-                    let is_thumbnail = p
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|n| n.to_lowercase().ends_with("thumbnail.png"))
-                        .unwrap_or(false);
-
-                    if is_thumbnail {
+                if is_image_path(&p) {
+                    if is_thumbnail_file(&p) {
                         stats.thumbnail_files += 1;
                     } else {
                         stats.image_files += 1;
@@ -56,35 +118,48 @@ pub fn scan_dir_recursive(root: &Path, current: &Path, stats: &mut FolderStats) 
 }
 
 pub fn collect_images_recursive(root: &Path, current: &Path, files: &mut Vec<String>) {
+    let Some(root_canonical) = canonical_root(root) else {
+        return;
+    };
+    let mut visited = HashSet::new();
+    collect_images_recursive_inner(root, &root_canonical, current, files, &mut visited);
+}
+
+fn collect_images_recursive_inner(
+    root: &Path,
+    root_canonical: &Path,
+    current: &Path,
+    files: &mut Vec<String>,
+    visited: &mut HashSet<PathBuf>,
+) {
     if files.len() > 300_000 {
+        return;
+    }
+
+    let Some(current_canonical) = canonical_inside_root(root_canonical, current) else {
+        return;
+    };
+    if !visited.insert(current_canonical) {
         return;
     }
 
     if let Ok(entries) = std::fs::read_dir(current) {
         for entry in entries.flatten() {
             let p = entry.path();
-            if p.is_dir() {
-                if !p.ends_with("thumbnails") {
-                    collect_images_recursive(root, &p, files);
-                }
-            } else if p.is_file() {
-                let ext = p
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-                if ["png", "jpg", "jpeg", "webp"].contains(&ext.as_str()) {
-                    let is_thumbnail = p
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|n| n.to_lowercase().ends_with("thumbnail.png"))
-                        .unwrap_or(false);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
 
-                    if !is_thumbnail {
-                        if let Ok(rel) = p.strip_prefix(root) {
-                            files.push(rel.to_string_lossy().replace("\\", "/"));
-                        }
-                    }
+            if safe_dir(root_canonical, &p, file_type) {
+                if !is_thumbnail_dir(&p) {
+                    collect_images_recursive_inner(root, root_canonical, &p, files, visited);
+                }
+            } else if safe_file(root_canonical, &p, file_type)
+                && is_image_path(&p)
+                && !is_thumbnail_file(&p)
+            {
+                if let Ok(rel) = p.strip_prefix(root) {
+                    files.push(rel.to_string_lossy().replace("\\", "/"));
                 }
             }
         }
@@ -92,87 +167,108 @@ pub fn collect_images_recursive(root: &Path, current: &Path, files: &mut Vec<Str
 }
 
 pub fn collect_images_recursive_absolute(root: &Path, current: &Path, files: &mut Vec<String>) {
-    if files.len() > 300_000 {
+    let Some(root_canonical) = canonical_root(root) else {
         return;
-    }
-
-    if let Ok(entries) = std::fs::read_dir(current) {
-        for entry in entries.flatten() {
-            let p = entry.path();
-            if p.is_dir() {
-                if !p.ends_with("thumbnails") {
-                    collect_images_recursive_absolute(root, &p, files);
-                }
-            } else if p.is_file() {
-                let ext = p
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-                if ["png", "jpg", "jpeg", "webp"].contains(&ext.as_str()) {
-                    let is_thumbnail = p
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|n| n.to_lowercase().ends_with("thumbnail.png"))
-                        .unwrap_or(false);
-
-                    if !is_thumbnail {
-                        files.push(p.to_string_lossy().replace("\\", "/"));
-                    }
-                }
-            }
-        }
-    }
+    };
+    let mut visited = HashSet::new();
+    collect_images_recursive_absolute_inner(&root_canonical, current, files, &mut visited);
 }
 
-pub fn collect_images_with_stats_recursive(
+fn collect_images_recursive_absolute_inner(
+    root_canonical: &Path,
     current: &Path,
-    files: &mut Vec<super::models::FileEntry>,
+    files: &mut Vec<String>,
+    visited: &mut HashSet<PathBuf>,
 ) {
     if files.len() > 300_000 {
         return;
     }
 
+    let Some(current_canonical) = canonical_inside_root(root_canonical, current) else {
+        return;
+    };
+    if !visited.insert(current_canonical) {
+        return;
+    }
+
     if let Ok(entries) = std::fs::read_dir(current) {
         for entry in entries.flatten() {
             let p = entry.path();
-            if p.is_dir() {
-                if !p.ends_with("thumbnails") {
-                    collect_images_with_stats_recursive(&p, files);
-                }
-            } else if p.is_file() {
-                let ext = p
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-                if ["png", "jpg", "jpeg", "webp"].contains(&ext.as_str()) {
-                    let is_thumbnail = p
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|n| n.to_lowercase().ends_with("thumbnail.png"))
-                        .unwrap_or(false);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
 
-                    if !is_thumbnail {
-                        let (size, modified) = match entry.metadata() {
-                            Ok(m) => (
-                                m.len(),
-                                m.modified()
-                                    .ok()
-                                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                                    .map(|d| d.as_millis() as u64)
-                                    .unwrap_or(0),
-                            ),
-                            Err(_) => (0, 0),
-                        };
-
-                        files.push(super::models::FileEntry {
-                            path: p.to_string_lossy().replace("\\", "/"),
-                            size,
-                            modified,
-                        });
-                    }
+            if safe_dir(root_canonical, &p, file_type) {
+                if !is_thumbnail_dir(&p) {
+                    collect_images_recursive_absolute_inner(root_canonical, &p, files, visited);
                 }
+            } else if safe_file(root_canonical, &p, file_type)
+                && is_image_path(&p)
+                && !is_thumbnail_file(&p)
+            {
+                files.push(p.to_string_lossy().replace("\\", "/"));
+            }
+        }
+    }
+}
+
+pub fn collect_images_with_stats_recursive(current: &Path, files: &mut Vec<FileEntry>) {
+    let Some(root_canonical) = canonical_root(current) else {
+        return;
+    };
+    let mut visited = HashSet::new();
+    collect_images_with_stats_recursive_inner(&root_canonical, current, files, &mut visited);
+}
+
+fn collect_images_with_stats_recursive_inner(
+    root_canonical: &Path,
+    current: &Path,
+    files: &mut Vec<FileEntry>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    if files.len() > 300_000 {
+        return;
+    }
+
+    let Some(current_canonical) = canonical_inside_root(root_canonical, current) else {
+        return;
+    };
+    if !visited.insert(current_canonical) {
+        return;
+    }
+
+    if let Ok(entries) = std::fs::read_dir(current) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+
+            if safe_dir(root_canonical, &p, file_type) {
+                if !is_thumbnail_dir(&p) {
+                    collect_images_with_stats_recursive_inner(root_canonical, &p, files, visited);
+                }
+            } else if safe_file(root_canonical, &p, file_type)
+                && is_image_path(&p)
+                && !is_thumbnail_file(&p)
+            {
+                let (size, modified) = match entry.metadata() {
+                    Ok(m) => (
+                        m.len(),
+                        m.modified()
+                            .ok()
+                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0),
+                    ),
+                    Err(_) => (0, 0),
+                };
+
+                files.push(FileEntry {
+                    path: p.to_string_lossy().replace("\\", "/"),
+                    size,
+                    modified,
+                });
             }
         }
     }
@@ -181,68 +277,220 @@ pub fn collect_images_with_stats_recursive(
 pub fn collect_images_with_stats_since_recursive(
     current: &Path,
     since_timestamp: u64, // Unix millis
-    files: &mut Vec<super::models::FileEntry>,
+    files: &mut Vec<FileEntry>,
+) {
+    let Some(root_canonical) = canonical_root(current) else {
+        return;
+    };
+    let mut visited = HashSet::new();
+    collect_images_with_stats_since_recursive_inner(
+        &root_canonical,
+        current,
+        since_timestamp,
+        files,
+        &mut visited,
+    );
+}
+
+fn collect_images_with_stats_since_recursive_inner(
+    root_canonical: &Path,
+    current: &Path,
+    since_timestamp: u64,
+    files: &mut Vec<FileEntry>,
+    visited: &mut HashSet<PathBuf>,
 ) {
     if files.len() > 300_000 {
+        return;
+    }
+
+    let Some(current_canonical) = canonical_inside_root(root_canonical, current) else {
+        return;
+    };
+    if !visited.insert(current_canonical) {
         return;
     }
 
     if let Ok(entries) = std::fs::read_dir(current) {
         for entry in entries.flatten() {
             let p = entry.path();
-            if p.is_dir() {
-                if !p.ends_with("thumbnails") {
-                    collect_images_with_stats_since_recursive(&p, since_timestamp, files);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+
+            if safe_dir(root_canonical, &p, file_type) {
+                if !is_thumbnail_dir(&p) {
+                    collect_images_with_stats_since_recursive_inner(
+                        root_canonical,
+                        &p,
+                        since_timestamp,
+                        files,
+                        visited,
+                    );
                 }
-            } else if p.is_file() {
-                // Check extension first to avoid unnecessary stat calls on non-images
-                let ext = p
-                    .extension()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-                    .to_lowercase();
-
-                if ["png", "jpg", "jpeg", "webp"].contains(&ext.as_str()) {
-                    let is_thumbnail = p
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .map(|n| n.to_lowercase().ends_with("thumbnail.png"))
-                        .unwrap_or(false);
-
-                    if !is_thumbnail {
-                        // Now check timestamps - we check BOTH mtime AND ctime
-                        // Copied files often retain their original mtime but have new ctime
-                        let (size, modified, created) = match entry.metadata() {
-                            Ok(m) => {
-                                let mtime = m
-                                    .modified()
-                                    .ok()
-                                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                                    .map(|d| d.as_millis() as u64)
-                                    .unwrap_or(0);
-                                let ctime = m
-                                    .created()
-                                    .ok()
-                                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                                    .map(|d| d.as_millis() as u64)
-                                    .unwrap_or(0);
-                                (m.len(), mtime, ctime)
-                            }
-                            Err(_) => (0, 0, 0),
-                        };
-
-                        // FILTER: Include if EITHER modified > since_timestamp OR created > since_timestamp
-                        // This catches both edited files (mtime changes) and copied files (ctime changes)
-                        if modified > since_timestamp || created > since_timestamp {
-                            files.push(super::models::FileEntry {
-                                path: p.to_string_lossy().replace("\\", "/"),
-                                size,
-                                modified: modified.max(created), // Use the more recent timestamp
-                            });
-                        }
+            } else if safe_file(root_canonical, &p, file_type)
+                && is_image_path(&p)
+                && !is_thumbnail_file(&p)
+            {
+                let (size, modified, created) = match entry.metadata() {
+                    Ok(m) => {
+                        let mtime = m
+                            .modified()
+                            .ok()
+                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0);
+                        let ctime = m
+                            .created()
+                            .ok()
+                            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                            .map(|d| d.as_millis() as u64)
+                            .unwrap_or(0);
+                        (m.len(), mtime, ctime)
                     }
+                    Err(_) => (0, 0, 0),
+                };
+
+                if modified > since_timestamp || created > since_timestamp {
+                    files.push(FileEntry {
+                        path: p.to_string_lossy().replace("\\", "/"),
+                        size,
+                        modified: modified.max(created),
+                    });
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock is available")
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "ambit-scanner-{name}-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("temp dir can be created");
+            Self { path }
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn write_file(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("parent dir can be created");
+        }
+        fs::write(path, b"image").expect("test file can be written");
+    }
+
+    fn normalized(path: &Path) -> String {
+        path.to_string_lossy().replace("\\", "/")
+    }
+
+    #[cfg(unix)]
+    fn symlink_dir(target: &Path, link: &Path) -> io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_dir(target: &Path, link: &Path) -> io::Result<()> {
+        std::os::windows::fs::symlink_dir(target, link)
+    }
+
+    #[cfg(unix)]
+    fn symlink_file(target: &Path, link: &Path) -> io::Result<()> {
+        std::os::unix::fs::symlink(target, link)
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(target: &Path, link: &Path) -> io::Result<()> {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+
+    #[test]
+    fn traversal_skips_current_paths_outside_root() {
+        let root = TestDir::new("root");
+        let outside = TestDir::new("outside");
+        write_file(&outside.path.join("outside.png"));
+
+        let mut stats = FolderStats::default();
+        scan_dir_recursive(&root.path, &outside.path, &mut stats);
+        assert_eq!(stats.image_files, 0);
+
+        let mut relative = Vec::new();
+        collect_images_recursive(&root.path, &outside.path, &mut relative);
+        assert!(relative.is_empty());
+
+        let mut absolute = Vec::new();
+        collect_images_recursive_absolute(&root.path, &outside.path, &mut absolute);
+        assert!(absolute.is_empty());
+    }
+
+    #[test]
+    fn traversal_skips_linked_outside_entries_for_all_scanners() {
+        let root = TestDir::new("linked-root");
+        let outside = TestDir::new("linked-outside");
+
+        let inside = root.path.join("inside.png");
+        let nested = root.path.join("nested").join("inner.webp");
+        let outside_image = outside.path.join("outside.png");
+        write_file(&inside);
+        write_file(&nested);
+        write_file(&outside_image);
+
+        let linked_dir = root.path.join("linked-outside");
+        let linked_file = root.path.join("linked-file.png");
+        let _ = symlink_dir(&outside.path, &linked_dir);
+        let _ = symlink_file(&outside_image, &linked_file);
+
+        let mut stats = FolderStats::default();
+        scan_dir_recursive(&root.path, &root.path, &mut stats);
+        assert_eq!(stats.image_files, 2);
+
+        let mut relative = Vec::new();
+        collect_images_recursive(&root.path, &root.path, &mut relative);
+        relative.sort();
+        assert_eq!(relative, vec!["inside.png", "nested/inner.webp"]);
+
+        let expected_absolute = {
+            let mut values = vec![normalized(&inside), normalized(&nested)];
+            values.sort();
+            values
+        };
+
+        let mut absolute = Vec::new();
+        collect_images_recursive_absolute(&root.path, &root.path, &mut absolute);
+        absolute.sort();
+        assert_eq!(absolute, expected_absolute);
+
+        let mut with_stats = Vec::new();
+        collect_images_with_stats_recursive(&root.path, &mut with_stats);
+        let mut with_stats_paths: Vec<_> = with_stats.iter().map(|entry| entry.path.clone()).collect();
+        with_stats_paths.sort();
+        assert_eq!(with_stats_paths, expected_absolute);
+
+        let mut since = Vec::new();
+        collect_images_with_stats_since_recursive(&root.path, 0, &mut since);
+        let mut since_paths: Vec<_> = since.iter().map(|entry| entry.path.clone()).collect();
+        since_paths.sort();
+        assert_eq!(since_paths, expected_absolute);
     }
 }

--- a/src/services/invoke/__tests__/pathResolver.test.ts
+++ b/src/services/invoke/__tests__/pathResolver.test.ts
@@ -53,6 +53,29 @@ describe('InvokeAI image path resolver', () => {
         });
     });
 
+    it.each([
+        ['traversal image name', '../outside.png', undefined],
+        ['nested traversal image name', '2026/05/25/../../outside.png', undefined],
+        ['output traversal image name', 'outputs/images/../../outside.png', undefined],
+        ['absolute image name', '/tmp/outside.png', undefined],
+        ['drive-qualified image name', 'C:/Windows/outside.png', undefined],
+        ['UNC image name', '\\\\server\\share\\outside.png', undefined],
+        ['traversal image_subfolder', 'safe.png', '../outside'],
+        ['absolute image_subfolder', 'safe.png', '/tmp/outside'],
+        ['drive-qualified image_subfolder', 'safe.png', 'C:/outside'],
+        ['UNC image_subfolder', 'safe.png', '\\\\server\\share']
+    ])('rejects %s from InvokeAI database rows', async (_label, imageName, imageSubfolder) => {
+        const listImages = vi.fn().mockResolvedValue(files);
+        const resolver = createInvokeImagePathResolver('D:/Invoke', listImages);
+
+        await expect(resolver.resolveImagePath(imageName, imageSubfolder)).resolves.toEqual({
+            absolutePath: null,
+            relativePath: null,
+            ambiguous: false
+        });
+        expect(listImages).not.toHaveBeenCalled();
+    });
+
     it('uses existing InvokeAI thumbnail candidates and falls back to the source image when none exist', async () => {
         const resolver = createInvokeImagePathResolver('D:/Invoke', vi.fn().mockResolvedValue(files));
 
@@ -81,5 +104,22 @@ describe('InvokeAI image path resolver', () => {
         ]);
 
         expect(resolver.resolveThumbnailPath(null, nested, existing)).toBe('D:/Invoke/outputs/images/thumbnails/2026/05/25/date.webp');
+    });
+
+    it('ignores unsafe thumbnail names and falls back to bounded thumbnail candidates', async () => {
+        const resolver = createInvokeImagePathResolver('D:/Invoke', vi.fn().mockResolvedValue(files));
+        const nested = await resolver.resolveImagePath('date.png');
+
+        const boundedFallbacks = [
+            'D:/Invoke/outputs/images/2026/05/25/date.webp',
+            'D:/Invoke/outputs/images/2026/05/25/thumbnails/date.webp',
+            'D:/Invoke/outputs/images/thumbnails/2026/05/25/date.webp',
+            'D:/Invoke/outputs/images/thumbnails/date.webp'
+        ];
+
+        expect(resolver.getThumbnailPathCandidates('../outside.webp', nested)).toEqual(boundedFallbacks);
+        expect(resolver.getThumbnailPathCandidates('/tmp/outside.webp', nested)).toEqual(boundedFallbacks);
+        expect(resolver.getThumbnailPathCandidates('C:/outside.webp', nested)).toEqual(boundedFallbacks);
+        expect(resolver.getThumbnailPathCandidates('\\\\server\\share\\outside.webp', nested)).toEqual(boundedFallbacks);
     });
 });

--- a/src/services/invoke/__tests__/syncService.test.ts
+++ b/src/services/invoke/__tests__/syncService.test.ts
@@ -466,6 +466,51 @@ describe('syncImages live mode', () => {
         expect(insertImagesBatch).not.toHaveBeenCalled();
     });
 
+    it('skips unsafe InvokeAI database paths before filesystem probes or inserts', async () => {
+        const selectMock = vi.fn(async (query: string) => {
+            if (query.includes('PRAGMA table_info(images)')) {
+                return [{ name: 'metadata_json' }, { name: 'image_subfolder' }];
+            }
+            if (query.includes("SELECT name FROM sqlite_master WHERE type='table'")) {
+                return [{ name: 'images' }];
+            }
+            if (query.includes('SELECT 1 as found FROM images i')) {
+                return [{ found: 1 }];
+            }
+            if (query.includes('SELECT count(*) as count FROM images i')) {
+                return [{ count: 1 }];
+            }
+            if (query.includes('FROM images i') && query.includes('OFFSET 0')) {
+                return [{
+                    image_name: '../outside.png',
+                    image_subfolder: '',
+                    metadata_blob: {},
+                    created_at: '2026-04-18 12:00:00',
+                    width: 512,
+                    height: 512
+                }];
+            }
+            return [];
+        });
+
+        vi.mocked(Database.load).mockResolvedValue(createInvokeDb(selectMock) as never);
+
+        const result = await syncImages(
+            'D:/AI/art/webUI/invokeai/databases',
+            vi.fn(),
+            undefined,
+            {
+                mode: 'live',
+                syncBoards: false,
+                syncFavorites: false
+            }
+        );
+
+        expect(result.imported).toBe(0);
+        expect(commands.getFileSizesBulk).not.toHaveBeenCalled();
+        expect(insertImagesBatch).not.toHaveBeenCalled();
+    });
+
     it('repairs an existing stale flat InvokeAI row when the real file resolves to a subfolder', async () => {
         const staleFlatPath = 'D:/AI/art/webUI/invokeai/outputs/images/date.png';
         const resolvedPath = 'D:/AI/art/webUI/invokeai/outputs/images/2026/04/18/date.png';

--- a/src/services/invoke/pathResolver.ts
+++ b/src/services/invoke/pathResolver.ts
@@ -14,32 +14,47 @@ interface InvokeDiskIndex {
 
 const OUTPUT_IMAGES_PREFIX = 'outputs/images/';
 
-const trimLeadingSlash = (path: string): string => path.replace(/^\/+/, '');
+const unresolvedPath = (): ResolvedInvokeImagePath => ({
+    absolutePath: null,
+    relativePath: null,
+    ambiguous: false
+});
 
 const isOutputImagesRelative = (path: string): boolean =>
     path.toLowerCase().startsWith(OUTPUT_IMAGES_PREFIX);
 
 const hasPathSeparator = (path: string): boolean => /[\\/]/.test(path);
 
-const normalizeRelativePath = (path: string): string =>
-    trimLeadingSlash(normalizePath(path)).replace(/\/+$/, '');
+const isUnsafePathInput = (path: string): boolean =>
+    /^[\\/]/.test(path) || /^[A-Za-z]:/.test(path) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(path);
+
+const normalizeSafeRelativePath = (path: string | null | undefined): string | null => {
+    const raw = (path || '').trim();
+    if (!raw || isUnsafePathInput(raw)) return null;
+
+    const normalized = normalizePath(raw).replace(/\/+$/, '');
+    if (!normalized) return null;
+
+    const parts = normalized.split('/').filter(Boolean);
+    if (parts.some(part => part === '.' || part === '..')) return null;
+
+    return parts.join('/');
+};
 
 const joinRelativePath = (...parts: Array<string | null | undefined>): string =>
     parts
-        .map(part => part ? normalizeRelativePath(part) : '')
+        .map(part => normalizeSafeRelativePath(part) || '')
         .filter(Boolean)
         .join('/');
 
 const toRootRelativeImagePath = (imageName: string): string => {
-    const normalized = normalizeRelativePath(imageName);
-    return isOutputImagesRelative(normalized)
-        ? normalized
-        : `${OUTPUT_IMAGES_PREFIX}${normalized}`;
+    return isOutputImagesRelative(imageName)
+        ? imageName
+        : `${OUTPUT_IMAGES_PREFIX}${imageName}`;
 };
 
 const toSubfolderImagePath = (imageName: string, imageSubfolder: string): string => {
-    const normalizedName = normalizeRelativePath(imageName);
-    const filename = getFilename(normalizedName) || normalizedName;
+    const filename = getFilename(imageName) || imageName;
     const normalizedSubfolder = isOutputImagesRelative(imageSubfolder)
         ? imageSubfolder.slice(OUTPUT_IMAGES_PREFIX.length)
         : imageSubfolder;
@@ -47,14 +62,16 @@ const toSubfolderImagePath = (imageName: string, imageSubfolder: string): string
 };
 
 const fromOutputImagesRelative = (rootRelativePath: string): string | null => {
-    const normalized = normalizeRelativePath(rootRelativePath);
+    const normalized = normalizeSafeRelativePath(rootRelativePath);
+    if (!normalized) return null;
+
     return isOutputImagesRelative(normalized)
         ? normalized.slice(OUTPUT_IMAGES_PREFIX.length)
         : null;
 };
 
 const toAbsolutePath = (invokeRoot: string, rootRelativePath: string): string =>
-    normalizePath(`${invokeRoot}/${normalizeRelativePath(rootRelativePath)}`);
+    normalizePath(`${invokeRoot}/${normalizeSafeRelativePath(rootRelativePath) || ''}`);
 
 export const buildInvokeImageDiskIndex = (files: string[]): InvokeDiskIndex => {
     const byRootRelative = new Map<string, string>();
@@ -62,7 +79,7 @@ export const buildInvokeImageDiskIndex = (files: string[]): InvokeDiskIndex => {
     const byBasename = new Map<string, string | null>();
 
     files.forEach((file) => {
-        const rootRelative = normalizeRelativePath(file);
+        const rootRelative = normalizeSafeRelativePath(file);
         if (!rootRelative) return;
 
         byRootRelative.set(rootRelative.toLowerCase(), rootRelative);
@@ -106,11 +123,20 @@ export const createInvokeImagePathResolver = (
         imageName: string,
         imageSubfolder?: string | null
     ): Promise<ResolvedInvokeImagePath> => {
-        const normalizedName = normalizeRelativePath(imageName);
-        const normalizedSubfolder = normalizeRelativePath(imageSubfolder || '');
+        const normalizedName = normalizeSafeRelativePath(imageName);
+        const rawSubfolder = (imageSubfolder || '').trim();
+        const normalizedSubfolder = rawSubfolder ? normalizeSafeRelativePath(rawSubfolder) : '';
+        if (!normalizedName || normalizedSubfolder === null) {
+            console.warn('[InvokeAI Sync] Unsafe image path in InvokeAI database row; skipping.', {
+                imageName,
+                imageSubfolder
+            });
+            return unresolvedPath();
+        }
+
         const directRelativePath = normalizedSubfolder
-            ? toSubfolderImagePath(imageName, normalizedSubfolder)
-            : toRootRelativeImagePath(imageName);
+            ? toSubfolderImagePath(normalizedName, normalizedSubfolder)
+            : toRootRelativeImagePath(normalizedName);
         const fallbackRelativePath = directRelativePath;
         const fallback: ResolvedInvokeImagePath = {
             absolutePath: toAbsolutePath(normalizedRoot, fallbackRelativePath),
@@ -172,7 +198,7 @@ export const createInvokeImagePathResolver = (
         const imageBasename = imagesRelative ? getFilename(imagesRelative) : getFilename(resolvedImage.absolutePath);
         const fallbackThumbnailName = imageBasename.replace(/\.[^/.]+$/, '.webp');
 
-        const normalizedThumbnail = normalizeRelativePath(thumbnailName || fallbackThumbnailName);
+        const normalizedThumbnail = normalizeSafeRelativePath(thumbnailName) ?? normalizeSafeRelativePath(fallbackThumbnailName);
         if (!normalizedThumbnail) return [];
 
         const candidates: string[] = [];
@@ -213,7 +239,9 @@ export const createInvokeImagePathResolver = (
     };
 
     const getLegacyFlatImagePath = (imageName: string): string | null => {
-        const normalizedName = normalizeRelativePath(imageName);
+        const normalizedName = normalizeSafeRelativePath(imageName);
+        if (!normalizedName) return null;
+
         const filename = getFilename(normalizedName);
         if (!filename) return null;
 

--- a/src/services/invoke/syncService.ts
+++ b/src/services/invoke/syncService.ts
@@ -547,10 +547,12 @@ export const syncImages = async (
 
         let sizes: number[] = [];
         const fileSizeProbeStartedAt = liveWatchNow();
-        try {
-            sizes = await unwrap(commands.getFileSizesBulk(batchPaths));
-        } catch (e) {
-            sizes = new Array(rows.length).fill(0);
+        if (batchPaths.length > 0) {
+            try {
+                sizes = await unwrap(commands.getFileSizesBulk(batchPaths));
+            } catch (e) {
+                sizes = new Array(batchPaths.length).fill(0);
+            }
         }
         const fileSizeProbeMs = elapsedMs(fileSizeProbeStartedAt);
 


### PR DESCRIPTION
## Summary
- bound scanner traversal to the selected canonical root and skip linked/outside files or directories
- reject unsafe InvokeAI DB image, subfolder, and thumbnail paths before filesystem probes
- add focused Rust and frontend coverage for traversal and InvokeAI path escape cases

## Verification
- node_modules\\.bin\\vitest.cmd run src/services/invoke/__tests__/pathResolver.test.ts src/services/invoke/__tests__/syncService.test.ts
- cargo test --manifest-path src-tauri/Cargo.toml traversal
- corepack pnpm run typecheck
- git diff --check

Note: cargo fmt --check could not run because rustfmt is not installed for toolchain 1.96.0-x86_64-pc-windows-msvc.