### PR TITLE
docs: refresh public repo readiness notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md
-Agent doc system: agent-doc-system v1.1.0
+Agent doc system: agent-doc-system v1.2.0
 
 ## Purpose
 Ambit is a local-first desktop image manager for large AI-generated image libraries. The repo is a Tauri v2 app with a React/TypeScript frontend and a Rust/SQLite backend. Most agent tasks here touch feature UI, Tauri commands, metadata parsing, or library/query performance.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -232,7 +232,7 @@ Status: Deferred
 ### Why Cleanup Is Needed
 - `src/services/repository.ts` still carries a `LocalStorageRepository` and mock-image defaults, but the live desktop app uses `TauriFsRepository` plus SQLite.
 - `src/services/TauriFsRepository.ts`, `src/stores/settingsStore.ts`, and Rust keyring or database code split persistence across JSON, SQLite, and secure OS storage.
-- Windows app data is currently split across Local and Roaming AppData. This is valid Tauri/Windows behavior, but Ambit's large, local-first SQLite library is better suited to Local AppData than Roaming.
+- Windows app data still has a legacy Local/Roaming compatibility boundary. The active SQLite library now prefers Local AppData, while Roaming remains only as a fallback for older data that could not be moved automatically.
 
 ### Current Classification
 - `src/services/repository.ts` is not the canonical desktop persistence path today; it exports `TauriFsRepository` for the shipping app while still carrying a LocalStorage or mock fallback.
@@ -249,7 +249,7 @@ Status: Deferred
 
 ### Safe-Change Warning
 - Persistence changes can silently affect existing user libraries and first-run behavior.
-- Do not change the default database directory without a compatibility migration and rollback-aware testing on an existing Roaming database.
+- Do not change database directory behavior again without a compatibility migration and rollback-aware testing on existing Local and legacy Roaming databases.
 
 ### Suggested Future Direction
 - Make the production Tauri persistence path the obvious canonical path in the frontend.
@@ -282,9 +282,9 @@ Status: In transition
 ### Current State
 - Production config now uses `io.github.asuraace.ambit` as the bundle identifier.
 - Development config remains on `com.ambit.dev`.
-- Release builds run a one-time startup migration before SQL initialization:
-  - Roaming AppData moves from `com.ambit.app` to `io.github.asuraace.ambit` when the new profile has no `images.db`.
-  - Local AppData moves from `com.ambit.app` to `io.github.asuraace.ambit` when the new profile has no `library.json` or `.thumbnails`.
+- Release builds run startup data migrations before SQL initialization:
+  - legacy `com.ambit.app` data moves into `io.github.asuraace.ambit` when the current profile has no conflicting data.
+  - eligible legacy/current Roaming database files move to Local AppData when Local has no active database.
   - Existing new-profile data is never overwritten.
 - Reset/purge and historical migration repair code check both the current and legacy production identifiers during this transition.
 
@@ -300,7 +300,7 @@ Status: In transition
 
 ### Not Part of the Current Task
 - Do not change the dev identifier.
-- Do not move the SQLite database from Roaming to Local AppData as part of this identifier-only migration.
+- Do not remove legacy `com.ambit.app` or Roaming fallback checks until the public-beta upgrade window is intentionally closed.
 
 ## Smart Thumbnail Optimization and Removed Maintenance Tab
 Status: Deferred

--- a/docs/release-candidate-validation.md
+++ b/docs/release-candidate-validation.md
@@ -1,51 +1,50 @@
 # Release Candidate Validation
 
-Status: In progress
-Last updated: 2026-05-15
+Status: Active
+Last updated: 2026-07-02
 
-This record tracks the release-candidate checks that must pass after the hardening branches are stacked. It separates checks Codex can prove in the workspace from checks that require a real installed Windows app and reachable GitHub Release assets.
+This checklist tracks release-candidate evidence for Ambit public beta builds. It separates checks Codex can prove in the workspace from checks that require a real installed Windows app and unauthenticated release assets.
 
-## Current Evidence
+Do not treat authenticated maintainer access through `gh release download` as updater validation. Installed Ambit clients must be able to reach `latest.json`, the installer URL, and the updater signature without GitHub authentication.
 
