### PR TITLE
docs: add assets resource discovery guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Avoid broad refactors unless the task explicitly calls for them.
 - `src/services/`: persistence adapters, Tauri-facing services, and DB helper modules.
 - `src-tauri/src/`: Rust backend for Tauri commands, SQLite, metadata parsing, scanning, watcher, and security.
 - `.github/workflows/`: release automation.
-- `docs/`: agent docs and release workflow notes.
+- `docs/`: agent docs, user manual, and release workflow notes.
 
 Start here for common tasks:
 - App shell and cross-feature UI orchestration: `src/App.tsx`, `src/components/`, `src/features/`
@@ -76,6 +76,7 @@ Use this file as the entry point. Do not bulk-read `docs/` unless one of the rou
 - For active work, constraints, and maintainer-review notes, read `docs/progress.md`.
 - For release automation details, read `docs/WORKFLOW_SETUP.md`.
 - For deferred structural cleanup, read `docs/refactor.md` if present.
+- For user-facing manual coverage, start at `docs/manual/index.md`.
 
 ## Completion Checklist
 Before finishing, confirm:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,13 +35,14 @@ Start here for common tasks:
 - Desktop dev app: `pnpm run app:dev`
 - Frontend build: `pnpm run build`
 - Desktop build: `pnpm run app:build`
+- Lint: `pnpm run lint`
 - TypeScript check: `pnpm run typecheck`
 - Frontend tests: `pnpm run test` for watch mode, `pnpm run test:run` for CI-style one-shot runs
 - Coverage: `pnpm run coverage`
 - Rust tests: `pnpm run test:rust`
 - Release verification gate: `pnpm run verify:release`
 
-No dedicated lint script is defined in `package.json`. Production app builds now run `verify:release` before `tauri build --ci`.
+Production app builds run `verify:release` before `tauri build --ci`.
 
 ## Change Policy
 - No `any`. Keep TypeScript strict.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 Status: Canonical
-Last reviewed: 2026-05-15
+Last reviewed: 2026-07-07
 
 ## System Overview
 Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust backend exposed through Tauri commands. Images and heavy metadata live in SQLite under Local AppData, lightweight app state lives in `library.json` under app-local data, and sensitive secrets such as the Gemini API key live in the OS keyring.
@@ -29,14 +29,14 @@ Risks: parser heuristics and watcher behavior can create wrong metadata or miss 
 Related docs: `docs/WORKFLOW_SETUP.md`
 
 ### Frontend App Shell and Feature Surfaces
-Purpose: render the desktop UI, modals, viewer, filter panel, maintenance screens, and settings flows.
+Purpose: render the desktop UI, modals, viewer, filter panel, grid/timeline/statistics views, maintenance screens, and settings flows.
 Code: `src/index.tsx`, `src/App.tsx`, `src/components/`, `src/features/`
 Interacts with: contexts, stores, hooks, `src/services/`, generated bindings, and Tauri plugins
 Risks: `src/App.tsx` coordinates many cross-feature concerns, so changes can regress areas outside the touched feature
 Related docs: `docs/refactor.md#frontend-state-and-shell-coordination`
 
 ### Query, State, and Persistence Adapters
-Purpose: own frontend query flows, transient UI state, JSON-backed settings and recent-search persistence, and database helper modules.
+Purpose: own frontend query flows, transient UI state, JSON-backed settings and recent-search persistence, thumbnail services, and database helper modules.
 Code: `src/contexts/`, `src/stores/`, `src/hooks/`, `src/services/`
 Interacts with: `src/features/`, `src/bindings.ts`, `src-tauri/src/db/`, app-local `library.json`
 Risks: state ownership is split across React Query, contexts, Zustand, and repository adapters, which makes duplicate sources of truth easy to introduce

--- a/docs/manual/adding-folders.md
+++ b/docs/manual/adding-folders.md
@@ -23,7 +23,7 @@ Use integrations when you want Ambit to understand an existing generator workspa
 
 ## Monitored Image Folders
 
