### PR TITLE
docs: refresh implementation documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,14 @@ Start here for common tasks:
 - Desktop dev app: `pnpm run app:dev`
 - Frontend build: `pnpm run build`
 - Desktop build: `pnpm run app:build`
+- Lint: `pnpm run lint`
 - TypeScript check: `pnpm run typecheck`
 - Frontend tests: `pnpm run test` for watch mode, `pnpm run test:run` for CI-style one-shot runs
 - Coverage: `pnpm run coverage`
 - Rust tests: `pnpm run test:rust`
 - Release verification gate: `pnpm run verify:release`
 
-No dedicated lint script is defined in `package.json`. Production app builds now run `verify:release` before `tauri build --ci`.
+Production app builds run `verify:release` before `tauri build --ci`.
 
 ## Change Policy
 - No `any`. Keep TypeScript strict.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 Status: Canonical
-Last reviewed: 2026-05-15
+Last reviewed: 2026-07-07
 
 ## System Overview
 Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust backend exposed through Tauri commands. Images and heavy metadata live in SQLite under Local AppData, lightweight app state lives in `library.json` under app-local data, and sensitive secrets such as the Gemini API key live in the OS keyring.
@@ -29,14 +29,14 @@ Risks: parser heuristics and watcher behavior can create wrong metadata or miss 
 Related docs: `docs/WORKFLOW_SETUP.md`
 
 ### Frontend App Shell and Feature Surfaces
-Purpose: render the desktop UI, modals, viewer, filter panel, maintenance screens, and settings flows.
+Purpose: render the desktop UI, modals, viewer, filter panel, grid/timeline/statistics views, maintenance screens, and settings flows.
 Code: `src/index.tsx`, `src/App.tsx`, `src/components/`, `src/features/`
 Interacts with: contexts, stores, hooks, `src/services/`, generated bindings, and Tauri plugins
 Risks: `src/App.tsx` coordinates many cross-feature concerns, so changes can regress areas outside the touched feature
 Related docs: `docs/refactor.md#frontend-state-and-shell-coordination`
 
 ### Query, State, and Persistence Adapters
-Purpose: own frontend query flows, transient UI state, JSON-backed settings and recent-search persistence, and database helper modules.
+Purpose: own frontend query flows, transient UI state, JSON-backed settings and recent-search persistence, thumbnail services, and database helper modules.
 Code: `src/contexts/`, `src/stores/`, `src/hooks/`, `src/services/`
 Interacts with: `src/features/`, `src/bindings.ts`, `src-tauri/src/db/`, app-local `library.json`
 Risks: state ownership is split across React Query, contexts, Zustand, and repository adapters, which makes duplicate sources of truth easy to introduce

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -27,7 +27,7 @@ The core app is local-first. Image records, metadata, thumbnails, and settings a
 - [Browsing The Library](browsing-library.md): use grid, timeline, statistics, selection, favorites, pins, and the viewer.
 - [Search, Filters, And Collections](search-filters-collections.md): search prompts and metadata, use facets, and organize images.
 - [Viewer And Metadata](viewer-and-metadata.md): inspect prompts, resources, workflow data, notes, and image versions.
-- [Maintenance](maintenance.md): resolve missing files, duplicates, removed items, untagged records, intermediates, and thumbnail problems.
+- [Maintenance](maintenance.md): resolve missing files, thumbnail optimization, duplicates, removed items, untagged records, and intermediates.
 - [Settings And Privacy](settings-and-privacy.md): understand folders, privacy controls, AI features, update checks, and network behavior.
 - [Troubleshooting](troubleshooting.md): diagnose common first-run, scan, metadata, thumbnail, and privacy issues.
 

--- a/docs/manual/maintenance.md
+++ b/docs/manual/maintenance.md
@@ -8,21 +8,24 @@ Maintenance helps keep Ambit's catalog aligned with your local files and metadat
 
 Ambit currently exposes these maintenance tabs:
 
+- Missing: find catalog records whose source files are missing.
+- Thumbnails: regenerate unoptimized thumbnails, repair broken thumbnail references, and clean up unused thumbnails.
 - Duplicates: find and resolve duplicate candidates.
 - Untagged: review records with missing or incomplete metadata.
 - Intermediates: review images flagged as intermediates when the tab is visible.