-| Area | Result | Evidence |
-| --- | --- | --- |
-| Updater signing secret | Pass | GitHub Actions run `25927212899` completed successfully for `updater-signing-preflight`: <https://github.com/AsuraAce/ambit/actions/runs/25927212899>. |
-| GitHub auth for release inspection | Pass | Local `gh auth status` is authenticated as `AsuraAce` with `repo` and `workflow` scopes. |
-| Existing release assets | Partial | `gh release view v0.5.0` finds `latest.json`, NSIS, MSI, and signature assets. These assets predate the current hardening stack and are not a valid RC for this branch. |
-| Public updater reachability | Blocked | Unauthenticated `Invoke-WebRequest` to `https://github.com/AsuraAce/ambit/releases/download/v0.5.0/latest.json` returned GitHub `Not Found` while the repository is private. The updater cannot rely on private GitHub Release URLs for a public beta. |
-| Browser smoke | Pass | Browser mock mode loaded `http://127.0.0.1:1421/` with title `Ambit \| Local AI Workspace`, no framework overlay, and no current-URL console warnings or errors. |
-| Settings/updater copy | Pass | Settings > Advanced > Interface renders `Automatic Updates`, GitHub Releases startup copy, disabled development update status, `Check for Updates`, and `Reset Onboarding`. |
-| Import modal | Pass | Header import action in browser mock mode opens the safe import education modal; integration buttons and one-time import options render. |
-| Onboarding network disclosure | Pass | Onboarding Privacy step renders local-first, Gemini, GitHub Releases, and CivitAI `Resolve Online` disclosure copy. |
+## Required Evidence
 
-## Release Blocker
+| Area | Required evidence |
+| --- | --- |
+| Version provenance | Release tag, package metadata, Tauri config, installer names, and `latest.json` all use the same `<version>`. |
+| Release workflow | Release workflow completed from a valid `vX.Y.Z` tag whose commit is reachable from `main`. |
+| Updater signing | `updater-signing-preflight` passes with environment-scoped updater signing secrets. |
+| Build gate | `pnpm run verify:release` passes before packaging. |
+| Release assets | GitHub Release contains the Windows setup installer, MSI installer, both `.sig` files, and `latest.json`. |
+| Public updater reachability | Clean unauthenticated requests can fetch `latest.json` and the installer URL referenced by it. |
+| Installed updater flow | A previously installed signed Ambit build can discover, verify, install, relaunch into the RC, and preserve profile data. |
 
-The installed-app updater test is not complete. Before public beta announcement, publish a real release candidate from the current hardening stack to a public, unauthenticated endpoint and verify:
+## Public Endpoint Check
+
+Run this from a shell that is not authenticated to GitHub:
+
+```powershell
+Invoke-WebRequest -Uri https://github.com/AsuraAce/ambit/releases/download/<tag>/latest.json -UseBasicParsing
+Invoke-WebRequest -Uri https://github.com/AsuraAce/ambit/releases/download/<tag>/Ambit_<version>_x64-setup.exe -UseBasicParsing -OutFile $env:TEMP\Ambit_<version>_x64-setup.exe
+```
+
+Confirm:
 
 1. `latest.json` is reachable without GitHub authentication.
 2. The installer URL in `latest.json` is reachable without GitHub authentication.
 3. The signature in `latest.json` verifies with the updater public key embedded in `src-tauri/tauri.conf.json`.
-4. A previously installed signed Ambit build can check for the RC update, show the update prompt, install the update, relaunch, and preserve profile data.
+4. Asset names and URLs match the release tag and version.
 
-Do not treat an authenticated `gh release download` success as updater validation. It only proves the maintainer can see the asset, not that installed public-beta clients can.
+## Installed-App Updater Test
 
-## Manual RC Workflow
+Use this pass before announcing a release candidate as updater-ready:
 
-Use this exact pass before tagging or announcing the beta:
-
-1. Merge the hardening stack into the release branch.
-2. Create a draft or pre-release RC from that release branch.
-3. Attach the Windows NSIS installer, MSI installer, both `.sig` files, and `latest.json`.
-4. Confirm the repository is public, or publish the same assets to another public endpoint configured in the updater.
-5. From a clean unauthenticated shell, run:
-
-   ```powershell
-   Invoke-WebRequest -Uri https://github.com/AsuraAce/ambit/releases/download/<tag>/latest.json -UseBasicParsing
-   Invoke-WebRequest -Uri https://github.com/AsuraAce/ambit/releases/download/<tag>/Ambit_<version>_x64-setup.exe -UseBasicParsing -OutFile $env:TEMP\Ambit_<version>_x64-setup.exe
-   ```
-
-6. Install the previous signed build.
-7. Trigger `Check for Updates` from Settings > Advanced > Interface.
-8. Confirm the update prompt appears, the package installs, the app relaunches, and the existing profile remains available.
-9. Record the RC tag, installed-from version, updated-to version, profile type, and result in `docs/release-test-checklist.md`.
-
+1. Install the previous signed public beta build.
+2. Launch Ambit and confirm the existing profile opens.
+3. Publish or select the RC release whose assets are publicly reachable.
+4. Trigger `Check for Updates` from Settings > Advanced > Interface.
+5. Confirm the update prompt appears.
+6. Install the update through Ambit.
+7. Confirm Ambit relaunches into `<version>`.
+8. Confirm folders, collections, favorites, prompts, thumbnails, and settings remain available.
+9. Record the tag, installed-from version, updated-to version, profile type, and result in `docs/release-test-checklist.md`.