-Open Settings, then Connections, then Folders to manage image folders.
+Open Settings > Connections > Folders to manage image folders.
 
 In the Folders section you can:
 
@@ -47,7 +47,9 @@ For SD WebUI style folders, Ambit can auto-detect variants such as A1111, Forge,
 
 ## Resource Folders
 
-Settings, Connections, Folders also includes resource discovery. Use this for model, LoRA, embedding, ControlNet, or IP-Adapter folders. Resource folders help Ambit build a local asset inventory, which can make resource filters more useful.
+Resource folders are managed separately from image folders. Open Settings > Connections > Resources to add model, LoRA, embedding, ControlNet, or IP-Adapter folders. Resource folders build a local asset inventory; they do not import images.
+
+For details, see [Assets And Resource Discovery](assets-resource-discovery.md).
 
 ## During Scans
 

--- a/docs/manual/assets-resource-discovery.md
+++ b/docs/manual/assets-resource-discovery.md
@@ -1,0 +1,77 @@
+# Assets And Resource Discovery
+
+[Back to manual index](index.md)
+
+Ambit's Assets tab combines two related ideas: resources found in imported image metadata, and optional local resource files discovered on disk. This helps you filter images by the assets they used while also keeping a local inventory of models and related files.
+
+## Asset Sources
+
+Ambit can show assets from:
+
+- image metadata: checkpoints, LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter references parsed from imported images and workflows
+- local disk discovery: model and resource files scanned from folders you add in Settings
+
+Image-used assets can filter the library because Ambit has indexed images that reference them. Local-only assets are inventory entries. They can show that a resource exists on disk, but they do not filter images until Ambit has at least one indexed image that matches the asset.
+
+If an asset is both used by images and found on disk, Ambit can merge it into one row with an image count and a local marker.
+
+## Add Resource Folders
+
+Open Settings > Connections > Resources.
+
+Use the Resources page to:
+
+- add a folder that contains local model or resource files
+- scan all configured resource folders with Scan Now
+- remove a resource folder from Ambit's local inventory
+
+Resource discovery is opt-in and path-scoped. Ambit scans only the folders you add. Adding a resource folder does not import images and does not move, delete, or reorganize your model files.
+
+Prefer specific folders when possible, such as:
+
+- `models/checkpoints`
+- `models/Lora` or `models/loras`
+- `models/embeddings` or `models/textual_inversion`
+- `models/hypernetworks`
+- `models/controlnet`
+- `models/ipadapter`
+
+If you add a broad `models` root, Ambit shows a warning because broad roots can contain many supported and unsupported model-like folders. Current discovery recognizes common supported folders and skips known unsupported folders such as VAE, CLIP, text encoder, upscaler, detector, caption, face-restore, and unrecognized custom folders.
+
+## Supported Files And Previews
+
+Resource discovery looks for common model-like files such as `.safetensors`, `.ckpt`, `.pt`, `.bin`, and `.pth` when they are in a supported resource folder.
+
+Ambit also scans sidecar preview images such as `.jpg`, `.png`, and `.webp`. When a resource has a sidecar preview, the Assets tab can use it as the resource thumbnail. Otherwise Ambit can use a dynamic thumbnail from an indexed image that used the asset.
+
+In the Assets tab, right-click a resource row or thumbnail to manage thumbnail behavior when actions are available:
+
+- Use Preview: return to the sidecar preview when one exists
+- Use Dynamic: use an indexed image thumbnail instead of a sidecar or override
+- Mask Thumbnail, Always Show Thumbnail, or Reset Thumbnail Privacy: control privacy handling for that resource thumbnail
+
+## Assets Tab Scopes
+
+Open the Library filter panel, then choose Assets.
+
+The Assets tab has three scopes:
+
+- Used in Library: resources found in imported images
+- Local on Disk: resources discovered from configured resource folders
+- All Assets: both used resources and local disk inventory
+
+The Assets tab shows sections for checkpoints, LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter resources when matching items exist. You can search within a section, sort it, and switch between list and grid views.
+
+For LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter resources, Match Any shows images with at least one selected asset and Match All shows images that contain every selected asset in that category. Checkpoints stay Match Any because each image has one main checkpoint or model.
+
+## Empty Or Confusing Results
+
+If Local on Disk is empty, add a resource folder from Settings > Connections > Resources and run Scan Now.
+
+If a local-only asset appears with no image count, Ambit found the file on disk but has not matched it to any indexed image usage yet. Refresh image metadata or import images that used that asset if you expect it to become filterable.
+
+If a broad model root gives noisy or missing inventory, remove it and add specific resource folders instead. This is usually clearer than scanning an entire generator `models` tree at once.
+
+## Next Step
+
+For filter syntax and collection workflows, continue with [Search, Filters, And Collections](search-filters-collections.md).

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -27,7 +27,7 @@ The core app is local-first. Image records, metadata, thumbnails, and settings a
 - [Browsing The Library](browsing-library.md): use grid, timeline, statistics, selection, favorites, pins, and the viewer.
 - [Search, Filters, And Collections](search-filters-collections.md): search prompts and metadata, use facets, and organize images.
 - [Viewer And Metadata](viewer-and-metadata.md): inspect prompts, resources, workflow data, notes, and image versions.