-- Missing: find catalog records whose source files are missing.
 - Removed: restore removed records or permanently delete files when that action is chosen.
 
 ```mermaid
 flowchart TD
     A["Maintenance"] --> B["Duplicates"]
-    A --> C["Untagged"]
-    A --> D["Intermediates"]
-    A --> E["Missing"]
-    A --> F["Removed"]
-    E --> G["Verify library paths"]
-    F --> H["Restore or delete"]
+    A --> C["Thumbnails"]
+    A --> D["Untagged"]
+    A --> E["Intermediates"]
+    A --> F["Missing"]
+    A --> G["Removed"]
+    C --> H["Regenerate or repair"]
+    F --> I["Verify library paths"]
+    G --> J["Restore or delete"]
 ```
 
 ## Duplicates
@@ -30,6 +33,20 @@ flowchart TD
 The Duplicates tab scans for likely duplicate images. Duplicate cleanup is conservative: resolving duplicates removes redundant records from Ambit's library or Removed flow by default rather than deleting original files automatically.
 
 Use Compare when available to inspect candidates before resolving them.
+
+## Thumbnails
+
+The Thumbnails tab finds images that could benefit from thumbnail regeneration. It can work across the whole library or the current filtered view.
+
+Use it to:
+
+- regenerate selected thumbnails
+- regenerate all unoptimized thumbnails in the chosen scope
+- include upgradeable thumbnails when you want higher-quality replacements
+- repair broken thumbnail references
+- clean up unused thumbnail files when the current scope is optimized
+
+Ambit can also heal thumbnails in the background during normal use, so this tab is the manual repair and review surface rather than the only thumbnail path.
 
 ## Missing
 
@@ -51,11 +68,13 @@ Use these tabs to remove, review, or unmark records depending on what the tab of
 
 ## Thumbnail Problems
 
-Ambit performs thumbnail handling in the background. If thumbnails are stale or broken, use Settings, Advanced, Troubleshooting:
+Ambit performs thumbnail handling in the background. If thumbnails are stale or broken, start with Maintenance, Thumbnails:
 
-- Verify Files checks thumbnail paths and resets missing thumbnail references.
-- Reset All clears thumbnail references so Ambit can rediscover or regenerate thumbnails.
-- Verify Library checks source files and thumbnails together.
+- Repair Broken Thumbnails checks thumbnail files on disk and resets missing thumbnail references.
+- Regenerate Selected rebuilds thumbnails for selected records.
+- Regenerate All Unoptimized repairs the chosen scope in batches.
+
+Settings, Advanced, Support includes an Open Maintenance shortcut for these repair tools.
 
 ## Metadata Refresh
 

--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -22,21 +22,26 @@ Open Help, then Search Syntax, for the in-app operator list.
 
 Useful operators include:
 
+- `-term` or `!term` excludes a positive-prompt term.
 - `neg:blur` searches the negative prompt.
 - `file:portrait` searches filename or path.
+- `all:anime` searches path and raw metadata.
 - `model:sdxl` filters by model.
 - `lora:detail` filters by LoRA.
+- `cn:pose` or `controlnet:pose` filters by ControlNet.
+- `ip:adapter` or `ipadapter:adapter` filters by IP-Adapter.
 - `tool:invoke` filters by generator.
 - `sampler:euler` filters by sampler.
 - `steps:>30` filters generation steps.
 - `cfg:<7` filters CFG.
 - `seed:12345` filters seed.
 - `date:2026-04` filters by local calendar month.
+- `date:2026-04..2026-06` filters by an inclusive ISO date range.
 - `after:2026-04` and `before:2025` filter date ranges.
 - `w:>1024` and `h:<768` filter dimensions.
 - `upscaled:true` shows upscaled images.
 
-Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity.
+Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity. Plain terms combine with AND; `OR` only groups adjacent positive-prompt terms.
 
 ## Filter Panel
 

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -39,9 +39,9 @@ Useful checks:
 
 ## Thumbnails Are Broken
 
-Open Settings, Advanced, Troubleshooting.
+Open Maintenance, then Thumbnails.
 
-Use Verify Files first. If thumbnails still fail, use Reset All to clear thumbnail references so Ambit can rediscover or regenerate them. Use Verify Library when you want to check source files and thumbnails together.
+Use Repair Broken Thumbnails first. If thumbnails still fail, regenerate selected thumbnails or run Regenerate All Unoptimized for the current scope. Settings, Advanced, Support also has an Open Maintenance shortcut.
 
 ## Images Show As Missing
 
