### PR TITLE
chore: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a crash, broken workflow, install/update problem, or other app bug.
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Ambit. Please include enough detail that the issue can be reproduced or investigated.
+
+        If this is a security vulnerability, do not report it here. Use GitHub Security Advisories or follow `SECURITY.md`.
+  - type: input
+    id: ambit-version
+    attributes:
+      label: Ambit version
+      description: Find this in the app footer, settings/about area, installer filename, or GitHub release.
+      placeholder: "v0.6.4"
+    validations:
+      required: true
+  - type: input
+    id: windows-version
+    attributes:
+      label: Windows version
+      placeholder: "Windows 11 23H2"
+    validations:
+      required: true
+  - type: dropdown
+    id: install-update-path
+    attributes:
+      label: Install or update path
+      options:
+        - Fresh install
+        - Updated from a previous Ambit version
+        - Built from source
+        - Portable or manual build
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the visible problem, error, or confusing behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: A numbered list is best. Include folder/import/update details if relevant.
+      placeholder: |
+        1. Open Ambit
+        2. Add or scan folder ...
+        3. Click ...
+        4. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots-logs
+    attributes:
+      label: Screenshots, logs, or diagnostics
+      description: Drag screenshots here, paste relevant logs, or include support diagnostics if they help.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Quick checks
+      options:
+        - label: I checked the latest release and this still happens.
+          required: false
+        - label: This started after an Ambit update.
+          required: false
+        - label: I can provide a sample file or sanitized metadata if needed.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/AsuraAce/ambit/security/advisories/new
+    about: Please report suspected vulnerabilities privately instead of opening a public issue.
+  - name: Security policy
+    url: https://github.com/AsuraAce/ambit/blob/main/SECURITY.md
+    about: Read Ambit's security reporting policy and what to include in a private report.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,53 @@
+name: Feature request
+description: Suggest a workflow improvement or new capability for Ambit.
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Ambit is in public beta, so concrete workflow problems are especially useful.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the workflow friction or missing capability.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like Ambit to do?
+      description: Describe the behavior or UI you imagine.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Large libraries
+        - Search and filtering
+        - Metadata and parsing
+        - Organization and collections
+        - Viewer and slideshow
+        - Import and folder scanning
+        - Settings and diagnostics
+        - Installer or updater
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds
+      description: Tell us what you do today, even if it is messy.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, examples, related tools, or notes about library size can help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/metadata_parser_issue.yml
+++ b/.github/ISSUE_TEMPLATE/metadata_parser_issue.yml
@@ -1,0 +1,73 @@
+name: Metadata or parser issue
+description: Report missing, incorrect, or confusing metadata, model, LoRA, or resource detection.
+title: "[Metadata]: "
+labels: ["metadata", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Metadata depends on what the generating tool stored in the image. A sample image or sanitized metadata is usually the fastest way to fix parser issues.
+
+        Please remove private prompts or paths before sharing if needed.
+  - type: input
+    id: ambit-version
+    attributes:
+      label: Ambit version
+      placeholder: "v0.6.4"
+    validations:
+      required: true
+  - type: dropdown
+    id: generator
+    attributes:
+      label: Generating tool or metadata source
+      options:
+        - InvokeAI
+        - ComfyUI
+        - A1111 / Stable Diffusion WebUI
+        - SD.Next
+        - Fooocus
+        - Midjourney or external image
+        - Unknown
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: image-format
+    attributes:
+      label: Image format
+      options:
+        - PNG
+        - JPEG / JPG
+        - WebP
+        - Other
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What metadata looks wrong or missing?
+      description: Mention prompts, model, LoRAs, checkpoints, embeddings, ControlNet, IP-adapter, seed, dates, workflow, or filters as relevant.
+    validations:
+      required: true
+  - type: textarea
+    id: sample
+    attributes:
+      label: Sample image or sanitized metadata
+      description: Attach a small sample image, paste sanitized metadata, or explain why you cannot share it.
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: What should Ambit show, filter, or parse instead?
+    validations:
+      required: true
+  - type: textarea
+    id: library-context
+    attributes:
+      label: Library context
+      description: Note if this affects many files, only one generator, or a specific folder/tool setup.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,55 @@
+name: Question or help
+description: Ask for help using Ambit during the public beta.
+title: "[Question]: "
+labels: ["question", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome during public beta. Please include enough context to make the answer useful.
+
+        If this is a suspected security issue, do not report it here. Use GitHub Security Advisories or follow `SECURITY.md`.
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do?
+      description: Describe the goal, not just the button or screen.
+    validations:
+      required: true
+  - type: input
+    id: ambit-version
+    attributes:
+      label: Ambit version
+      placeholder: "v0.6.4"
+    validations:
+      required: false
+  - type: dropdown
+    id: related-area
+    attributes:
+      label: Related area
+      options:
+        - Installation or update
+        - Adding folders or importing images
+        - Search and filtering
+        - Metadata or generation data
+        - Collections, favorites, or pins
+        - Viewer or slideshow
+        - Settings or privacy
+        - Other
+    validations:
+      required: false
+  - type: input
+    id: generator
+    attributes:
+      label: Related generator or tool
+      description: Optional, if this is about metadata or generated images.
+      placeholder: "InvokeAI, ComfyUI, A1111, SD.Next, ..."
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, error text, or a short description of your library setup can help.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- add structured GitHub Issue Forms for bugs, metadata/parser issues, feature requests, and questions
- add issue-template contact links for private security reporting
- upsert public-beta triage labels on GitHub

## Verification
- git diff --cached --check
- verified staged scope contains only .github/ISSUE_TEMPLATE files
- verified planned labels exist on GitHub

No app code, workflows, release artifacts, or runtime behavior changed.