-- [Maintenance](maintenance.md): resolve missing files, duplicates, removed items, untagged records, intermediates, and thumbnail problems.
+- [Maintenance](maintenance.md): resolve missing files, thumbnail optimization, duplicates, removed items, untagged records, and intermediates.
 - [Settings And Privacy](settings-and-privacy.md): understand folders, privacy controls, AI features, update checks, and network behavior.
 - [Troubleshooting](troubleshooting.md): diagnose common first-run, scan, metadata, thumbnail, and privacy issues.
 

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -26,6 +26,7 @@ The core app is local-first. Image records, metadata, thumbnails, and settings a
 - [Adding Folders](adding-folders.md): add monitored image folders, connect generator outputs, and run one-time imports.
 - [Browsing The Library](browsing-library.md): use grid, timeline, statistics, selection, favorites, pins, and the viewer.
 - [Search, Filters, And Collections](search-filters-collections.md): search prompts and metadata, use facets, and organize images.
+- [Assets And Resource Discovery](assets-resource-discovery.md): understand used assets, local disk inventory, resource folders, and Assets tab scopes.
 - [Viewer And Metadata](viewer-and-metadata.md): inspect prompts, resources, workflow data, notes, and image versions.
 - [Maintenance](maintenance.md): resolve missing files, thumbnail optimization, duplicates, removed items, untagged records, and intermediates.
 - [Settings And Privacy](settings-and-privacy.md): understand folders, privacy controls, AI features, update checks, and network behavior.

--- a/docs/manual/maintenance.md
+++ b/docs/manual/maintenance.md
@@ -8,21 +8,24 @@ Maintenance helps keep Ambit's catalog aligned with your local files and metadat
 
 Ambit currently exposes these maintenance tabs:
 
+- Missing: find catalog records whose source files are missing.
+- Thumbnails: regenerate unoptimized thumbnails, repair broken thumbnail references, and clean up unused thumbnails.
 - Duplicates: find and resolve duplicate candidates.
 - Untagged: review records with missing or incomplete metadata.
 - Intermediates: review images flagged as intermediates when the tab is visible.
-- Missing: find catalog records whose source files are missing.
 - Removed: restore removed records or permanently delete files when that action is chosen.
 
 ```mermaid
 flowchart TD
     A["Maintenance"] --> B["Duplicates"]
-    A --> C["Untagged"]
-    A --> D["Intermediates"]
-    A --> E["Missing"]
-    A --> F["Removed"]
-    E --> G["Verify library paths"]
-    F --> H["Restore or delete"]
+    A --> C["Thumbnails"]
+    A --> D["Untagged"]
+    A --> E["Intermediates"]
+    A --> F["Missing"]
+    A --> G["Removed"]
+    C --> H["Regenerate or repair"]
+    F --> I["Verify library paths"]
+    G --> J["Restore or delete"]
 ```
 
 ## Duplicates