@@ -82,7 +82,7 @@ Gemini is not required for core Ambit browsing, search, metadata parsing, or mai
 
 ## Online Model Resolution Is Disabled Or Busy
 
-Resolve Online is blocked while library work is already running, such as import, sync, scan, thumbnail regeneration, duplicate scan, or background healing. Wait for the current task to finish, then run resolution again.
+Resolve Online is blocked while library work is already running, such as import, sync, scan, thumbnail optimization, duplicate scan, or background healing. Wait for the current task to finish, then run resolution again.
 
 Online model resolution sends unresolved model hash strings to CivitAI. It does not send image files.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,15 +1,16 @@
 # Progress
 Status: Current
-Last reviewed: 2026-06-04
+Last reviewed: 2026-07-07
 
 ## Current State
-- The repo is currently on package version `0.5.0`; do not infer release publication status from this file alone.
+- The repo is currently on package version `0.6.4`; do not infer release publication status from this file alone.
 - The routed docs package is now baseline repo infrastructure: `AGENTS.md`, `docs/architecture.md`, `docs/WORKFLOW_SETUP.md`, and this file should be maintained rather than re-bootstrapped.
-- Production build hardening is in progress: `app:build` now runs `verify:release` before `tauri build --ci`, and the release gate includes a no-bundle Tauri compatibility build.
+- Production build hardening is part of the normal build path: `app:build` now runs `verify:release` before `tauri build --ci`, and the release gate includes a no-bundle Tauri compatibility build.
 - Frontend bundle cleanup has a build-output guard: `build:guard` fails if ineffective dynamic imports return or the startup entry chunk exceeds the 500 kB warning threshold.
 - The Live Watch incremental facet branch now avoids the old default idle-time full facet rebuild for normal live imports. Live Watch refreshes changed resource facets through the incremental queue, while manual recovery and non-live flows retain the full rebuild fallback.
 - The latest manual InvokeAI run showed the resource incremental path working as intended: browser logs emitted `mode:"resource-incremental"`, Rust resource refresh completed in about `452ms`, and the previously slow `caradhras-mix_style` LoRA refresh was about `106ms` instead of multi-second.
 - Asset drill-down now uses standard disjunctive faceting semantics: selected Match Any values keep sibling alternatives visible by counting that facet against all other active filters, while Match All keeps narrowed co-occurrence counts. Checkpoints remain multi-select but Any-only because each image has one checkpoint/model, and generator tools remain Any-only in the UI.
+- Maintenance currently exposes Missing, Thumbnails, Duplicates, Untagged, conditional Intermediates, and Removed tabs. Thumbnail optimization remains a visible maintenance surface as well as a background healing path.
 
 ## Current Constraints
 - `package.json` defines dev, build, lint, typecheck, one-shot frontend test, coverage, Rust test, Tauri no-bundle check, and release verification scripts.
@@ -23,7 +24,7 @@ Last reviewed: 2026-06-04
 - Duplicate cleanup remains conservative: resolving duplicates removes redundant records from the Ambit library/Removed list flow rather than deleting files by default.
 
 ## Next Work
-- Add browser smoke tests for lazy-loaded app surfaces: settings, dashboard, maintenance, command palette, export, viewer, compare, recovery, slideshow, and collection editor.
+- Add browser smoke tests for lazy-loaded app surfaces: settings, dashboard/statistics, maintenance, command palette, export, viewer, compare, recovery, slideshow, and collection editor.
 - Add coverage thresholds after the public-beta baseline is reviewed.
 - Add a small Tauri desktop launch smoke test later, using a temporary app data/profile directory; keep installer/update testing for release packaging work.
 - Production builds now use the Tauri identifier `io.github.asuraace.ambit`. Release builds run a one-time startup migration from the legacy `com.ambit.app` Roaming and Local AppData directories before SQL initialization, and reset/repair paths still check both identifiers during the public-beta transition.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -1,6 +1,6 @@
 # Refactor Notes
 Status: Deferred
-Last reviewed: 2026-06-04
+Last reviewed: 2026-07-07
 
 ## How to Use This File
 Use this file to record deferred structural cleanup that changes how contributors should edit the repo safely. Keep active workstreams and short-lived blockers in `docs/progress.md`.
@@ -306,28 +306,27 @@ Status: In transition
 Status: Deferred
 
 ### Why Cleanup Is Needed
