### PR TITLE
test: cover logging behavior

### DIFF
--- a/src/services/db/__tests__/connection.test.ts
+++ b/src/services/db/__tests__/connection.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const databaseLoadMock = vi.hoisted(() => vi.fn());
 const getMainDatabaseUrlMock = vi.hoisted(() => vi.fn());
@@ -30,6 +30,10 @@ describe('database connection', () => {
         databaseLoadMock.mockResolvedValue(createDatabaseMock());
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it('loads the backend-selected main database URL', async () => {
         const { getDb } = await import('../connection');
 
@@ -48,5 +52,36 @@ describe('database connection', () => {
 
         expect(getMainDatabaseUrlMock).toHaveBeenCalledTimes(1);
         expect(databaseLoadMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs startup database phases so slow local libraries can be diagnosed', async () => {
+        const { getDb } = await import('../connection');
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+        let nowMs = 0;
+        vi.spyOn(performance, 'now').mockImplementation(() => {
+            nowMs += 10;
+            return nowMs;
+        });
+
+        await getDb();
+
+        expect(infoSpy).toHaveBeenCalledWith('[Startup DB] Database.load completed in 10ms');
+        expect(infoSpy).toHaveBeenCalledWith('[Startup DB] Performance PRAGMAs completed in 10ms');
+        expect(infoSpy).toHaveBeenCalledWith('[Startup DB] Frontend covering indexes completed in 10ms');
+        expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('logs database optimization failures without blocking library load', async () => {
+        const dbMock = createDatabaseMock();
+        const optimizationError = new Error('pragma failed');
+        dbMock.execute.mockRejectedValueOnce(optimizationError);
+        databaseLoadMock.mockResolvedValue(dbMock);
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const { getDb } = await import('../connection');
+
+        await expect(getDb()).resolves.toBe(dbMock);
+
+        expect(errorSpy).toHaveBeenCalledWith('[DB] Failed to set PRAGMAs or Indexes', optimizationError);
     });
 });

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+import { createDefaultAppSettings } from '../../constants/defaultSettings';
+import type { LogLevel } from '../../types';
+import { useSettingsStore } from '../../stores/settingsStore';
+import { resetGlobalLoggingForTests, setupGlobalLogging } from '../logger';
+
+const hostConsole = {
+    log: console.log,
+    debug: console.debug,
+    info: console.info,
+    warn: console.warn,
+    error: console.error
+};
+
+type ConsoleMethod = keyof typeof hostConsole;
+type ConsoleSpy = MockInstance<typeof console.log>;
+let consoleSpies: Record<ConsoleMethod, ConsoleSpy>;
+
+const installConsoleSpies = () => {
+    consoleSpies = {
+        log: vi.spyOn(console, 'log').mockImplementation(() => undefined),
+        debug: vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+        info: vi.spyOn(console, 'info').mockImplementation(() => undefined),
+        warn: vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+        error: vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    };
+};
+
+const restoreHostConsole = () => {
+    console.log = hostConsole.log;
+    console.debug = hostConsole.debug;
+    console.info = hostConsole.info;
+    console.warn = hostConsole.warn;
+    console.error = hostConsole.error;
+};
+
+const setLogLevel = (logLevel?: LogLevel) => {
+    useSettingsStore.setState({
+        settings: createDefaultAppSettings({ logLevel })
+    });
+};
+
+describe('setupGlobalLogging', () => {
+    beforeEach(() => {
+        resetGlobalLoggingForTests();
+        restoreHostConsole();
+        installConsoleSpies();
+        setLogLevel('info');
+    });
+
+    afterEach(() => {
+        resetGlobalLoggingForTests();
+        restoreHostConsole();
+        vi.restoreAllMocks();
+    });
+
+    it('keeps info-level operational logs while suppressing debug noise by default', () => {
+        setupGlobalLogging();
+
+        console.debug('[diagnostics] hidden');
+        console.log('[startup] visible');
+        console.info('[startup] visible');
+        console.warn('[startup] warning');
+        console.error('[startup] failure');
+
+        expect(consoleSpies.debug).not.toHaveBeenCalled();
+        expect(consoleSpies.log).toHaveBeenCalledWith('[startup] visible');
+        expect(consoleSpies.info).toHaveBeenCalledWith('[startup] visible');
+        expect(consoleSpies.warn).toHaveBeenCalledWith('[startup] warning');
+        expect(consoleSpies.error).toHaveBeenCalledWith('[startup] failure');
+    });
+
+    it.each([
+        ['debug', ['debug', 'log', 'info', 'warn', 'error']],
+        ['warn', ['warn', 'error']],
+        ['error', ['error']],
+        ['none', []]
+    ] as const)('routes only useful %s-level logs through the original console', (level, expectedMethods) => {
+        setLogLevel(level);
+        setupGlobalLogging();
+
+        console.debug('debug message');
+        console.log('log message');
+        console.info('info message');
+        console.warn('warn message');
+        console.error('error message');
+
+        const methods = ['debug', 'log', 'info', 'warn', 'error'] as const;
+        const expected = new Set<ConsoleMethod>(expectedMethods);
+        methods.forEach((method) => {
+            const assertion = expect(consoleSpies[method]);
+            if (expected.has(method)) {
+                assertion.toHaveBeenCalledTimes(1);
+            } else {
+                assertion.not.toHaveBeenCalled();
+            }
+        });
+    });
+
+    it('responds to log-level changes after setup so support diagnostics can be enabled live', () => {
+        setupGlobalLogging();
+
+        console.debug('[before] hidden');
+        setLogLevel('debug');
+        console.debug('[after] visible');
+
+        expect(consoleSpies.debug).toHaveBeenCalledTimes(1);
+        expect(consoleSpies.debug).toHaveBeenCalledWith('[after] visible');
+    });
+
+    it('falls back to info when persisted settings contain an unknown log level', () => {
+        setLogLevel('verbose' as unknown as LogLevel);
+        setupGlobalLogging();
+
+        console.debug('[diagnostics] hidden');
+        console.info('[startup] visible');
+
+        expect(consoleSpies.debug).not.toHaveBeenCalled();
+        expect(consoleSpies.info).toHaveBeenCalledWith('[startup] visible');
+    });
+
+    it('is idempotent so repeated app layout renders do not wrap console methods again', () => {
+        setupGlobalLogging();
+        setupGlobalLogging();
+
+        console.error('[startup] failure');
+
+        expect(consoleSpies.error).toHaveBeenCalledTimes(1);
+        expect(consoleSpies.error).toHaveBeenCalledWith('[startup] failure');
+    });
+});

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -54,3 +54,14 @@ export const setupGlobalLogging = () => {
         if (getLevelValue() <= LOG_LEVELS.error) originalConsole!.error(...args);
     };
 };
+
+export const resetGlobalLoggingForTests = () => {
+    if (!originalConsole) return;
+
+    console.log = originalConsole.log;
+    console.debug = originalConsole.debug;
+    console.info = originalConsole.info;
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+    originalConsole = null;
+};


### PR DESCRIPTION
## Summary
- add direct coverage for the global frontend logging severity gate
- cover live log-level changes, fallback behavior, and idempotent setup
- add deterministic DB startup logging assertions for normal and optimization-failure paths

## Why
The app already emits important diagnostics through shared console gating and startup DB phase logs, but those paths lacked focused tests. This makes the logging behavior easier to maintain and avoids timing-based flakes in startup log assertions.

## Validation
- `node_modules\.bin\vitest.cmd run src/services/db/__tests__/connection.test.ts`
- `node_modules\.bin\vitest.cmd run src/utils/__tests__/logger.test.ts src/services/db/__tests__/connection.test.ts`
- `corepack pnpm run typecheck`
- `git diff --check`