@@ -30,6 +33,20 @@ flowchart TD
 The Duplicates tab scans for likely duplicate images. Duplicate cleanup is conservative: resolving duplicates removes redundant records from Ambit's library or Removed flow by default rather than deleting original files automatically.
 
 Use Compare when available to inspect candidates before resolving them.
+
+## Thumbnails
+
+The Thumbnails tab finds images that could benefit from thumbnail regeneration. It can work across the whole library or the current filtered view.
+
+Use it to:
+
+- regenerate selected thumbnails
+- regenerate all unoptimized thumbnails in the chosen scope
+- include upgradeable thumbnails when you want higher-quality replacements
+- repair broken thumbnail references
+- clean up unused thumbnail files when the current scope is optimized
+
+Ambit can also heal thumbnails in the background during normal use, so this tab is the manual repair and review surface rather than the only thumbnail path.
 
 ## Missing
 
@@ -51,11 +68,13 @@ Use these tabs to remove, review, or unmark records depending on what the tab of
 
 ## Thumbnail Problems
 
-Ambit performs thumbnail handling in the background. If thumbnails are stale or broken, use Settings, Advanced, Troubleshooting:
+Ambit performs thumbnail handling in the background. If thumbnails are stale or broken, start with Maintenance, Thumbnails:
 
-- Verify Files checks thumbnail paths and resets missing thumbnail references.
-- Reset All clears thumbnail references so Ambit can rediscover or regenerate thumbnails.
-- Verify Library checks source files and thumbnails together.
+- Repair Broken Thumbnails checks thumbnail files on disk and resets missing thumbnail references.
+- Regenerate Selected rebuilds thumbnails for selected records.
+- Regenerate All Unoptimized repairs the chosen scope in batches.
+
+Settings, Advanced, Support includes an Open Maintenance shortcut for these repair tools.
 
 ## Metadata Refresh
 

--- a/docs/manual/maintenance.md
+++ b/docs/manual/maintenance.md
@@ -78,7 +78,7 @@ Settings, Advanced, Support includes an Open Maintenance shortcut for these repa
 
 ## Metadata Refresh
 
-From Settings, Connections, Folders, use Refresh All Metadata or a folder-level refresh when metadata filters look stale after external changes.
+From Settings > Connections > Folders, use Refresh All Metadata or a folder-level refresh when metadata filters look stale after external changes.
 
 ## Next Step
 

--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -22,21 +22,26 @@ Open Help, then Search Syntax, for the in-app operator list.
 
 Useful operators include:
 
+- `-term` or `!term` excludes a positive-prompt term.
 - `neg:blur` searches the negative prompt.
 - `file:portrait` searches filename or path.
+- `all:anime` searches path and raw metadata.
 - `model:sdxl` filters by model.
 - `lora:detail` filters by LoRA.
+- `cn:pose` or `controlnet:pose` filters by ControlNet.
+- `ip:adapter` or `ipadapter:adapter` filters by IP-Adapter.
 - `tool:invoke` filters by generator.
 - `sampler:euler` filters by sampler.
 - `steps:>30` filters generation steps.
 - `cfg:<7` filters CFG.
 - `seed:12345` filters seed.
 - `date:2026-04` filters by local calendar month.
+- `date:2026-04..2026-06` filters by an inclusive ISO date range.
 - `after:2026-04` and `before:2025` filter date ranges.
 - `w:>1024` and `h:<768` filter dimensions.
 - `upscaled:true` shows upscaled images.
 
-Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity.
+Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity. Plain terms combine with AND; `OR` only groups adjacent positive-prompt terms.
 
 ## Filter Panel
 