-- Product rule: there is no current Maintenance thumbnail regeneration tab. Thumbnail regeneration is handled by import/native generation, lazy gallery healing, background Smart Thumbnail Optimization, and explicit settings/model/collection thumbnail tools.
-- The visible Maintenance thumbnails tab was removed; `src/features/maintenance/components/MaintenanceTabs.tsx` documents that background healing now owns thumbnail regeneration.
+- Product rule: thumbnail repair is currently split between visible Maintenance tools and background healing. `MaintenanceTabs.tsx` exposes a `Thumbnails` tab, while import/native generation, lazy gallery healing, and background Smart Thumbnail Optimization can also create or improve thumbnails.
 - `src/hooks/useThumbnailQueue.ts` still starts Smart Thumbnail Optimization automatically after a short startup delay when `enableAutoThumbnailHealing` is enabled.
 - The queue processes thumbnails in small batches and pauses during import or sync, but it begins by running full-library unoptimized-thumbnail count queries. On large production libraries, those count scans can still compete with normal browsing and search.
-- Legacy thumbnail-maintenance UI code such as `ThumbnailsTab` and thumbnail scan paths remains in the tree even though it is no longer reachable from the visible maintenance tabs.
-- This mismatch keeps confusing maintainers and agents because the code shape still suggests a removed feature exists.
+- The visible `ThumbnailsTab` owns manual regeneration, broken-reference repair, developer-only thumbnail DB sync, and orphan thumbnail cleanup. Background healing owns automatic optimization.
+- This split keeps confusing maintainers and agents because thumbnail repair paths span visible UI, background startup work, services, and maintenance state.
 
 ### Current Pain Points
 - Startup can feel responsive overall while background thumbnail work still creates intermittent SQLite load shortly after launch.
 - The initial `getUnoptimizedImagesCount` query answers "how many total?" before doing useful work, which is expensive for large libraries and not always necessary.
-- Dead or latent thumbnail maintenance UI code makes it harder to know which thumbnail repair path is canonical.
+- Multiple active thumbnail repair paths make it harder to know which path is canonical for a given user problem.
 
 ### Safe-Change Warning
 - Thumbnail work touches SQLite, filesystem scope, scanner commands, React Query image caches, and user-facing thumbnails. Avoid mixing this cleanup with unrelated maintenance UI work.
-- Do not remove manual Advanced settings actions for clearing or verifying thumbnails unless a replacement workflow is explicitly designed.
-- Do not reintroduce a Maintenance thumbnail regeneration tab unless the product decision is explicitly reopened.
+- Do not remove visible Maintenance thumbnail actions or Advanced maintenance navigation unless a replacement workflow is explicitly designed.
+- Do not move all thumbnail repair into background healing unless the product decision is explicitly reopened.
 
 ### Suggested Future Direction
 - Make Smart Thumbnail Optimization more incremental: fetch and process small candidate batches first, and avoid full-library count scans on startup.
 - Consider deferring background thumbnail healing until the app is idle for longer, until the user enables it explicitly, or until recent startup/import/sync work has settled.
 - Add an indexed or materialized thumbnail-repair candidate path if full scans remain necessary.
-- Remove or quarantine unreachable thumbnail maintenance UI code in a dedicated cleanup after confirming no hidden route still uses it.
+- Clarify ownership between visible thumbnail maintenance, Advanced maintenance navigation, and background healing in a dedicated cleanup.
 
 ### Not Part of the Current Task
 - Do not change thumbnail behavior while stabilizing prod startup and search migration fixes.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -302,7 +302,7 @@ Status: In transition
 - Do not change the dev identifier.
 - Do not remove legacy `com.ambit.app` or Roaming fallback checks until the public-beta upgrade window is intentionally closed.
 
-## Smart Thumbnail Optimization and Removed Maintenance Tab
+## Smart Thumbnail Optimization and Thumbnail Maintenance Ownership
 Status: Deferred
 
 ### Why Cleanup Is Needed


### PR DESCRIPTION
## Summary
- refresh agent docs for the current lint script, package version, and reviewed architecture/progress state
- align maintenance docs with the visible Thumbnails maintenance tab and background healing split
- document current search operators for exclusion, raw metadata, ControlNet, IP-Adapter, and date ranges

## Verification
- git diff --check
- pnpm run check:versions
- rg stale documentation claims