### PR TITLE
fix: prevent startup maintenance flicker

### DIFF
--- a/src/components/StartupMaintenanceGate.tsx
+++ b/src/components/StartupMaintenanceGate.tsx
@@ -7,16 +7,21 @@ interface StartupMaintenanceGateProps {
     children: React.ReactNode;
 }
 
+const MAINTENANCE_REVEAL_DELAY_MS = 700;
+
+const STARTUP_PHASE_LABELS: Record<StartupDbPhase, string> = {
+    'Preparing library database': 'Preparing library database',
+    'Updating database schema': 'Preparing database',
+    'Optimizing database': 'Optimizing database',
+    'Loading library': 'Loading library'
+};
+
 const STARTUP_PHASE_COPY: Record<StartupDbPhase, string> = {
     'Preparing library database': 'Checking the local library database before Ambit opens.',
-    'Updating database schema': 'Updating library database. Startup may take longer than usual this time.',
+    'Updating database schema': 'Preparing the local database. Startup may take longer than usual this time.',
     'Optimizing database': 'Optimizing the local database for large libraries.',
     'Loading library': 'Loading your library.'
 };
-
-const nextFrame = () => new Promise<void>((resolve) => {
-    window.requestAnimationFrame(() => resolve());
-});
 
 const dismissStaticLoader = () => {
     const loader = document.getElementById('static-loading');
@@ -33,28 +38,39 @@ const dismissStaticLoader = () => {
 export const StartupMaintenanceGate: React.FC<StartupMaintenanceGateProps> = ({ children }) => {
     const [phase, setPhase] = React.useState<StartupDbPhase>('Preparing library database');
     const [isReady, setIsReady] = React.useState(isBrowserMockMode());
+    const [isMaintenanceVisible, setIsMaintenanceVisible] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
 
     React.useEffect(() => {
         if (isReady) return;
 
         let isMounted = true;
+        const revealTimerId = window.setTimeout(() => {
+            if (!isMounted) return;
+
+            dismissStaticLoader();
+            setIsMaintenanceVisible(true);
+        }, MAINTENANCE_REVEAL_DELAY_MS);
 
         const prepareDatabase = async () => {
             try {
                 setPhase('Preparing library database');
-                dismissStaticLoader();
-                await nextFrame();
                 await getDb({
                     onPhase: (nextPhase) => {
                         if (isMounted) setPhase(nextPhase);
                     }
                 });
-                if (isMounted) setIsReady(true);
+                if (isMounted) {
+                    window.clearTimeout(revealTimerId);
+                    setIsReady(true);
+                }
             } catch (err) {
                 console.error('[Startup] Failed to prepare database', err);
                 if (isMounted) {
+                    window.clearTimeout(revealTimerId);
+                    dismissStaticLoader();
                     setError(err instanceof Error ? err.message : String(err));
+                    setIsMaintenanceVisible(true);
                 }
             }
         };
@@ -63,11 +79,16 @@ export const StartupMaintenanceGate: React.FC<StartupMaintenanceGateProps> = ({ 
 
         return () => {
             isMounted = false;
+            window.clearTimeout(revealTimerId);
         };
     }, [isReady]);
 
     if (isReady) {
         return <>{children}</>;
+    }
+
+    if (!isMaintenanceVisible) {
+        return null;
     }
 
     return (
@@ -82,7 +103,7 @@ export const StartupMaintenanceGate: React.FC<StartupMaintenanceGateProps> = ({ 
                             Startup Maintenance
                         </p>
                         <h1 className="mt-1 text-xl font-black tracking-tight">
-                            {error ? 'Database startup failed' : phase}
+                            {error ? 'Database startup failed' : STARTUP_PHASE_LABELS[phase]}
                         </h1>
                     </div>
                 </div>

--- a/src/components/__tests__/StartupMaintenanceGate.test.tsx
+++ b/src/components/__tests__/StartupMaintenanceGate.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor } from '../../test/testUtils';
+import { act, render, screen } from '../../test/testUtils';
 import { StartupMaintenanceGate } from '../StartupMaintenanceGate';
 import { getDb } from '../../services/db/connection';
 import { isBrowserMockMode } from '../../services/runtime';
@@ -13,23 +13,73 @@ vi.mock('../../services/runtime', () => ({
     isBrowserMockMode: vi.fn()
 }));
 
-const requestAnimationFrameMock = (callback: FrameRequestCallback) => {
-    callback(0);
-    return 1;
+const addStaticLoader = () => {
+    const staticLoader = document.createElement('div');
+    staticLoader.id = 'static-loading';
+    document.body.appendChild(staticLoader);
+    return staticLoader;
+};
+
+const flushAsyncWork = async () => {
+    await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+    });
 };
 
 describe('StartupMaintenanceGate', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.useFakeTimers();
         vi.mocked(isBrowserMockMode).mockReturnValue(false);
-        vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
     });
 
     afterEach(() => {
         document.getElementById('static-loading')?.remove();
+        vi.clearAllTimers();
+        vi.useRealTimers();
     });
 
-    it('shows database maintenance before mounting the app', async () => {
+    it('keeps fast database startup behind the static loader without flashing maintenance', async () => {
+        const staticLoader = addStaticLoader();
+        vi.mocked(getDb).mockResolvedValue({} as Awaited<ReturnType<typeof getDb>>);
+
+        render(
+            <StartupMaintenanceGate>
+                <div>Library ready</div>
+            </StartupMaintenanceGate>
+        );
+
+        await flushAsyncWork();
+
+        expect(screen.getByText('Library ready')).toBeTruthy();
+        expect(screen.queryByText('Startup Maintenance')).toBeNull();
+        expect(staticLoader.style.opacity).toBe('');
+        expect(staticLoader.style.pointerEvents).toBe('');
+    });
+
+    it('keeps pending database startup on the static loader before the reveal delay', async () => {
+        const staticLoader = addStaticLoader();
+        vi.mocked(getDb).mockImplementation(() => new Promise(() => undefined));
+
+        render(
+            <StartupMaintenanceGate>
+                <div>Library ready</div>
+            </StartupMaintenanceGate>
+        );
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(699);
+        });
+
+        expect(screen.queryByText('Startup Maintenance')).toBeNull();
+        expect(screen.queryByText('Library ready')).toBeNull();
+        expect(staticLoader.style.opacity).toBe('');
+        expect(staticLoader.style.pointerEvents).toBe('');
+    });
+
+    it('reveals database maintenance for slow startup and keeps tracking phase updates', async () => {
+        const staticLoader = addStaticLoader();
         let resolveDb!: () => void;
         vi.mocked(getDb).mockImplementation(({ onPhase } = {}) => new Promise((resolve) => {
             onPhase?.('Updating database schema');
@@ -42,27 +92,30 @@ describe('StartupMaintenanceGate', () => {
             </StartupMaintenanceGate>
         );
 
-        expect(screen.getByText('Startup Maintenance')).toBeTruthy();
-        expect(screen.getByText('Preparing library database')).toBeTruthy();
+        expect(screen.queryByText('Startup Maintenance')).toBeNull();
         expect(screen.queryByText('Library ready')).toBeNull();
 
-        await waitFor(() => {
-            expect(screen.getByText('Updating database schema')).toBeTruthy();
-            expect(screen.getByText('Updating library database. Startup may take longer than usual this time.')).toBeTruthy();
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(700);
         });
 
-        resolveDb();
+        expect(staticLoader.style.opacity).toBe('0');
+        expect(staticLoader.style.pointerEvents).toBe('none');
+        expect(screen.getByText('Startup Maintenance')).toBeTruthy();
+        expect(screen.getByText('Preparing database')).toBeTruthy();
+        expect(screen.getByText('Preparing the local database. Startup may take longer than usual this time.')).toBeTruthy();
 
-        await waitFor(() => {
-            expect(screen.getByText('Library ready')).toBeTruthy();
+        await act(async () => {
+            resolveDb();
+            await Promise.resolve();
         });
+
+        expect(screen.getByText('Library ready')).toBeTruthy();
     });
 
-    it('dismisses the static preloader so startup maintenance is visible', async () => {
-        const staticLoader = document.createElement('div');
-        staticLoader.id = 'static-loading';
-        document.body.appendChild(staticLoader);
-        vi.mocked(getDb).mockImplementation(() => new Promise(() => undefined));
+    it('shows an actionable error immediately when database preparation fails', async () => {
+        const staticLoader = addStaticLoader();
+        vi.mocked(getDb).mockRejectedValue(new Error('migration failed'));
 
         render(
             <StartupMaintenanceGate>
@@ -70,11 +123,15 @@ describe('StartupMaintenanceGate', () => {
             </StartupMaintenanceGate>
         );
 
-        await waitFor(() => {
-            expect(staticLoader.style.opacity).toBe('0');
-            expect(staticLoader.style.pointerEvents).toBe('none');
-        });
+        await flushAsyncWork();
+
+        expect(staticLoader.style.opacity).toBe('0');
+        expect(staticLoader.style.pointerEvents).toBe('none');
         expect(screen.getByText('Startup Maintenance')).toBeTruthy();
+        expect(screen.getByText('Database startup failed')).toBeTruthy();
+        expect(screen.getByText('Ambit could not prepare the local library database. Restart the app and contact support if this repeats.')).toBeTruthy();
+        expect(screen.getByText('migration failed')).toBeTruthy();
+        expect(screen.queryByText('Library ready')).toBeNull();
     });
 
     it('skips database preparation in browser mock mode', () => {
@@ -87,23 +144,7 @@ describe('StartupMaintenanceGate', () => {
         );
 
         expect(screen.getByText('Browser mock app')).toBeTruthy();
+        expect(screen.queryByText('Startup Maintenance')).toBeNull();
         expect(vi.mocked(getDb)).not.toHaveBeenCalled();
-    });
-
-    it('shows an actionable error when database preparation fails', async () => {
-        vi.mocked(getDb).mockRejectedValue(new Error('migration failed'));
-
-        render(
-            <StartupMaintenanceGate>
-                <div>Library ready</div>
-            </StartupMaintenanceGate>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByText('Database startup failed')).toBeTruthy();
-            expect(screen.getByText('Ambit could not prepare the local library database. Restart the app and contact support if this repeats.')).toBeTruthy();
-            expect(screen.getByText('migration failed')).toBeTruthy();
-        });
-        expect(screen.queryByText('Library ready')).toBeNull();
     });
 });


### PR DESCRIPTION
## Summary
- Keep the branded static loader visible during fast database startup so the maintenance card does not flash on app start or F5 refresh.
- Reveal Startup Maintenance only after a 700ms delay or immediately on database startup failure.
- Soften first-load database copy from schema-update language to a more general preparation message.

## Validation
- `node_modules\.bin\vitest.cmd run src/components/__tests__/StartupMaintenanceGate.test.tsx src/hooks/__tests__/useAppUpdater.test.tsx`
- `corepack pnpm run typecheck`
- `git diff --cached --check`