--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -63,7 +63,7 @@ The Assets tab can switch between:
 - Local on Disk: resources discovered from configured resource folders.
 - All Assets: both library-used and locally discovered resources.
 
-If Local on Disk is empty, add resource folders from Settings, Connections, Folders.
+If Local on Disk is empty, add resource folders from Settings > Connections > Resources. For setup details and local-only inventory behavior, see [Assets And Resource Discovery](assets-resource-discovery.md).
 
 ## Collections
 

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -39,9 +39,9 @@ Useful checks:
 
 ## Thumbnails Are Broken
 
-Open Settings, Advanced, Troubleshooting.
+Open Maintenance, then Thumbnails.
 
-Use Verify Files first. If thumbnails still fail, use Reset All to clear thumbnail references so Ambit can rediscover or regenerate them. Use Verify Library when you want to check source files and thumbnails together.
+Use Repair Broken Thumbnails first. If thumbnails still fail, regenerate selected thumbnails or run Regenerate All Unoptimized for the current scope. Settings, Advanced, Support also has an Open Maintenance shortcut.
 
 ## Images Show As Missing
 
@@ -82,7 +82,7 @@ Gemini is not required for core Ambit browsing, search, metadata parsing, or mai
 
 ## Online Model Resolution Is Disabled Or Busy
 
-Resolve Online is blocked while library work is already running, such as import, sync, scan, thumbnail regeneration, duplicate scan, or background healing. Wait for the current task to finish, then run resolution again.
+Resolve Online is blocked while library work is already running, such as import, sync, scan, thumbnail optimization, duplicate scan, or background healing. Wait for the current task to finish, then run resolution again.
 
 Online model resolution sends unresolved model hash strings to CivitAI. It does not send image files.
 

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -9,7 +9,7 @@ This page lists common first-run and library issues. When in doubt, prefer actio
 Confirm that you added image sources:
 
 - use Add Images, then Add Folder for a normal folder
-- use Settings, Connections, Folders for monitored folders
+- use Settings > Connections > Folders for monitored folders
 - use Settings, Connections, ComfyUI for a ComfyUI output folder
 - use Settings, Connections, SD WebUI for A1111, Forge, SD.Next, Anapnoe, or archive folders
 - use Settings, Connections, InvokeAI for an InvokeAI root containing `databases/invokeai.db`
@@ -21,7 +21,7 @@ Large folders can take time to scan. Wait for import activity to finish before a
 Try these steps:
 
 1. Confirm the folder path still exists and is accessible.
-2. Rescan the folder from Settings, Connections, Folders.
+2. Rescan the folder from Settings > Connections > Folders.
 3. Use Refresh All Metadata if the files exist but filters or parsed metadata look stale.
 4. For SD WebUI folders, scan again with the correct installation type selected instead of Auto if detection looked wrong.
 

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,15 +1,16 @@
 # Progress
 Status: Current
-Last reviewed: 2026-06-04
+Last reviewed: 2026-07-07
 
 ## Current State
-- The repo is currently on package version `0.5.0`; do not infer release publication status from this file alone.
+- The repo is currently on package version `0.6.4`; do not infer release publication status from this file alone.
 - The routed docs package is now baseline repo infrastructure: `AGENTS.md`, `docs/architecture.md`, `docs/WORKFLOW_SETUP.md`, and this file should be maintained rather than re-bootstrapped.