--- a/docs/release-test-checklist.md
+++ b/docs/release-test-checklist.md
@@ -1,7 +1,7 @@
 # Release Test Checklist
 
 Status: Working draft
-Last updated: 2026-05-15
+Last updated: 2026-07-02
 
 Use this checklist for staged release testing of Ambit. It is scoped to the current app shape:
 
@@ -286,12 +286,13 @@ Owner: Shared, leaning user. I can produce and inspect artifacts; you should val
 - [ ] Installed-app updater check can discover, verify, install, and relaunch into the release candidate.
 
 Phase 6 notes:
-- Fresh profile requires clearing both current directories, `AppData\Local\io.github.asuraace.ambit` and `AppData\Roaming\io.github.asuraace.ambit`; settings live under Local, while the main SQLite library lives under Roaming.
-- Identifier migration testing also uses the legacy directories `AppData\Local\com.ambit.app` and `AppData\Roaming\com.ambit.app`. The packaged release build should move legacy data into the current identifier when the current profile has no conflicting `library.json`, `.thumbnails`, or `images.db` data.
+- Fresh profile testing should clear the current Local AppData directory, `%LOCALAPPDATA%\io.github.asuraace.ambit`. During the public-beta transition, also inspect the current Roaming fallback and legacy `com.ambit.app` Local/Roaming directories when migration behavior is part of the test.
+- The main SQLite library database should be created under Local AppData. Roaming AppData is retained only as a legacy fallback for older data that could not be moved automatically.
+- Identifier migration testing also uses the legacy directories `AppData\Local\com.ambit.app` and `AppData\Roaming\com.ambit.app`. The packaged release build should move eligible legacy data into the current identifier when the current profile has no conflicting `library.json`, `.thumbnails`, or active database data.
 - Conflict testing should pre-create current-profile data and confirm legacy `com.ambit.app` data is not overwritten or deleted.
 - Updater validation requires signing setup, public release assets, and installed-app behavior checks before each public beta release.
-- Current GitHub repository visibility is private as of the 2026-05-15 RC validation pass; unauthenticated updater checks will fail until the release assets are published from a public endpoint.
-- Version state as of this pass: package metadata is `0.5.0`; confirm the final release tag, GitHub Release, updater manifest, and installer metadata all match before publishing.
+- Unauthenticated updater checks require release assets to be published from the configured public endpoint.
+- Confirm the final release tag, GitHub Release, updater manifest, installer metadata, and app version all match before publishing.
 
 ## Sign-Off Summary
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,6 +1,6 @@
 # Support
 Status: Active
-Last reviewed: 2026-04-24
+Last reviewed: 2026-07-02
 
 ## Current Offering
 - Ambit is free and open source.
@@ -19,12 +19,11 @@ Use this language consistently in the app, README, and creator pages:
 - Use Ko-fi as the simple one-time tip path outside GitHub.
 - Add Patreon only if you decide to run an actual membership program with recurring benefits, posts, or community access.
 
-## Launch Checklist
-- Replace the Stripe customer support phone number with a dedicated support/business number when available.
-- Review the Ko-fi support email before public release and switch it to a project/creator support address if needed.
-- Keep the in-app copy aligned with the current offer.
+## Maintenance Checklist
+- Keep the in-app, README, and creator-page support copy aligned with the current offer.
 - Keep `.github/FUNDING.yml` synced with the active funding providers.
-- After `AsuraAce/ambit` becomes public, add it under GitHub Sponsors > Profile details > Featured work.
+- Keep public support routes focused on GitHub Issues for bugs and GitHub Releases for packaged builds.
+- If paid support, memberships, or dedicated business contact channels are added later, update this file, the README, and the app copy together.
 
 ## External Page Structure
 ### Support Page


### PR DESCRIPTION
## Summary
- refreshed release-candidate and updater validation docs for public, unauthenticated release assets
- corrected release-test and refactor notes so Local AppData is the active SQLite location and Roaming is legacy fallback only
- replaced launch-prep support notes with stable public support maintenance guidance
- updated the AGENTS.md agent-doc-system stamp to v1.2.0

## Verification
- git diff --check
- searched tracked public/docs files for stale private-readiness wording: v0.5.0, repository is private, before public release, main SQLite library lives under Roaming
- searched tracked public/docs files for private/local paths: C:/Users, C:\Users, D:/AI, Artemis, OneDrive, codex-security-scans