### PR TITLE
fix: bound resource metadata scanning

### DIFF
--- a/src-tauri/src/metadata/resources.rs
+++ b/src-tauri/src/metadata/resources.rs
@@ -6,6 +6,76 @@ pub struct Resources {
     pub embeddings: Vec<String>,
 }
 
+const MAX_RESOURCE_SCAN_DEPTH: usize = 64;
+const MAX_RESOURCE_SCAN_NODES: usize = 50_000;
+const MAX_NESTED_JSON_STRING_DEPTH: usize = 4;
+const MAX_NESTED_JSON_STRING_BYTES: usize = 2 * 1024 * 1024;
+const MAX_AGGREGATE_NESTED_JSON_STRING_BYTES: usize = 8 * 1024 * 1024;
+
+#[derive(Default)]
+struct ResourceScanBudget {
+    nodes_visited: usize,
+    nested_json_string_bytes: usize,
+    exhausted: bool,
+    logged_limit: bool,
+}
+
+impl ResourceScanBudget {
+    fn allow_node(&mut self, depth: usize) -> bool {
+        if self.exhausted {
+            return false;
+        }
+        if depth > MAX_RESOURCE_SCAN_DEPTH {
+            self.exhaust("maximum traversal depth reached");
+            return false;
+        }
+        if self.nodes_visited >= MAX_RESOURCE_SCAN_NODES {
+            self.exhaust("maximum traversal node count reached");
+            return false;
+        }
+
+        self.nodes_visited += 1;
+        true
+    }
+
+    fn allow_nested_json_string(&mut self, nested_depth: usize, byte_len: usize) -> bool {
+        if self.exhausted {
+            return false;
+        }
+        if nested_depth >= MAX_NESTED_JSON_STRING_DEPTH {
+            self.exhaust("maximum nested JSON string depth reached");
+            return false;
+        }
+        if byte_len > MAX_NESTED_JSON_STRING_BYTES {
+            self.note_limit("skipping oversized nested JSON string");
+            return false;
+        }
+        if self
+            .nested_json_string_bytes
+            .saturating_add(byte_len)
+            > MAX_AGGREGATE_NESTED_JSON_STRING_BYTES
+        {
+            self.exhaust("maximum aggregate nested JSON string bytes reached");
+            return false;
+        }
+
+        self.nested_json_string_bytes += byte_len;
+        true
+    }
+
+    fn exhaust(&mut self, reason: &str) {
+        self.exhausted = true;
+        self.note_limit(reason);
+    }
+
+    fn note_limit(&mut self, reason: &str) {
+        if !self.logged_limit {
+            log::debug!("[Resources] Resource metadata scan budget reached: {reason}");
+            self.logged_limit = true;
+        }
+    }
+}
+
 pub fn extract_loras(val: &serde_json::Value, res: &mut Resources) {
     let process_item = |l: &serde_json::Value, res: &mut Resources| {
         let name = l
@@ -166,6 +236,21 @@ pub fn extract_embeddings(val: &serde_json::Value, res: &mut Resources) {
 }
 
 pub fn scan_for_resources(val: &serde_json::Value, res: &mut Resources) {
+    let mut budget = ResourceScanBudget::default();
+    scan_for_resources_inner(val, res, &mut budget, 0, 0);
+}
+
+fn scan_for_resources_inner(
+    val: &serde_json::Value,
+    res: &mut Resources,
+    budget: &mut ResourceScanBudget,
+    depth: usize,
+    nested_json_string_depth: usize,
+) {
+    if !budget.allow_node(depth) {
+        return;
+    }
+
     match val {
         serde_json::Value::Object(map) => {
             if let Some(loras) = map.get("loras") {
@@ -200,21 +285,51 @@ pub fn scan_for_resources(val: &serde_json::Value, res: &mut Resources) {
             }
 
             for (_, v) in map {
+                if budget.exhausted {
+                    break;
+                }
                 if let Some(s) = v.as_str() {
                     // Try to parse string as JSON if it looks like one
-                    if s.trim_start().starts_with('{') {
+                    let trimmed = s.trim_start();
+                    if trimmed.starts_with('{')
+                        && budget.allow_nested_json_string(
+                            nested_json_string_depth,
+                            trimmed.len(),
+                        )
+                    {
                         if let Ok(nested) = serde_json::from_str(s) {
-                            scan_for_resources(&nested, res);
+                            scan_for_resources_inner(
+                                &nested,
+                                res,
+                                budget,
+                                depth + 1,
+                                nested_json_string_depth + 1,
+                            );
                         }
                     }
                 } else if v.is_object() || v.is_array() {
-                    scan_for_resources(v, res);
+                    scan_for_resources_inner(
+                        v,
+                        res,
+                        budget,
+                        depth + 1,
+                        nested_json_string_depth,
+                    );
                 }
             }
         }
         serde_json::Value::Array(arr) => {
             for v in arr {
-                scan_for_resources(v, res);
+                if budget.exhausted {
+                    break;
+                }
+                scan_for_resources_inner(
+                    v,
+                    res,
+                    budget,
+                    depth + 1,
+                    nested_json_string_depth,
+                );
             }
         }
         _ => {}
@@ -286,6 +401,135 @@ mod tests {
         assert_eq!(res.control_nets.len(), 2);
         assert!(res.control_nets.contains(&"canny".to_string()));
         assert!(res.control_nets.contains(&"softedge".to_string()));
+    }
+
+    #[test]
+    fn test_scan_for_resources_nested_json_string() {
+        let mut res = Resources::default();
+        let nested = json!({
+            "loras": [
+                { "lora_name": "string_style", "weight": 0.75 }
+            ],
+            "ip_adapters": [
+                { "model_name": "face_adapter" }
+            ]
+        });
+        let payload = json!({
+            "workflow": serde_json::to_string(&nested).unwrap()
+        });
+
+        scan_for_resources(&payload, &mut res);
+
+        assert_eq!(res.loras, vec!["string_style (0.75)".to_string()]);
+        assert_eq!(res.ip_adapters, vec!["face_adapter".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_for_resources_stops_at_traversal_depth_budget() {
+        let mut res = Resources::default();
+        let mut deep = json!({ "loras": [{ "lora_name": "too_deep" }] });
+        for _ in 0..(MAX_RESOURCE_SCAN_DEPTH + 2) {
+            deep = json!({ "nested": deep });
+        }
+        let payload = json!({
+            "loras": [{ "lora_name": "early" }],
+            "deep": deep
+        });
+
+        scan_for_resources(&payload, &mut res);
+
+        assert_eq!(res.loras, vec!["early".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_for_resources_stops_at_node_budget() {
+        let mut res = Resources::default();
+        let mut many_nodes: Vec<serde_json::Value> = (0..MAX_RESOURCE_SCAN_NODES)
+            .map(|idx| json!({ "node": idx }))
+            .collect();
+        many_nodes.push(json!({
+            "loras": [{ "lora_name": "too_late" }]
+        }));
+        let payload = json!({
+            "loras": [{ "lora_name": "early" }],
+            "many": many_nodes
+        });
+
+        scan_for_resources(&payload, &mut res);
+
+        assert_eq!(res.loras, vec!["early".to_string()]);
+        assert!(
+            !res.loras.contains(&"too_late".to_string()),
+            "resources past the node budget must not be extracted"
+        );
+    }
+
+    #[test]
+    fn test_scan_for_resources_stops_at_nested_json_string_depth_budget() {
+        let mut res = Resources::default();
+        let mut nested = json!({ "loras": [{ "lora_name": "too_deep" }] });
+        for _ in 0..(MAX_NESTED_JSON_STRING_DEPTH + 1) {
+            nested = json!({
+                "wrapped": serde_json::to_string(&nested).unwrap()
+            });
+        }
+        let payload = json!({
+            "loras": [{ "lora_name": "early" }],
+            "workflow": serde_json::to_string(&nested).unwrap()
+        });
+
+        scan_for_resources(&payload, &mut res);
+
+        assert_eq!(res.loras, vec!["early".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_for_resources_skips_oversized_nested_json_string() {
+        let mut res = Resources::default();
+        let huge_name = "x".repeat(MAX_NESTED_JSON_STRING_BYTES);
+        let oversized = format!(
+            "{{\"loras\":[{{\"lora_name\":\"{}\"}}]}}",
+            huge_name
+        );
+        let valid = json!({
+            "loras": [{ "lora_name": "small_valid" }]
+        });
+        let payload = json!({
+            "oversized": oversized,
+            "valid": serde_json::to_string(&valid).unwrap()
+        });
+
+        scan_for_resources(&payload, &mut res);
+
+        assert_eq!(res.loras, vec!["small_valid".to_string()]);
+    }
+
+    #[test]
+    fn test_scan_for_resources_stops_at_aggregate_nested_json_string_budget() {
+        let mut res = Resources::default();
+        let padding = "x".repeat(1024 * 1024);
+        let mut payload = serde_json::Map::new();
+        for idx in 0..10 {
+            let nested = json!({
+                "loras": [{ "lora_name": format!("style_{idx}") }],
+                "padding": padding
+            });
+            payload.insert(
+                format!("workflow_{idx}"),
+                serde_json::Value::String(serde_json::to_string(&nested).unwrap()),
+            );
+        }
+
+        scan_for_resources(&serde_json::Value::Object(payload), &mut res);
+
+        assert!(
+            !res.loras.is_empty(),
+            "resources found before the aggregate budget is exhausted should be preserved"
+        );
+        assert!(
+            res.loras.len() < 10,
+            "aggregate nested JSON string budget should prevent parsing every payload"
+        );
     }
 
     #[test]


### PR DESCRIPTION
﻿## Summary
- Add bounded traversal state to the resource metadata scanner.
- Limit traversal depth, visited JSON nodes, nested JSON-string parse depth, per-string parse size, and aggregate nested JSON parse bytes.
- Preserve resources found before a scan budget is exhausted while skipping pathological metadata safely.

## Validation
- `cargo test --manifest-path src-tauri/Cargo.toml resources --quiet`
- `git diff --check`

## Notes
- `cargo fmt --check` could not run locally because `rustfmt` is not installed for toolchain `1.96.0-x86_64-pc-windows-msvc`.