-- Production build hardening is in progress: `app:build` now runs `verify:release` before `tauri build --ci`, and the release gate includes a no-bundle Tauri compatibility build.
+- Production build hardening is part of the normal build path: `app:build` now runs `verify:release` before `tauri build --ci`, and the release gate includes a no-bundle Tauri compatibility build.
 - Frontend bundle cleanup has a build-output guard: `build:guard` fails if ineffective dynamic imports return or the startup entry chunk exceeds the 500 kB warning threshold.
 - The Live Watch incremental facet branch now avoids the old default idle-time full facet rebuild for normal live imports. Live Watch refreshes changed resource facets through the incremental queue, while manual recovery and non-live flows retain the full rebuild fallback.
 - The latest manual InvokeAI run showed the resource incremental path working as intended: browser logs emitted `mode:"resource-incremental"`, Rust resource refresh completed in about `452ms`, and the previously slow `caradhras-mix_style` LoRA refresh was about `106ms` instead of multi-second.
 - Asset drill-down now uses standard disjunctive faceting semantics: selected Match Any values keep sibling alternatives visible by counting that facet against all other active filters, while Match All keeps narrowed co-occurrence counts. Checkpoints remain multi-select but Any-only because each image has one checkpoint/model, and generator tools remain Any-only in the UI.
+- Maintenance currently exposes Missing, Thumbnails, Duplicates, Untagged, conditional Intermediates, and Removed tabs. Thumbnail optimization remains a visible maintenance surface as well as a background healing path.
 
 ## Current Constraints
 - `package.json` defines dev, build, lint, typecheck, one-shot frontend test, coverage, Rust test, Tauri no-bundle check, and release verification scripts.
@@ -23,7 +24,7 @@ Last reviewed: 2026-06-04
 - Duplicate cleanup remains conservative: resolving duplicates removes redundant records from the Ambit library/Removed list flow rather than deleting files by default.
 
 ## Next Work
-- Add browser smoke tests for lazy-loaded app surfaces: settings, dashboard, maintenance, command palette, export, viewer, compare, recovery, slideshow, and collection editor.
+- Add browser smoke tests for lazy-loaded app surfaces: settings, dashboard/statistics, maintenance, command palette, export, viewer, compare, recovery, slideshow, and collection editor.
 - Add coverage thresholds after the public-beta baseline is reviewed.
 - Add a small Tauri desktop launch smoke test later, using a temporary app data/profile directory; keep installer/update testing for release packaging work.
 - Production builds now use the Tauri identifier `io.github.asuraace.ambit`. Release builds run a one-time startup migration from the legacy `com.ambit.app` Roaming and Local AppData directories before SQL initialization, and reset/repair paths still check both identifiers during the public-beta transition.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -419,25 +419,25 @@ Status: Deferred
 
 ### Why Cleanup Is Needed
 - Resource folder discovery can recurse through a broad root such as a ComfyUI `models` directory, but current disk-scan classification is heuristic.
-- The scanner recognizes common supported assets from path text: LoRA, embedding, hypernetwork, ControlNet, and IP-Adapter; anything else with a model-like extension currently falls back to checkpoint.
-- This makes standard folders such as `models/loras`, `models/checkpoints`, `models/controlnet`, and `models/ipadapter` mostly usable, but broad roots can misclassify unsupported model folders such as VAE, CLIP/text encoders, upscale models, detectors, or custom extension folders as checkpoints.
+- The scanner recognizes common supported assets from path text: checkpoints, LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter.
+- Known unsupported folders such as VAE, CLIP/text encoders, upscale models, detectors, caption models, face-restore models, and unrecognized custom folders are skipped instead of being treated as checkpoints, but the broad-root workflow is still hard for users to audit.
 
 ### Current Pain Points
 - Adding each supported resource folder separately gives cleaner inventory today, but it is tedious for users with normal ComfyUI or A1111-style directory trees.
-- Adding a full model root is convenient, but noisy misclassification can make the Assets tab look less trustworthy.
-- Unknown or unsupported local model files do not have a neutral inventory bucket, so the fallback checkpoint behavior carries too much meaning.
+- Adding a full model root is convenient, but skipped or unsupported files are not summarized clearly enough for users to understand why they did not appear in the Assets tab.
+- Unknown or unsupported local model files do not have a visible neutral inventory bucket, so Ambit cannot yet distinguish "intentionally ignored" from "not discovered" in the UI.
 - Local disk discovery and image-metadata harvesting meet through `models` and `facet_cache`, with a lightweight query-layer match key for obvious filename or display-name aliases.
 - The lightweight match key is not a durable asset identity. Disk-scanned rows still use a file-path-derived hash, while image-harvested rows can use metadata hashes, parser-cleaned names, or CivitAI-resolved display names.
 
 ### Safe-Change Warning
