### PR TITLE
fix: parameterize image pagination cursors

### DIFF
--- a/src/services/db/__tests__/searchRepo.test.ts
+++ b/src/services/db/__tests__/searchRepo.test.ts
@@ -1058,6 +1058,81 @@ describe('searchRepo scoped stats queries', () => {
         expect(keywordParams).toEqual(['Detailer', 0, 0]);
     });
 
+    it.each([
+        {
+            label: 'default image search',
+            args: [undefined, undefined] as const,
+            expectedSql: 'FROM images',
+            expectedParams: [0, "x' OR 1=1 --", "id' OR 1=1 --"]
+        },
+        {
+            label: 'collection search',
+            args: ["collection' OR 1=1 --", undefined] as const,
+            expectedSql: 'FROM collection_images ci',
+            expectedParams: ["collection' OR 1=1 --", 0, "x' OR 1=1 --", "id' OR 1=1 --"]
+        },
+        {
+            label: 'lora search',
+            args: [undefined, "lora' OR 1=1 --"] as const,
+            expectedSql: 'FROM image_loras il',
+            expectedParams: ["lora' OR 1=1 --", 0, "x' OR 1=1 --", "id' OR 1=1 --"]
+        },
+        {
+            label: 'collection and lora search',
+            args: ["collection' OR 1=1 --", "lora' OR 1=1 --"] as const,
+            expectedSql: 'FROM collection_images ci',
+            expectedParams: ["collection' OR 1=1 --", "lora' OR 1=1 --", 0, "x' OR 1=1 --", "id' OR 1=1 --"]
+        }
+    ])('binds image pagination cursor values for $label', async ({ args, expectedSql, expectedParams }) => {
+        const db = { select: vi.fn(async () => []) };
+        getDbMock.mockResolvedValue(db);
+
+        const { searchImages } = await import('../searchRepo');
+        await searchImages('WHERE is_deleted = ?', [0], 100, 'path', 'ASC', false, args[0], args[1], {
+            val: "x' OR 1=1 --",
+            id: "id' OR 1=1 --"
+        });
+
+        const [searchSql, searchParams] = findSelectCall(db, (value) => value.includes(expectedSql)) as [string, unknown[]];
+        const normalizedSql = searchSql.replace(/\s+/g, ' ').trim();
+
+        expect(normalizedSql).toContain('AND (images.path, images.id) > (?, ?)');
+        expect(searchSql).not.toContain("x' OR 1=1 --");
+        expect(searchSql).not.toContain("id' OR 1=1 --");
+        expect(searchParams).toEqual(expectedParams);
+    });
+
+    it('binds pinned-priority cursor values without interpolating filename or id', async () => {
+        const db = { select: vi.fn(async () => []) };
+        getDbMock.mockResolvedValue(db);
+
+        const { searchImages } = await import('../searchRepo');
+        await searchImages('WHERE is_deleted = ?', [0], 100, 'path', 'ASC', true, "collection' OR 1=1 --", undefined, {
+            val: "x' OR 1=1 --",
+            id: "id' OR 1=1 --",
+            isPinned: 1
+        });
+
+        const [searchSql, searchParams] = findSelectCall(db, (value) => value.includes('FROM collection_images ci')) as [string, unknown[]];
+        const normalizedSql = searchSql.replace(/\s+/g, ' ').trim();
+
+        expect(normalizedSql).toContain('images.is_pinned < ?');
+        expect(normalizedSql).toContain('images.is_pinned = ? AND images.path > ?');
+        expect(normalizedSql).toContain('images.is_pinned = ? AND images.path = ? AND images.id > ?');
+        expect(searchSql).not.toContain("x' OR 1=1 --");
+        expect(searchSql).not.toContain("id' OR 1=1 --");
+        expect(searchParams).toEqual([
+            "collection' OR 1=1 --",
+            0,
+            1,
+            1,
+            "x' OR 1=1 --",
+            1,
+            "x' OR 1=1 --",
+            "id' OR 1=1 --"
+        ]);
+    });
+
     it('uses canonical LoRA references for optimized image count and search', async () => {
         const db = {
             select: vi.fn(async (sql: string) => {

--- a/src/services/db/searchRepo.ts
+++ b/src/services/db/searchRepo.ts
@@ -510,12 +510,10 @@ export const searchImages = async (
         ? `ORDER BY images.is_pinned DESC, images.${sortField} ${sortOrder}, images.id ${sortOrder === 'DESC' ? 'DESC' : 'ASC'}` // Strict tie-breaker
         : `ORDER BY images.${sortField} ${sortOrder}, images.id ${sortOrder === 'DESC' ? 'DESC' : 'ASC'}`;
 
-    // Helper to build cursor condition
-    const buildCursorWhere = () => {
-        if (!cursor) return '';
+    const buildCursorWhere = (): { sql: string; params: unknown[] } => {
+        if (!cursor) return { sql: '', params: [] };
 
         const op = sortOrder === 'DESC' ? '<' : '>';
-        const sortValParam = typeof cursor.val === 'string' ? `'${cursor.val}'` : cursor.val;
 
         if (prioritizePinned) {
             // Complex case: Pinned (1) -> Unpinned (0). 
@@ -539,16 +537,21 @@ export const searchImages = async (
 
             const pinnedVal = cursor.isPinned ?? 0;
 
-            return `AND (
-                images.is_pinned < ${pinnedVal}
-                OR (images.is_pinned = ${pinnedVal} AND images.${sortField} ${op} ${sortValParam})
-                OR (images.is_pinned = ${pinnedVal} AND images.${sortField} = ${sortValParam} AND images.id ${op} '${cursor.id}')
-            )`;
+            return {
+                sql: `AND (
+                    images.is_pinned < ?
+                    OR (images.is_pinned = ? AND images.${sortField} ${op} ?)
+                    OR (images.is_pinned = ? AND images.${sortField} = ? AND images.id ${op} ?)
+                )`,
+                params: [pinnedVal, pinnedVal, cursor.val, pinnedVal, cursor.val, cursor.id]
+            };
         }
 
         // Simple case: (sortField, id) < (val, id)
-        // Ensure we handle string vs number types correctly for sql injection safety if raw string
-        return `AND (images.${sortField}, images.id) ${op} (${sortValParam}, '${cursor.id}')`;
+        return {
+            sql: `AND (images.${sortField}, images.id) ${op} (?, ?)`,
+            params: [cursor.val, cursor.id]
+        };
     };
 
     const cursorWhere = buildCursorWhere();
@@ -561,11 +564,11 @@ export const searchImages = async (
             JOIN image_loras il ON il.image_id = ci.image_id
             JOIN images ON images.id = ci.image_id
             ${finalWhere.replace('WHERE', `WHERE ci.collection_id = ? AND ${loraReferencePredicate} AND`)}
-            ${cursorWhere}
+            ${cursorWhere.sql}
             ${orderBy}
             LIMIT ${limit}
         `;
-        const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [collectionId, loraName, ...params]));
+        const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [collectionId, loraName, ...params, ...cursorWhere.params]));
         return rows.map(mapRowToImage);
     }
 
@@ -576,11 +579,11 @@ export const searchImages = async (
             FROM collection_images ci
             CROSS JOIN images ON images.id = ci.image_id
             ${finalWhere.replace('WHERE', 'WHERE ci.collection_id = ? AND')}
-            ${cursorWhere}
+            ${cursorWhere.sql}
             ${orderBy}
             LIMIT ${limit}
         `;
-        const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [collectionId, ...params]));
+        const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [collectionId, ...params, ...cursorWhere.params]));
         return rows.map(mapRowToImage);
     }
 
@@ -592,11 +595,11 @@ export const searchImages = async (
             FROM image_loras il
             CROSS JOIN images ON images.id = il.image_id
             ${finalWhere.replace('WHERE', `WHERE ${loraReferencePredicate} AND`)}
-            ${cursorWhere}
+            ${cursorWhere.sql}
             ${orderBy}
             LIMIT ${limit}
         `;
-        const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [loraName, ...params]));
+        const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [loraName, ...params, ...cursorWhere.params]));
         return rows.map(mapRowToImage);
     }
 
@@ -614,12 +617,12 @@ export const searchImages = async (
         SELECT ${getImageFieldsLight()}
         ${fromClause}
         ${finalWhere} 
-        ${cursorWhere}
+        ${cursorWhere.sql}
         ${orderBy} 
         LIMIT ${limit}
     `;
 
-    const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, params));
+    const rows = await timeDbCall('searchImages', reason, () => db.select<ImageRow[]>(query, [...params, ...cursorWhere.params]));
     
     return rows.map(mapRowToImage);
 };


### PR DESCRIPTION
## Summary
- bind gallery pagination cursor values instead of interpolating them into SQL
- preserve existing keyset pagination, sort behavior, pinned-priority behavior, and query shapes
- add regression coverage for malicious cursor filenames and IDs across default, collection, LoRA, collection+LoRA, and pinned pagination paths

## Validation
- `node_modules\.bin\vitest.cmd run src/services/db/__tests__/searchRepo.test.ts`
- `corepack pnpm run test:run -- src/services/db/__tests__/searchRepo.test.ts`
- `corepack pnpm run typecheck`
- `git diff --check`