### PR TITLE
fix: bound PNG metadata parsing budgets

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/src/metadata/parsers.rs
+++ b/src-tauri/src/metadata/parsers.rs
@@ -5,6 +5,8 @@ use std::io::{Read, Seek, SeekFrom};
 
 const MAX_PNG_METADATA_CHUNK_BYTES: u64 = 16 * 1024 * 1024;
 const MAX_PNG_DECOMPRESSED_TEXT_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_PNG_METADATA_TOTAL_CHUNK_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_PNG_DECODED_TEXT_TOTAL_BYTES: u64 = 16 * 1024 * 1024;
 
 pub fn scan_jpeg_metadata(path: &std::path::Path) -> Result<HashMap<String, String>, String> {
     let mut file = File::open(path).map_err(|e| e.to_string())?;
@@ -66,15 +68,95 @@ fn skip_chunk_data_and_crc<R: Seek>(reader: &mut R, length: u64) -> Result<(), S
         .map_err(|e| e.to_string())
 }
 
-fn read_limited_zlib_text(data: &[u8]) -> Option<String> {
-    let decoder = ZlibDecoder::new(data);
-    let mut limited = decoder.take(MAX_PNG_DECOMPRESSED_TEXT_BYTES + 1);
-    let mut s = String::new();
+#[derive(Default)]
+struct PngMetadataBudget {
+    raw_chunk_bytes: u64,
+    decoded_text_bytes: u64,
+    raw_exhausted: bool,
+    decoded_exhausted: bool,
+    logged_limit: bool,
+}
 
-    if limited.read_to_string(&mut s).is_ok() && s.len() as u64 <= MAX_PNG_DECOMPRESSED_TEXT_BYTES {
-        Some(s)
-    } else {
-        None
+impl PngMetadataBudget {
+    fn allow_raw_chunk(&mut self, length: u64) -> bool {
+        if self.raw_exhausted {
+            return false;
+        }
+
+        if self
+            .raw_chunk_bytes
+            .saturating_add(length)
+            > MAX_PNG_METADATA_TOTAL_CHUNK_BYTES
+        {
+            self.raw_exhausted = true;
+            self.note_limit("maximum aggregate PNG metadata chunk bytes reached");
+            return false;
+        }
+
+        self.raw_chunk_bytes += length;
+        true
+    }
+
+    fn remaining_decoded_text_bytes(&self) -> u64 {
+        if self.decoded_exhausted {
+            return 0;
+        }
+        MAX_PNG_DECODED_TEXT_TOTAL_BYTES.saturating_sub(self.decoded_text_bytes)
+    }
+
+    fn accept_decoded_text(&mut self, value: String) -> Option<String> {
+        if self.decoded_exhausted {
+            return None;
+        }
+
+        let byte_len = value.len() as u64;
+        if byte_len > self.remaining_decoded_text_bytes() {
+            self.exhaust_decoded_text();
+            return None;
+        }
+
+        self.decoded_text_bytes += byte_len;
+        Some(value)
+    }
+
+    fn exhaust_decoded_text(&mut self) {
+        if !self.decoded_exhausted {
+            self.decoded_exhausted = true;
+            self.note_limit("maximum aggregate decoded PNG text bytes reached");
+        }
+    }
+
+    fn note_limit(&mut self, reason: &str) {
+        if !self.logged_limit {
+            log::debug!("[PNG] Metadata budget reached: {reason}");
+            self.logged_limit = true;
+        }
+    }
+}
+
+enum LimitedZlibText {
+    Text(String),
+    ExceededLimit,
+    Invalid,
+}
+
+fn read_limited_zlib_text(data: &[u8], max_decoded_bytes: u64) -> LimitedZlibText {
+    if max_decoded_bytes == 0 {
+        return LimitedZlibText::ExceededLimit;
+    }
+
+    let decoder = ZlibDecoder::new(data);
+    let limit = MAX_PNG_DECOMPRESSED_TEXT_BYTES.min(max_decoded_bytes);
+    let mut limited = decoder.take(limit + 1);
+    let mut bytes = Vec::new();
+
+    match limited.read_to_end(&mut bytes) {
+        Ok(_) if bytes.len() as u64 > limit => LimitedZlibText::ExceededLimit,
+        Ok(_) => match String::from_utf8(bytes) {
+            Ok(s) => LimitedZlibText::Text(s),
+            Err(_) => LimitedZlibText::Invalid,
+        },
+        Err(_) => LimitedZlibText::Invalid,
     }
 }
 
@@ -97,6 +179,7 @@ pub fn extract_png_chunks<R: Read + Seek>(
 
     let mut chunks = HashMap::new();
     let mut loop_count = 0;
+    let mut budget = PngMetadataBudget::default();
 
     loop {
         if loop_count > 10000 {
@@ -125,6 +208,10 @@ pub fn extract_png_chunks<R: Read + Seek>(
                 skip_chunk_data_and_crc(reader, length)?;
                 continue;
             }
+            if !budget.allow_raw_chunk(length) {
+                skip_chunk_data_and_crc(reader, length)?;
+                continue;
+            }
 
             let mut chunk_data = vec![0; length as usize];
             if reader.read_exact(&mut chunk_data).is_err() {
@@ -139,7 +226,9 @@ pub fn extract_png_chunks<R: Read + Seek>(
                     &chunk_data
                 };
 
-                if let Some(comment) = parse_exif(data_slice) {
+                if let Some(comment) =
+                    parse_exif(data_slice).and_then(|comment| budget.accept_decoded_text(comment))
+                {
                     chunks.insert("parameters".to_string(), comment);
                 }
             } else if let Some(pos) = chunk_data.iter().position(|&x| x == 0) {
@@ -148,14 +237,25 @@ pub fn extract_png_chunks<R: Read + Seek>(
                 if chunk_type == "zTXt" {
                     if pos + 2 < chunk_data.len() && chunk_data[pos + 1] == 0 {
                         let compressed = &chunk_data[pos + 2..];
-                        if let Some(s) = read_limited_zlib_text(compressed) {
-                            chunks.insert(key, s);
+                        match read_limited_zlib_text(
+                            compressed,
+                            budget.remaining_decoded_text_bytes(),
+                        ) {
+                            LimitedZlibText::Text(s) => {
+                                if let Some(s) = budget.accept_decoded_text(s) {
+                                    chunks.insert(key, s);
+                                }
+                            }
+                            LimitedZlibText::ExceededLimit => budget.exhaust_decoded_text(),
+                            LimitedZlibText::Invalid => {}
                         }
                     }
                 } else if chunk_type == "tEXt" {
                     if pos + 1 < chunk_data.len() {
                         let val = String::from_utf8_lossy(&chunk_data[pos + 1..]).to_string();
-                        chunks.insert(key, val);
+                        if let Some(val) = budget.accept_decoded_text(val) {
+                            chunks.insert(key, val);
+                        }
                     }
                 } else if chunk_type == "iTXt" {
                     // Simplified iTXt parsing
@@ -178,11 +278,23 @@ pub fn extract_png_chunks<R: Read + Seek>(
                         if curr < chunk_data.len() {
                             let data_slice = &chunk_data[curr..];
                             if is_compressed {
-                                if let Some(s) = read_limited_zlib_text(data_slice) {
-                                    chunks.insert(key, s);
+                                match read_limited_zlib_text(
+                                    data_slice,
+                                    budget.remaining_decoded_text_bytes(),
+                                ) {
+                                    LimitedZlibText::Text(s) => {
+                                        if let Some(s) = budget.accept_decoded_text(s) {
+                                            chunks.insert(key, s);
+                                        }
+                                    }
+                                    LimitedZlibText::ExceededLimit => budget.exhaust_decoded_text(),
+                                    LimitedZlibText::Invalid => {}
                                 }
                             } else {
-                                chunks.insert(key, String::from_utf8_lossy(data_slice).to_string());
+                                let val = String::from_utf8_lossy(data_slice).to_string();
+                                if let Some(val) = budget.accept_decoded_text(val) {
+                                    chunks.insert(key, val);
+                                }
                             }
                         }
                     }
@@ -404,6 +516,78 @@ mod tests {
     use super::*;
     use std::io::Cursor;
 
+    fn png_fixture() -> Vec<u8> {
+        vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    }
+
+    fn push_png_chunk(png: &mut Vec<u8>, chunk_type: &[u8; 4], data: &[u8]) {
+        png.extend_from_slice(&(data.len() as u32).to_be_bytes());
+        png.extend_from_slice(chunk_type);
+        png.extend_from_slice(data);
+        png.extend_from_slice(&[0; 4]);
+    }
+
+    fn push_iend(png: &mut Vec<u8>) {
+        push_png_chunk(png, b"IEND", &[]);
+    }
+
+    fn text_chunk_data(key: &str, value_len: usize, fill: u8) -> Vec<u8> {
+        let mut data = Vec::with_capacity(key.len() + 1 + value_len);
+        data.extend_from_slice(key.as_bytes());
+        data.push(0);
+        data.extend(std::iter::repeat(fill).take(value_len));
+        data
+    }
+
+    fn itxt_uncompressed_data(key: &str, value_len: usize, fill: u8) -> Vec<u8> {
+        let mut data = Vec::with_capacity(key.len() + 5 + value_len);
+        data.extend_from_slice(key.as_bytes());
+        data.push(0);
+        data.push(0);
+        data.push(0);
+        data.push(0);
+        data.push(0);
+        data.extend(std::iter::repeat(fill).take(value_len));
+        data
+    }
+
+    fn ztxt_chunk_data(key: &str, value: &[u8]) -> Vec<u8> {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(value).unwrap();
+        let compressed_text = encoder.finish().unwrap();
+
+        let mut data = Vec::with_capacity(key.len() + 2 + compressed_text.len());
+        data.extend_from_slice(key.as_bytes());
+        data.push(0);
+        data.push(0);
+        data.extend_from_slice(&compressed_text);
+        data
+    }
+
+    fn itxt_compressed_data(key: &str, value: &[u8]) -> Vec<u8> {
+        use flate2::write::ZlibEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(value).unwrap();
+        let compressed_text = encoder.finish().unwrap();
+
+        let mut data = Vec::with_capacity(key.len() + 5 + compressed_text.len());
+        data.extend_from_slice(key.as_bytes());
+        data.push(0);
+        data.push(1);
+        data.push(0);
+        data.push(0);
+        data.push(0);
+        data.extend_from_slice(&compressed_text);
+        data
+    }
+
     #[test]
     fn test_parse_exif_le_ascii() {
         // Simple case: UserComment directly in IFD0
@@ -451,6 +635,335 @@ mod tests {
         let mut cursor = Cursor::new(png);
         let chunks = extract_png_chunks(&mut cursor).unwrap();
         assert_eq!(chunks.get("Software").map(|s| s.as_str()), Some("Ambit"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_caps_aggregate_text_bytes() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(&mut png, b"tEXt", b"too_late\0nope");
+        push_png_chunk(&mut png, b"tEXt", b"after_limit\0small");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert_eq!(
+            chunks.get("filler_a").map(|s| s.len()),
+            Some((MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize)
+        );
+        assert!(!chunks.contains_key("too_late"));
+        assert!(!chunks.contains_key("after_limit"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_caps_aggregate_raw_metadata_bytes() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+
+        let filler = vec![0u8; 4 * 1024 * 1024];
+        for _ in 0..8 {
+            push_png_chunk(&mut png, b"eXIf", &filler);
+        }
+
+        push_png_chunk(&mut png, b"tEXt", b"too_late\0nope");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("too_late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_caps_itxt_decoded_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"iTXt", b"early\0\0\0\0\0ok");
+        push_png_chunk(
+            &mut png,
+            b"iTXt",
+            &itxt_uncompressed_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"iTXt",
+            &itxt_uncompressed_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(&mut png, b"iTXt", b"too_late\0\0\0\0\0nope");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert_eq!(
+            chunks.get("filler_b").map(|s| s.len()),
+            Some((MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2) as usize)
+        );
+        assert!(!chunks.contains_key("too_late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_caps_compressed_text_by_remaining_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(&mut png, b"zTXt", &ztxt_chunk_data("too_late", b"nope"));
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("too_late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_ztxt_over_limit_exhausts_decoded_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 3) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(&mut png, b"zTXt", &ztxt_chunk_data("too_large", b"nope"));
+        push_png_chunk(&mut png, b"tEXt", b"late\0x");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("too_large"));
+        assert!(!chunks.contains_key("late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_compressed_itxt_over_limit_exhausts_decoded_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 3) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"iTXt",
+            &itxt_compressed_data("too_large", b"nope"),
+        );
+        push_png_chunk(&mut png, b"tEXt", b"late\0x");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("too_large"));
+        assert!(!chunks.contains_key("late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_ztxt_over_limit_invalid_utf8_exhausts_decoded_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 3) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"zTXt",
+            &ztxt_chunk_data("too_large_invalid_utf8", &[0xff, 0xff]),
+        );
+        push_png_chunk(&mut png, b"tEXt", b"late\0x");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("too_large_invalid_utf8"));
+        assert!(!chunks.contains_key("late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_compressed_itxt_over_limit_invalid_utf8_exhausts_decoded_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_a",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2) as usize,
+                b'a',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"tEXt",
+            &text_chunk_data(
+                "filler_b",
+                (MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 3) as usize,
+                b'b',
+            ),
+        );
+        push_png_chunk(
+            &mut png,
+            b"iTXt",
+            &itxt_compressed_data("too_large_invalid_utf8", &[0xff, 0xff]),
+        );
+        push_png_chunk(&mut png, b"tEXt", b"late\0x");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("too_large_invalid_utf8"));
+        assert!(!chunks.contains_key("late"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_within_limit_invalid_utf8_skips_only_current_chunk() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"zTXt",
+            &ztxt_chunk_data("invalid_utf8", &[0xff]),
+        );
+        push_png_chunk(&mut png, b"tEXt", b"late\0yes");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("invalid_utf8"));
+        assert_eq!(chunks.get("late").map(|s| s.as_str()), Some("yes"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_invalid_compressed_text_does_not_exhaust_budget() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"tEXt", b"early\0ok");
+        push_png_chunk(
+            &mut png,
+            b"zTXt",
+            b"invalid_compressed\0\0not valid deflate",
+        );
+        push_png_chunk(&mut png, b"tEXt", b"late\0yes");
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(chunks.get("early").map(|s| s.as_str()), Some("ok"));
+        assert!(!chunks.contains_key("invalid_compressed"));
+        assert_eq!(chunks.get("late").map(|s| s.as_str()), Some("yes"));
+    }
+
+    #[test]
+    fn test_extract_png_chunks_ztxt_compressed() {
+        let mut png = png_fixture();
+        push_png_chunk(&mut png, b"zTXt", &ztxt_chunk_data("Comment", b"CompressedValue"));
+        push_iend(&mut png);
+
+        let mut cursor = Cursor::new(png);
+        let chunks = extract_png_chunks(&mut cursor).unwrap();
+
+        assert_eq!(
+            chunks.get("Comment").map(|s| s.as_str()),
+            Some("CompressedValue")
+        );
     }
 
     #[test]

--- a/src/workers/__tests__/metadata.worker.security.test.ts
+++ b/src/workers/__tests__/metadata.worker.security.test.ts
@@ -1,6 +1,106 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { decompressDeflate } from '../metadata.worker';
+import { decompressDeflate, parsePngChunksEnhanced } from '../metadata.worker';
+
+const MAX_PNG_DECODED_TEXT_TOTAL_BYTES = 16 * 1024 * 1024;
+const textEncoder = new TextEncoder();
+const nativeDecompressionStream = globalThis.DecompressionStream;
+const nativeResponse = globalThis.Response;
+type Bytes = Uint8Array<ArrayBufferLike>;
+
+const concat = (parts: Bytes[]): Uint8Array => {
+    const totalLength = parts.reduce((total, part) => total + part.byteLength, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const part of parts) {
+        result.set(part, offset);
+        offset += part.byteLength;
+    }
+    return result;
+};
+
+const pngChunk = (type: string, data: Bytes = new Uint8Array()): Uint8Array => {
+    const result = new Uint8Array(8 + data.byteLength + 4);
+    const view = new DataView(result.buffer);
+    view.setUint32(0, data.byteLength);
+    result.set(textEncoder.encode(type), 4);
+    result.set(data, 8);
+    return result;
+};
+
+const pngFile = (...chunks: Bytes[]): Uint8Array =>
+    concat([
+        new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+        ...chunks,
+        pngChunk('IEND'),
+    ]);
+
+const textChunkData = (key: string, value: string | Bytes): Uint8Array => {
+    const encodedValue = typeof value === 'string' ? textEncoder.encode(value) : value;
+    return concat([textEncoder.encode(key), new Uint8Array([0]), encodedValue]);
+};
+
+const repeatedTextChunkData = (key: string, length: number, fill: number): Uint8Array =>
+    textChunkData(key, new Uint8Array(length).fill(fill));
+
+const malformedUtf8OverDecodedBudget = (): Uint8Array =>
+    new Uint8Array(Math.floor(MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 3) + 1).fill(0xff);
+
+const itxtUncompressedData = (key: string, value: string | Bytes): Uint8Array => {
+    const encodedValue = typeof value === 'string' ? textEncoder.encode(value) : value;
+    return concat([
+        textEncoder.encode(key),
+        new Uint8Array([0, 0, 0, 0, 0]),
+        encodedValue,
+    ]);
+};
+
+const repeatedItxtData = (key: string, length: number, fill: number): Uint8Array =>
+    itxtUncompressedData(key, new Uint8Array(length).fill(fill));
+
+const ztxtData = (key: string, compressed: Bytes = new Uint8Array([1, 2, 3])): Uint8Array =>
+    concat([textEncoder.encode(key), new Uint8Array([0, 0]), compressed]);
+
+const itxtCompressedData = (key: string, compressed: Bytes = new Uint8Array([1, 2, 3])): Uint8Array =>
+    concat([textEncoder.encode(key), new Uint8Array([0, 1, 0, 0, 0]), compressed]);
+
+const stubDeflateResult = (chunks: Bytes[]) => {
+    const mockReader = {
+        read: vi.fn(),
+        cancel: vi.fn(),
+    };
+    for (const chunk of chunks) {
+        mockReader.read.mockResolvedValueOnce({ done: false, value: chunk });
+    }
+    mockReader.read.mockResolvedValueOnce({ done: true, value: undefined });
+
+    const mockStream = {
+        getReader: () => mockReader,
+    };
+
+    vi.stubGlobal('DecompressionStream', vi.fn().mockImplementation(function() {
+        return {
+            writable: {},
+            readable: mockStream,
+        };
+    }));
+
+    vi.stubGlobal('Response', vi.fn().mockImplementation(function() {
+        return {
+            body: {
+                pipeThrough: vi.fn().mockReturnValue(mockStream),
+            },
+        };
+    }));
+
+    return mockReader;
+};
+
+const stubInvalidDeflate = () => {
+    vi.stubGlobal('DecompressionStream', vi.fn().mockImplementation(function() {
+        throw new Error('invalid deflate');
+    }));
+};
 
 describe('decompressDeflate Security Limits', () => {
     beforeEach(() => {
@@ -8,73 +108,209 @@ describe('decompressDeflate Security Limits', () => {
             warn: vi.fn(),
             error: console.error, // Don't mock error
             log: vi.fn(),
+            debug: vi.fn(),
         });
     });
 
     it('should handle small decompression normally', async () => {
         const mockData = new Uint8Array([1, 2, 3]);
-        const mockReader = {
-            read: vi.fn()
-                .mockResolvedValueOnce({ done: false, value: mockData })
-                .mockResolvedValueOnce({ done: true, value: undefined }),
-            cancel: vi.fn(),
-        };
-        const mockStream = {
-            getReader: () => mockReader,
-        };
-
-        vi.stubGlobal('DecompressionStream', vi.fn().mockImplementation(function() {
-            return {
-                writable: {},
-                readable: mockStream,
-            };
-        }));
-
-        vi.stubGlobal('Response', vi.fn().mockImplementation(function() {
-            return {
-                body: {
-                    pipeThrough: vi.fn().mockReturnValue(mockStream),
-                },
-            };
-        }));
+        stubDeflateResult([mockData]);
 
         const result = await decompressDeflate(new Uint8Array([0]));
-        expect(result).toEqual(mockData);
+        expect(result.status).toBe('ok');
+        if (result.status === 'ok') {
+            expect(result.data).toEqual(mockData);
+        }
     });
 
     it('should abort if decompressed size exceeds 10MB', async () => {
         const MAX_DECOMPRESSED_SIZE = 10 * 1024 * 1024;
         const largeChunk = new Uint8Array(MAX_DECOMPRESSED_SIZE + 1);
 
-        const mockReader = {
-            read: vi.fn()
-                .mockResolvedValueOnce({ done: false, value: largeChunk })
-                .mockResolvedValueOnce({ done: true, value: undefined }),
-            cancel: vi.fn(),
-        };
-        const mockStream = {
-            getReader: () => mockReader,
-        };
-
-        vi.stubGlobal('DecompressionStream', vi.fn().mockImplementation(function() {
-            return {
-                writable: {},
-                readable: mockStream,
-            };
-        }));
-
-        vi.stubGlobal('Response', vi.fn().mockImplementation(function() {
-            return {
-                body: {
-                    pipeThrough: vi.fn().mockReturnValue(mockStream),
-                },
-            };
-        }));
+        const mockReader = stubDeflateResult([largeChunk]);
 
         const result = await decompressDeflate(new Uint8Array([0]));
         
-        expect(result).toBeNull();
+        expect(result.status).toBe('over-limit');
         expect(mockReader.cancel).toHaveBeenCalled();
         expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Decompression limit exceeded'));
+    });
+});
+
+describe('parsePngChunksEnhanced Security Limits', () => {
+    beforeEach(() => {
+        if (nativeDecompressionStream) vi.stubGlobal('DecompressionStream', nativeDecompressionStream);
+        if (nativeResponse) vi.stubGlobal('Response', nativeResponse);
+        vi.stubGlobal('console', {
+            warn: vi.fn(),
+            error: console.error,
+            log: vi.fn(),
+            debug: vi.fn(),
+        });
+    });
+
+    it('should parse normal text, iTXt, and zTXt metadata', async () => {
+        const compressedValue = Uint8Array.from(textEncoder.encode('CompressedValue'));
+        const mockReader = stubDeflateResult([compressedValue]);
+
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('Software', 'Ambit')),
+            pngChunk('iTXt', itxtUncompressedData('Keyword', 'Value')),
+            pngChunk('zTXt', ztxtData('Compressed')),
+        ));
+
+        expect(chunks.Software).toBe('Ambit');
+        expect(chunks.Keyword).toBe('Value');
+        expect(mockReader.read).toHaveBeenCalled();
+        expect(chunks.Compressed).toBe('CompressedValue');
+    });
+
+    it('should preserve early text chunks and drop late chunks after the decoded aggregate budget', async () => {
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk(
+                'tEXt',
+                repeatedTextChunkData('filler_a', MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2, 97),
+            ),
+            pngChunk(
+                'tEXt',
+                repeatedTextChunkData('filler_b', MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2, 98),
+            ),
+            pngChunk('tEXt', textChunkData('too_late', 'nope')),
+            pngChunk('tEXt', textChunkData('after_limit', 'small')),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.filler_a).toHaveLength(MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2);
+        expect(chunks.too_late).toBeUndefined();
+        expect(chunks.after_limit).toBeUndefined();
+    });
+
+    it('should drop late chunks after the raw aggregate metadata budget', async () => {
+        const rawFiller = new Uint8Array(4 * 1024 * 1024);
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            ...Array.from({ length: 8 }, () => pngChunk('eXIf', rawFiller)),
+            pngChunk('tEXt', textChunkData('too_late', 'nope')),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.too_late).toBeUndefined();
+    });
+
+    it('should cap uncompressed iTXt by the decoded aggregate budget', async () => {
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('iTXt', itxtUncompressedData('early', 'ok')),
+            pngChunk(
+                'iTXt',
+                repeatedItxtData('filler_a', MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2, 97),
+            ),
+            pngChunk(
+                'iTXt',
+                repeatedItxtData('filler_b', MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2, 98),
+            ),
+            pngChunk('iTXt', itxtUncompressedData('too_late', 'nope')),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.filler_b).toHaveLength(MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2);
+        expect(chunks.too_late).toBeUndefined();
+    });
+
+    it('should not decompress zTXt once no decoded text budget remains', async () => {
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk(
+                'tEXt',
+                repeatedTextChunkData('filler_a', MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2, 97),
+            ),
+            pngChunk(
+                'tEXt',
+                repeatedTextChunkData('filler_b', MAX_PNG_DECODED_TEXT_TOTAL_BYTES / 2 - 2, 98),
+            ),
+            pngChunk('zTXt', ztxtData('too_late')),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.too_late).toBeUndefined();
+    });
+
+    it('should reject tEXt whose decoded replacement text exceeds the aggregate budget', async () => {
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk('tEXt', textChunkData('malformed', malformedUtf8OverDecodedBudget())),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.malformed).toBeUndefined();
+    });
+
+    it('should reject uncompressed iTXt whose decoded replacement text exceeds the aggregate budget', async () => {
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('iTXt', itxtUncompressedData('early', 'ok')),
+            pngChunk('iTXt', itxtUncompressedData('malformed', malformedUtf8OverDecodedBudget())),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.malformed).toBeUndefined();
+    });
+
+    it('should reject compressed zTXt after decoded replacement text exceeds the aggregate budget', async () => {
+        const mockReader = stubDeflateResult([malformedUtf8OverDecodedBudget()]);
+
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk('zTXt', ztxtData('malformed')),
+        ));
+
+        expect(mockReader.read).toHaveBeenCalled();
+        expect(chunks.early).toBe('ok');
+        expect(chunks.malformed).toBeUndefined();
+    });
+
+    it('should exhaust decoded budget after over-limit zTXt decompression', async () => {
+        const oversized = new Uint8Array(10 * 1024 * 1024 + 1);
+        const mockReader = stubDeflateResult([oversized]);
+
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk('zTXt', ztxtData('too_large')),
+            pngChunk('tEXt', textChunkData('late', 'x')),
+        ));
+
+        expect(mockReader.cancel).toHaveBeenCalled();
+        expect(chunks.early).toBe('ok');
+        expect(chunks.too_large).toBeUndefined();
+        expect(chunks.late).toBeUndefined();
+    });
+
+    it('should exhaust decoded budget after over-limit compressed iTXt decompression', async () => {
+        const oversized = new Uint8Array(10 * 1024 * 1024 + 1);
+        const mockReader = stubDeflateResult([oversized]);
+
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk('iTXt', itxtCompressedData('too_large')),
+            pngChunk('tEXt', textChunkData('late', 'x')),
+        ));
+
+        expect(mockReader.cancel).toHaveBeenCalled();
+        expect(chunks.early).toBe('ok');
+        expect(chunks.too_large).toBeUndefined();
+        expect(chunks.late).toBeUndefined();
+    });
+
+    it('should skip invalid compressed text without exhausting decoded budget', async () => {
+        stubInvalidDeflate();
+
+        const chunks = await parsePngChunksEnhanced(pngFile(
+            pngChunk('tEXt', textChunkData('early', 'ok')),
+            pngChunk('zTXt', ztxtData('invalid_compressed')),
+            pngChunk('tEXt', textChunkData('late', 'yes')),
+        ));
+
+        expect(chunks.early).toBe('ok');
+        expect(chunks.invalid_compressed).toBeUndefined();
+        expect(chunks.late).toBe('yes');
     });
 });

--- a/src/workers/metadata.worker.ts
+++ b/src/workers/metadata.worker.ts
@@ -15,6 +15,91 @@ export interface ParseResult {
 // Helper to decode text from buffer
 // Note: In a worker, TextDecoder is available in global scope in modern browsers.
 const textDecoder = new TextDecoder('utf-8');
+const textEncoder = new TextEncoder();
+
+const MAX_PNG_METADATA_CHUNK_BYTES = 16 * 1024 * 1024;
+const MAX_PNG_DECOMPRESSED_TEXT_BYTES = 10 * 1024 * 1024;
+const MAX_PNG_METADATA_TOTAL_CHUNK_BYTES = 32 * 1024 * 1024;
+const MAX_PNG_DECODED_TEXT_TOTAL_BYTES = 16 * 1024 * 1024;
+
+type PngMetadataBudget = {
+    rawChunkBytes: number;
+    decodedTextBytes: number;
+    rawExhausted: boolean;
+    decodedExhausted: boolean;
+    loggedLimit: boolean;
+};
+
+const createPngMetadataBudget = (): PngMetadataBudget => ({
+    rawChunkBytes: 0,
+    decodedTextBytes: 0,
+    rawExhausted: false,
+    decodedExhausted: false,
+    loggedLimit: false,
+});
+
+const notePngBudgetLimit = (budget: PngMetadataBudget, reason: string) => {
+    if (!budget.loggedLimit) {
+        if (typeof console.debug === 'function') {
+            console.debug(`[Worker] PNG metadata budget reached: ${reason}`);
+        }
+        budget.loggedLimit = true;
+    }
+};
+
+const isPngMetadataChunk = (type: string): boolean =>
+    type === 'tEXt' || type === 'iTXt' || type === 'zTXt' || type === 'eXIf';
+
+const allowPngMetadataChunk = (budget: PngMetadataBudget, length: number): boolean => {
+    if (budget.rawExhausted) return false;
+
+    if (length > MAX_PNG_METADATA_CHUNK_BYTES) {
+        notePngBudgetLimit(budget, 'single metadata chunk exceeds limit');
+        return false;
+    }
+    if (budget.rawChunkBytes + length > MAX_PNG_METADATA_TOTAL_CHUNK_BYTES) {
+        budget.rawExhausted = true;
+        notePngBudgetLimit(budget, 'aggregate metadata chunk bytes exceed limit');
+        return false;
+    }
+
+    budget.rawChunkBytes += length;
+    return true;
+};
+
+const remainingPngDecodedTextBytes = (budget: PngMetadataBudget): number =>
+    budget.decodedExhausted
+        ? 0
+        : Math.max(0, MAX_PNG_DECODED_TEXT_TOTAL_BYTES - budget.decodedTextBytes);
+
+const exhaustPngDecodedTextBudget = (budget: PngMetadataBudget) => {
+    budget.decodedExhausted = true;
+    notePngBudgetLimit(budget, 'aggregate decoded text bytes exceed limit');
+};
+
+const acceptPngDecodedText = (
+    chunks: Record<string, string>,
+    budget: PngMetadataBudget,
+    key: string,
+    value: string,
+): boolean => {
+    if (budget.decodedExhausted) return false;
+
+    const decodedBytes = textEncoder.encode(value).byteLength;
+    if (decodedBytes > remainingPngDecodedTextBytes(budget)) {
+        exhaustPngDecodedTextBudget(budget);
+        return false;
+    }
+
+    budget.decodedTextBytes += decodedBytes;
+    chunks[key] = value;
+    return true;
+};
+
+type DecompressDeflateResult =
+    | { status: 'ok'; data: Uint8Array }
+    | { status: 'over-limit' }
+    | { status: 'invalid' };
 
 type MetadataRecord = Record<string, unknown>;
 type WorkflowInput = MetadataRecord & {
@@ -473,6 +558,8 @@ const mergeMetadata = (base: Partial<ImageMetadata>, secondary: Partial<ImageMet
 
 const parsePngChunks = (buffer: Uint8Array): Record<string, string> => {
     const chunks: Record<string, string> = {};
+    if (buffer.length < 8) return chunks;
+
     const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 
     // Verify PNG header
@@ -480,19 +567,35 @@ const parsePngChunks = (buffer: Uint8Array): Record<string, string> => {
         return chunks;
     }
 
+    const budget = createPngMetadataBudget();
     let pos = 8;
     while (pos + 8 < buffer.length) {
         const length = view.getUint32(pos);
         const type = textDecoder.decode(buffer.slice(pos + 4, pos + 8));
         pos += 8;
+        const dataEnd = pos + length;
+
+        if (dataEnd + 4 > buffer.length) break;
+
+        if (isPngMetadataChunk(type)) {
+            if (!allowPngMetadataChunk(budget, length)) {
+                pos += length + 4;
+                continue;
+            }
+        }
 
         if (type === 'tEXt' || type === 'iTXt' || type === 'zTXt') {
-            const data = buffer.slice(pos, pos + length);
+            const data = buffer.slice(pos, dataEnd);
             const nullPos = data.indexOf(0);
             if (nullPos !== -1) {
                 const key = textDecoder.decode(data.slice(0, nullPos));
                 if (type === 'tEXt') {
-                    chunks[key] = textDecoder.decode(data.slice(nullPos + 1));
+                    acceptPngDecodedText(
+                        chunks,
+                        budget,
+                        key,
+                        textDecoder.decode(data.slice(nullPos + 1)),
+                    );
                 } else if (type === 'iTXt') {
                     // iTXt: Keyword (null) CompressionFlag (1) CompressionMethod (1) Language (null) TranslatedKeyword (null) Text
                     const isCompressed = data[nullPos + 1] === 1;
@@ -507,8 +610,13 @@ const parsePngChunks = (buffer: Uint8Array): Record<string, string> => {
                     if (isCompressed) {
                         // Decompression would require a lib like fflate in the worker.
                         // For now we skip compressed iTXt if not available.
-                    } else {
-                        chunks[key] = textDecoder.decode(data.slice(textStart));
+                    } else if (textStart <= data.byteLength) {
+                        acceptPngDecodedText(
+                            chunks,
+                            budget,
+                            key,
+                            textDecoder.decode(data.slice(textStart)),
+                        );
                     }
                 }
                 // zTXt would also need decompression.
@@ -625,17 +733,21 @@ const parseExifData = (data: Uint8Array): string | null => {
 };
 
 // Decompression helper using browser-native DecompressionStream
-export const decompressDeflate = async (buffer: Uint8Array): Promise<Uint8Array | null> => {
-    const MAX_DECOMPRESSED_SIZE = 10 * 1024 * 1024; // 10MB limit
+export const decompressDeflate = async (
+    buffer: Uint8Array,
+    maxDecompressedSize = MAX_PNG_DECOMPRESSED_TEXT_BYTES,
+): Promise<DecompressDeflateResult> => {
+    if (maxDecompressedSize <= 0) return { status: 'over-limit' };
+
     try {
         // DecompressionStream is available in modern browser environments (webview2/webkit)
         const DecompressionStreamImpl = (globalThis as DecompressionGlobal).DecompressionStream;
-        if (!DecompressionStreamImpl) return null;
+        if (!DecompressionStreamImpl) return { status: 'invalid' };
         const ds = new DecompressionStreamImpl('deflate');
         const body = new ArrayBuffer(buffer.byteLength);
         new Uint8Array(body).set(buffer);
         const stream = new Response(body).body?.pipeThrough(ds);
-        if (!stream) return null;
+        if (!stream) return { status: 'invalid' };
 
         const reader = stream.getReader();
         const chunks: Uint8Array[] = [];
@@ -647,10 +759,10 @@ export const decompressDeflate = async (buffer: Uint8Array): Promise<Uint8Array 
             if (!(value instanceof Uint8Array)) continue;
 
             totalSize += value.length;
-            if (totalSize > MAX_DECOMPRESSED_SIZE) {
-                console.warn('[Worker] Decompression limit exceeded (10MB)');
+            if (totalSize > maxDecompressedSize) {
+                console.warn(`[Worker] Decompression limit exceeded (${maxDecompressedSize} bytes)`);
                 await reader.cancel();
-                return null;
+                return { status: 'over-limit' };
             }
             chunks.push(value);
         }
@@ -661,11 +773,133 @@ export const decompressDeflate = async (buffer: Uint8Array): Promise<Uint8Array 
             result.set(chunk, offset);
             offset += chunk.length;
         }
-        return result;
+        return { status: 'ok', data: result };
     } catch (e) {
         console.error('[Worker] Decompression failed:', e);
-        return null;
+        return { status: 'invalid' };
     }
+};
+
+// Modified parsePngChunks to include eXIf and supported compressed chunks
+export const parsePngChunksEnhanced = async (buffer: Uint8Array): Promise<Record<string, string>> => {
+    const chunks: Record<string, string> = {};
+    if (buffer.length < 8) return chunks;
+
+    const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    const budget = createPngMetadataBudget();
+
+    if (view.getUint32(0) !== 0x89504e47 || view.getUint32(4) !== 0x0d0a1a0a) return chunks;
+
+    let pos = 8;
+    while (pos + 8 < buffer.length) {
+        const length = view.getUint32(pos);
+        const type = textDecoder.decode(buffer.slice(pos + 4, pos + 8));
+        pos += 8;
+        const dataEnd = pos + length;
+
+        if (dataEnd + 4 > buffer.length) break;
+
+        if (isPngMetadataChunk(type)) {
+            if (!allowPngMetadataChunk(budget, length)) {
+                pos += length + 4;
+                continue;
+            }
+        }
+
+        if (type === 'tEXt') {
+            const data = buffer.slice(pos, dataEnd);
+            const nullPos = data.indexOf(0);
+            if (nullPos !== -1) {
+                const key = textDecoder.decode(data.slice(0, nullPos));
+                acceptPngDecodedText(
+                    chunks,
+                    budget,
+                    key,
+                    textDecoder.decode(data.slice(nullPos + 1)),
+                );
+            }
+        } else if (type === 'zTXt') {
+            const data = buffer.slice(pos, dataEnd);
+            const nullPos = data.indexOf(0);
+            if (nullPos !== -1) {
+                const key = textDecoder.decode(data.slice(0, nullPos));
+                // zTXt: key (null) method (1 byte, must be 0 for deflate) compressedData
+                if (data[nullPos + 1] === 0) { // Compression method 0 (deflate)
+                    const compressed = data.slice(nullPos + 2);
+                    const maxDecoded = Math.min(
+                        MAX_PNG_DECOMPRESSED_TEXT_BYTES,
+                        remainingPngDecodedTextBytes(budget),
+                    );
+                    const decompressed = await decompressDeflate(compressed, maxDecoded);
+                    if (decompressed.status === 'ok') {
+                        acceptPngDecodedText(
+                            chunks,
+                            budget,
+                            key,
+                            textDecoder.decode(decompressed.data),
+                        );
+                    } else if (decompressed.status === 'over-limit') {
+                        exhaustPngDecodedTextBudget(budget);
+                    }
+                }
+            }
+        } else if (type === 'iTXt') {
+            const data = buffer.slice(pos, dataEnd);
+            const nullPos = data.indexOf(0);
+            if (nullPos !== -1) {
+                const key = textDecoder.decode(data.slice(0, nullPos));
+                const isCompressed = data[nullPos + 1] === 1;
+                const method = data[nullPos + 2]; // Compression method (0 for deflate)
+
+                let textStart = nullPos + 3;
+                while (textStart < data.length && data[textStart] !== 0) textStart++;
+                textStart++; // Skip Lang
+                while (textStart < data.length && data[textStart] !== 0) textStart++;
+                textStart++; // Skip Trans
+
+                if (textStart <= data.byteLength) {
+                    if (isCompressed) {
+                        if (method === 0) { // Compression method 0 (deflate)
+                            const compressed = data.slice(textStart);
+                            const maxDecoded = Math.min(
+                                MAX_PNG_DECOMPRESSED_TEXT_BYTES,
+                                remainingPngDecodedTextBytes(budget),
+                            );
+                            const decompressed = await decompressDeflate(compressed, maxDecoded);
+                            if (decompressed.status === 'ok') {
+                                acceptPngDecodedText(
+                                    chunks,
+                                    budget,
+                                    key,
+                                    textDecoder.decode(decompressed.data),
+                                );
+                            } else if (decompressed.status === 'over-limit') {
+                                exhaustPngDecodedTextBudget(budget);
+                            }
+                        }
+                    } else {
+                        acceptPngDecodedText(
+                            chunks,
+                            budget,
+                            key,
+                            textDecoder.decode(data.slice(textStart)),
+                        );
+                    }
+                }
+            }
+        } else if (type === 'eXIf') {
+            const data = buffer.slice(pos, dataEnd);
+            const exifComment = parseExifData(data);
+            if (exifComment && !chunks['parameters']) {
+                acceptPngDecodedText(chunks, budget, 'parameters', exifComment);
+            }
+        } else if (type === 'IEND') {
+            break;
+        }
+
+        pos += length + 4; // Data + CRC
+    }
+    return chunks;
 };
 
 // Worker Message Handler
@@ -677,83 +911,6 @@ self.onmessage = async (e: MessageEvent) => {
     const requestId = typeof request.requestId === 'string' ? request.requestId : undefined;
     const path = typeof request.path === 'string' ? request.path : '';
     const defaultTool = asGeneratorTool(request.defaultTool);
-
-    // Modified parsePngChunks to include eXIf and supported compressed chunks
-    const parsePngChunksEnhanced = async (buffer: Uint8Array): Promise<Record<string, string>> => {
-        const chunks: Record<string, string> = {};
-        const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-
-        if (view.getUint32(0) !== 0x89504e47 || view.getUint32(4) !== 0x0d0a1a0a) return chunks;
-
-        let pos = 8;
-        while (pos + 8 < buffer.length) {
-            const length = view.getUint32(pos);
-            const type = textDecoder.decode(buffer.slice(pos + 4, pos + 8));
-            pos += 8;
-
-            if (type === 'tEXt') {
-                const data = buffer.slice(pos, pos + length);
-                const nullPos = data.indexOf(0);
-                if (nullPos !== -1) {
-                    const key = textDecoder.decode(data.slice(0, nullPos));
-                    chunks[key] = textDecoder.decode(data.slice(nullPos + 1));
-                }
-            } else if (type === 'zTXt') {
-                const data = buffer.slice(pos, pos + length);
-                const nullPos = data.indexOf(0);
-                if (nullPos !== -1) {
-                    const key = textDecoder.decode(data.slice(0, nullPos));
-                    // zTXt: key (null) method (1 byte, must be 0 for deflate) compressedData
-                    if (data[nullPos + 1] === 0) { // Compression method 0 (deflate)
-                        const compressed = data.slice(nullPos + 2);
-                        const decompressed = await decompressDeflate(compressed);
-                        if (decompressed) {
-                            chunks[key] = textDecoder.decode(decompressed);
-                        }
-                    }
-                }
-            } else if (type === 'iTXt') {
-                const data = buffer.slice(pos, pos + length);
-                const nullPos = data.indexOf(0);
-                if (nullPos !== -1) {
-                    const key = textDecoder.decode(data.slice(0, nullPos));
-                    const isCompressed = data[nullPos + 1] === 1;
-                    const method = data[nullPos + 2]; // Compression method (0 for deflate)
-
-                    let textStart = nullPos + 3;
-                    while (textStart < data.length && data[textStart] !== 0) textStart++;
-                    textStart++; // Skip Lang
-                    while (textStart < data.length && data[textStart] !== 0) textStart++;
-                    textStart++; // Skip Trans
-
-                    if (isCompressed) {
-                        if (method === 0) { // Compression method 0 (deflate)
-                            const compressed = data.slice(textStart);
-                            const decompressed = await decompressDeflate(compressed);
-                            if (decompressed) {
-                                chunks[key] = textDecoder.decode(decompressed);
-                            }
-                        }
-                    } else {
-                        chunks[key] = textDecoder.decode(data.slice(textStart));
-                    }
-                }
-            } else if (type === 'eXIf') {
-                const data = buffer.slice(pos, pos + length);
-                const exifComment = parseExifData(data);
-                if (exifComment) {
-                    // Try to avoid overwriting standard parameters if already found, 
-                    // but usually eXIf is the fallback.
-                    if (!chunks['parameters']) chunks['parameters'] = exifComment;
-                }
-            } else if (type === 'IEND') {
-                break;
-            }
-
-            pos += length + 4; // Data + CRC
-        }
-        return chunks;
-    };
 
     if (!chunks && buffer) {
         chunks = await parsePngChunksEnhanced(buffer);


### PR DESCRIPTION
## Summary

- Bound PNG text metadata parsing with per-image raw and decoded budgets in Rust and the metadata worker.
- Treat compressed text that expands beyond the remaining decoded budget as terminal for decoded metadata.
- Keep malformed compressed data best-effort by skipping only that chunk.
- Align Cargo.lock app package version with the 0.6.3 manifests.

## Validation

- cargo test --manifest-path src-tauri/Cargo.toml png --quiet
- node_modules\.bin\vitest.cmd run src/workers/__tests__/metadata.worker.security.test.ts src/workers/metadata.worker.test.ts --reporter=dot
- corepack pnpm run typecheck
- git diff --check

## Notes

- cargo fmt --check --manifest-path src-tauri/Cargo.toml could not run because rustfmt is not installed for toolchain 1.96.0-x86_64-pc-windows-msvc.