-- Do not treat every unknown `.safetensors`, `.ckpt`, `.pt`, `.bin`, or `.pth` file under a model root as a checkpoint in a future taxonomy pass.
+- Do not reintroduce behavior that treats every unrecognized `.safetensors`, `.ckpt`, `.pt`, `.bin`, or `.pth` file under a model root as a checkpoint.
 - Filtering semantics must remain tied to image metadata usage. Unused disk-scanned assets can be shown as inventory, but they should not become active image filters until Ambit has at least one matching image usage.
 - Keep resource discovery opt-in and path-scoped; do not add automatic filesystem-wide model scanning.
 
 ### Suggested Future Direction
 - Add taxonomy-aware folder classification for known layouts, especially ComfyUI `models/`, A1111/Forge `models/`, and other common local AI image app structures.
 - Map supported folders explicitly, for example checkpoints, LoRAs, embeddings or textual inversion, hypernetworks, ControlNet, and IP-Adapter.
-- Route unsupported folders such as VAE, CLIP, text encoders, upscale models, detectors, and unknown/custom categories to `ignored` or `other` instead of checkpoint.
+- Keep unsupported folders such as VAE, CLIP, text encoders, upscale models, detectors, and unrecognized custom categories out of checkpoint results; if they need user visibility, route them to `ignored` or `other` instead.
 - Add a resource-folder type override in Settings: `Auto`, explicit supported asset types, `Other`, and `Ignore`.
 - Show a scan preview or summary with counts by inferred type plus warnings for unknown or ignored folders before users trust a broad model-root scan.
 - Store enough scan-source metadata to support stable rescans, stale `disk_scan` cleanup when folders are removed, and future per-folder classification overrides.
@@ -452,7 +452,7 @@ Status: Deferred
 - Do not persist Assets tab scope state unless a separate UX decision asks for it.
 
 ### Acceptance Direction
-- A user can add a normal ComfyUI `models` root and Ambit classifies standard supported resources correctly without polluting checkpoints with unsupported model files.
+- A user can add a normal ComfyUI `models` root and Ambit classifies standard supported resources correctly while keeping unsupported model files out of checkpoint results.
 - A user can override a folder type when auto-detection is wrong.
 - Broad root scans report unknown or ignored files clearly enough that users know why something did or did not appear in the Assets tab.
 - If a checkpoint, LoRA, ControlNet, or IP-Adapter is both used in images and present on disk, it appears once in `Used in Library` with the correct combined image count and a local marker.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -1,6 +1,6 @@
 # Refactor Notes
 Status: Deferred
-Last reviewed: 2026-06-04
+Last reviewed: 2026-07-07
 
 ## How to Use This File
 Use this file to record deferred structural cleanup that changes how contributors should edit the repo safely. Keep active workstreams and short-lived blockers in `docs/progress.md`.
@@ -306,28 +306,27 @@ Status: In transition
 Status: Deferred
 
 ### Why Cleanup Is Needed
-- Product rule: there is no current Maintenance thumbnail regeneration tab. Thumbnail regeneration is handled by import/native generation, lazy gallery healing, background Smart Thumbnail Optimization, and explicit settings/model/collection thumbnail tools.
-- The visible Maintenance thumbnails tab was removed; `src/features/maintenance/components/MaintenanceTabs.tsx` documents that background healing now owns thumbnail regeneration.
+- Product rule: thumbnail repair is currently split between visible Maintenance tools and background healing. `MaintenanceTabs.tsx` exposes a `Thumbnails` tab, while import/native generation, lazy gallery healing, and background Smart Thumbnail Optimization can also create or improve thumbnails.
 - `src/hooks/useThumbnailQueue.ts` still starts Smart Thumbnail Optimization automatically after a short startup delay when `enableAutoThumbnailHealing` is enabled.
 - The queue processes thumbnails in small batches and pauses during import or sync, but it begins by running full-library unoptimized-thumbnail count queries. On large production libraries, those count scans can still compete with normal browsing and search.
-- Legacy thumbnail-maintenance UI code such as `ThumbnailsTab` and thumbnail scan paths remains in the tree even though it is no longer reachable from the visible maintenance tabs.
-- This mismatch keeps confusing maintainers and agents because the code shape still suggests a removed feature exists.
+- The visible `ThumbnailsTab` owns manual regeneration, broken-reference repair, developer-only thumbnail DB sync, and orphan thumbnail cleanup. Background healing owns automatic optimization.
+- This split keeps confusing maintainers and agents because thumbnail repair paths span visible UI, background startup work, services, and maintenance state.
 
 ### Current Pain Points
 - Startup can feel responsive overall while background thumbnail work still creates intermittent SQLite load shortly after launch.
 - The initial `getUnoptimizedImagesCount` query answers "how many total?" before doing useful work, which is expensive for large libraries and not always necessary.
-- Dead or latent thumbnail maintenance UI code makes it harder to know which thumbnail repair path is canonical.
+- Multiple active thumbnail repair paths make it harder to know which path is canonical for a given user problem.
 
 ### Safe-Change Warning
 - Thumbnail work touches SQLite, filesystem scope, scanner commands, React Query image caches, and user-facing thumbnails. Avoid mixing this cleanup with unrelated maintenance UI work.
-- Do not remove manual Advanced settings actions for clearing or verifying thumbnails unless a replacement workflow is explicitly designed.
-- Do not reintroduce a Maintenance thumbnail regeneration tab unless the product decision is explicitly reopened.
+- Do not remove visible Maintenance thumbnail actions or Advanced maintenance navigation unless a replacement workflow is explicitly designed.
+- Do not move all thumbnail repair into background healing unless the product decision is explicitly reopened.
 
 ### Suggested Future Direction
 - Make Smart Thumbnail Optimization more incremental: fetch and process small candidate batches first, and avoid full-library count scans on startup.
 - Consider deferring background thumbnail healing until the app is idle for longer, until the user enables it explicitly, or until recent startup/import/sync work has settled.
 - Add an indexed or materialized thumbnail-repair candidate path if full scans remain necessary.
-- Remove or quarantine unreachable thumbnail maintenance UI code in a dedicated cleanup after confirming no hidden route still uses it.
+- Clarify ownership between visible thumbnail maintenance, Advanced maintenance navigation, and background healing in a dedicated cleanup.
 
 ### Not Part of the Current Task
 - Do not change thumbnail behavior while stabilizing prod startup and search migration fixes.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -302,7 +302,7 @@ Status: In transition
 - Do not change the dev identifier.
 - Do not remove legacy `com.ambit.app` or Roaming fallback checks until the public-beta upgrade window is intentionally closed.
 
-## Smart Thumbnail Optimization and Removed Maintenance Tab
+## Smart Thumbnail Optimization and Thumbnail Maintenance Ownership
 Status: Deferred
 
 ### Why Cleanup Is Needed


### PR DESCRIPTION
## Summary
- add a user manual page for Assets and Resource Discovery
- route manual and agent docs to the new page and correct resource-folder navigation
- refresh the resource discovery refactor note to match current scanner behavior for unsupported folders

## Verification
- `git diff --check`
- `git diff --cached --check`
- `rg -n "Settings, Connections, Folders" docs/manual` returned no matches
- `rg -n "falls back to checkpoint|fall back to checkpoint|fallback checkpoint|model-like extension.*checkpoint|Removed Maintenance Tab" docs` returned no matches

Docs-only change; no frontend or Rust tests were required.