### PR TITLE
fix: improve runtime logging diagnostics

### DIFF
--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -62,7 +62,7 @@ pub fn start_native_folder_watcher(
         let mut watcher_guard = state.watcher.lock().map_err(|e| e.to_string())?;
         if watcher_guard.is_some() {
             *watcher_guard = None;
-            println!("[Rust Watcher] Stopped watcher");
+            log::info!("[Rust Watcher] Stopped watcher");
         }
         return Ok(());
     }
@@ -71,7 +71,7 @@ pub fn start_native_folder_watcher(
 
     if watcher_guard.is_some() {
         *watcher_guard = None;
-        println!("[Rust Watcher] Restarting watcher with new paths...");
+        log::info!("[Rust Watcher] Restarting watcher with new paths...");
     }
 
     let app_handle = app.clone();
@@ -102,7 +102,7 @@ pub fn start_native_folder_watcher(
                             .map(|started_at| started_at.elapsed().as_millis())
                             .unwrap_or(0);
                         let to_emit: Vec<String> = buffer.drain().collect();
-                        println!(
+                        log::info!(
                             "[LiveWatchPerf] watcher batch emitted | reason=throttle | paths={} | age_ms={} | types={}",
                             to_emit.len(),
                             batch_age_ms,
@@ -120,7 +120,7 @@ pub fn start_native_folder_watcher(
                             .map(|started_at| started_at.elapsed().as_millis())
                             .unwrap_or(0);
                         let to_emit: Vec<String> = buffer.drain().collect();
-                        println!(
+                        log::info!(
                             "[LiveWatchPerf] watcher batch emitted | reason=timeout | paths={} | age_ms={} | types={}",
                             to_emit.len(),
                             batch_age_ms,
@@ -195,7 +195,7 @@ pub fn start_native_folder_watcher(
                         .collect();
 
                     if !valid_paths.is_empty() {
-                        println!(
+                        log::info!(
                             "[LiveWatchPerf] watcher event received | kind={} | raw_paths={} | matched_paths={} | types={}",
                             event_kind,
                             raw_path_count,
@@ -206,7 +206,7 @@ pub fn start_native_folder_watcher(
                     }
                 }
             }
-            Err(e) => println!("watch error: {:?}", e),
+            Err(e) => log::error!("[Rust Watcher] watch error: {:?}", e),
         }
     };
 
@@ -219,13 +219,13 @@ pub fn start_native_folder_watcher(
         if path_buf.exists() {
             if let Err(e) = watcher.watch(&path_buf, RecursiveMode::Recursive) {
                 let err_msg = format!("Failed to watch path {}: {}", path_str, e);
-                println!("[Rust Watcher] {}", err_msg);
+                log::error!("[Rust Watcher] {}", err_msg);
                 errors.push(err_msg);
             } else {
-                println!("[Rust Watcher] Added path: {}", path_str);
+                log::info!("[Rust Watcher] Added path: {}", path_str);
             }
         } else {
-            println!("[Rust Watcher] Skipping non-existent path: {}", path_str);
+            log::warn!("[Rust Watcher] Skipping non-existent path: {}", path_str);
         }
     }
 

--- a/src/components/__tests__/StartupMaintenanceGate.test.tsx
+++ b/src/components/__tests__/StartupMaintenanceGate.test.tsx
@@ -91,7 +91,9 @@ describe('StartupMaintenanceGate', () => {
     });
 
     it('shows an actionable error when database preparation fails', async () => {
-        vi.mocked(getDb).mockRejectedValue(new Error('migration failed'));
+        const startupError = new Error('migration failed');
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        vi.mocked(getDb).mockRejectedValue(startupError);
 
         render(
             <StartupMaintenanceGate>
@@ -105,5 +107,7 @@ describe('StartupMaintenanceGate', () => {
             expect(screen.getByText('migration failed')).toBeTruthy();
         });
         expect(screen.queryByText('Library ready')).toBeNull();
+        expect(errorSpy).toHaveBeenCalledWith('[Startup] Failed to prepare database', startupError);
+        errorSpy.mockRestore();
     });
 });

--- a/src/hooks/__tests__/useImportOps.test.ts
+++ b/src/hooks/__tests__/useImportOps.test.ts
@@ -230,6 +230,47 @@ describe('useImportOps', () => {
         );
     });
 
+    it('logs and skips startup path imports when there are no paths to process', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportPaths([], undefined, { mode: 'startup' });
+        });
+
+        expect(infoSpy).toHaveBeenCalledWith('[ImportOps] Startup path import skipped because no paths were provided.');
+        expect(mocks.getThumbnailDir).not.toHaveBeenCalled();
+        expect(mocks.processNativePaths).not.toHaveBeenCalled();
+        expect(useLibraryStore.getState().importRunId).toBeNull();
+        infoSpy.mockRestore();
+    });
+
+    it('logs and skips path imports when another import run is active', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const activeRunId = useLibraryStore.getState().beginImportRun({
+            owner: 'other-import',
+            abortController: new AbortController(),
+            progress: { current: 1, total: 2, message: 'Existing import' }
+        });
+        const { result } = renderImportOps();
+
+        await act(async () => {
+            await result.current.handleImportPaths(['C:/watch/new.png']);
+        });
+
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[ImportOps] Path import skipped because another import is active.',
+            {
+                mode: 'manual',
+                pathCount: 1
+            }
+        );
+        expect(activeRunId).toBeTruthy();
+        expect(mocks.processNativePaths).not.toHaveBeenCalled();
+        expect(mocks.addToast).toHaveBeenCalledWith('Import already in progress', 'info');
+        infoSpy.mockRestore();
+    });
+
     it('finalizes committed work before returning a cancelled partial folder result', async () => {
         const partialCancel = importResult({
             images: [importedImage('C:/watch-a/imported.png')],
@@ -366,6 +407,7 @@ describe('useImportOps', () => {
     });
 
     it('does not start a manual folder import while another import run is active', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
         const activeRunId = useLibraryStore.getState().beginImportRun({
             owner: 'other-import',
             abortController: new AbortController(),
@@ -380,8 +422,16 @@ describe('useImportOps', () => {
         expect(activeRunId).toBeTruthy();
         expect(mocks.processFoldersUnified).not.toHaveBeenCalled();
         expect(mocks.addToast).toHaveBeenCalledWith('Import already in progress', 'info');
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[ImportFolders] Folder import skipped because another import is active.',
+            {
+                mode: 'manual',
+                folderCount: 1
+            }
+        );
         expect(useLibraryStore.getState().importRunId).toBe(activeRunId);
         expect(useLibraryStore.getState().importProgress?.message).toBe('Existing import');
+        infoSpy.mockRestore();
     });
 
     it('uses stable Activity Dock messages for single-folder folder imports', async () => {

--- a/src/hooks/__tests__/useThumbnailQueue.test.ts
+++ b/src/hooks/__tests__/useThumbnailQueue.test.ts
@@ -197,4 +197,19 @@ describe('useThumbnailQueue behavioral contract', () => {
         expect(content).toContain('Restarting backend job for Smart Thumbnail settings change');
         expect(content).toContain("queryKey: ['images']");
     });
+
+    it('should keep support logs for thumbnail job lifecycle and recovery branches', async () => {
+        const fs = await import('fs/promises');
+        const path = await import('path');
+        const hookPath = path.join(__dirname, '..', 'useThumbnailQueue.ts');
+        const content = await fs.readFile(hookPath, 'utf-8');
+
+        expect(content).toContain('[ThumbnailQueue] Starting backend thumbnail optimization');
+        expect(content).toContain('[ThumbnailQueue] Pausing backend job for blocking activity');
+        expect(content).toContain('[ThumbnailQueue] Resuming after blocking activity...');
+        expect(content).toContain('[ThumbnailQueue] Failed to cancel backend job');
+        expect(content).toContain('[ThumbnailQueue] Backend thumbnail optimization failed');
+        expect(content).toContain('[ThumbnailQueue] Thumbnail facet cache refresh failed');
+        expect(content).toContain('[ThumbnailQueue] Failed to update backend throttle state');
+    });
 });

--- a/src/hooks/useImportOps.ts
+++ b/src/hooks/useImportOps.ts
@@ -194,7 +194,10 @@ export const useImportOps = ({
         const isManual = mode === 'manual';
         const shouldWaitForStableFiles = waitForStableFiles ?? isStartup;
 
-        if (paths.length === 0 && isStartup) return;
+        if (paths.length === 0 && isStartup) {
+            console.info('[ImportOps] Startup path import skipped because no paths were provided.');
+            return;
+        }
 
         const localAbortCtrl = externalAbortSignal ? null : new AbortController();
         const abortSignal = externalAbortSignal ?? localAbortCtrl?.signal;
@@ -205,6 +208,10 @@ export const useImportOps = ({
                 abortController: localAbortCtrl
             });
         if (!skipStateManagement && !importRunId) {
+            console.info('[ImportOps] Path import skipped because another import is active.', {
+                mode,
+                pathCount: paths.length
+            });
             if (isManual) addToast('Import already in progress', 'info');
             return;
         }
@@ -267,6 +274,10 @@ export const useImportOps = ({
             progress: initialProgress
         });
         if (!importRunId) {
+            console.info('[ImportFolders] Folder import skipped because another import is active.', {
+                mode,
+                folderCount: folders.length
+            });
             if (isManual) addToast('Import already in progress', 'info');
             return;
         }

--- a/src/services/WatcherService.ts
+++ b/src/services/WatcherService.ts
@@ -17,7 +17,9 @@ export class WatcherService {
 
     async startWatching(paths: string[], onChangeEvent: WatcherCallback) {
         if (isBrowserMockMode()) {
-            console.info('[WatcherService] Native watcher unavailable in browser mock mode.');
+            console.info('[WatcherService] Native watcher unavailable in browser mock mode; skipped start.', {
+                pathCount: paths.length
+            });
             return;
         }
 
@@ -25,11 +27,19 @@ export class WatcherService {
         const pathsChanged = paths.length !== this.lastPaths.length ||
             paths.some((p, i) => p !== this.lastPaths[i]);
 
-        if (this.isWatching && !pathsChanged) return;
+        if (this.isWatching && !pathsChanged) {
+            console.debug('[WatcherService] Native watcher already active for requested paths; skipped restart.', {
+                pathCount: paths.length
+            });
+            return;
+        }
 
         if (this.isWatching) await this.stopWatching();
 
-        if (paths.length === 0) return;
+        if (paths.length === 0) {
+            console.info('[WatcherService] Native watcher start skipped because no paths were configured.');
+            return;
+        }
 
         const startGeneration = ++this.generation;
 
@@ -37,6 +47,9 @@ export class WatcherService {
             // Start the native rust watcher which handles multiple paths
             await unwrap(commands.startNativeFolderWatcher(paths));
             if (startGeneration !== this.generation) {
+                console.info('[WatcherService] Native watcher start superseded before listener registration.', {
+                    pathCount: paths.length
+                });
                 await unwrap(commands.startNativeFolderWatcher([]));
                 return;
             }
@@ -65,6 +78,9 @@ export class WatcherService {
 
             const listenerReady = await listener.ready;
             if (startGeneration !== this.generation) {
+                console.info('[WatcherService] Native watcher start superseded after listener registration.', {
+                    pathCount: paths.length
+                });
                 listener.cleanup();
                 return;
             }
@@ -74,7 +90,9 @@ export class WatcherService {
             }
 
         } catch (err) {
-            console.error(`[WatcherService] Failed to start native watcher:`, err);
+            console.error('[WatcherService] Failed to start native watcher:', {
+                pathCount: paths.length
+            }, err);
             this.diagnostic?.finish('failed', { error: err instanceof Error ? err.message : String(err) });
             this.diagnostic = null;
             this.isWatching = false;
@@ -111,7 +129,7 @@ export class WatcherService {
             await unwrap(commands.startNativeFolderWatcher([]));
             console.log('[WatcherService] Stopped native watcher');
         } catch (e) {
-            console.error('Error stopping native watcher:', e);
+            console.error('[WatcherService] Failed to stop native watcher:', e);
         }
     }
 

--- a/src/services/__tests__/WatcherService.test.ts
+++ b/src/services/__tests__/WatcherService.test.ts
@@ -1,12 +1,20 @@
 import { listen } from '@tauri-apps/api/event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { commands } from '../../bindings';
 import { WatcherService } from '../WatcherService';
+
+const runtimeMocks = vi.hoisted(() => ({
+    isBrowserMockMode: vi.fn(() => false)
+}));
 
 vi.mock('../../bindings', () => ({
     commands: {
         startNativeFolderWatcher: vi.fn()
     }
+}));
+
+vi.mock('../runtime', () => ({
+    isBrowserMockMode: runtimeMocks.isBrowserMockMode
 }));
 
 const mockedStartNativeFolderWatcher = vi.mocked(commands.startNativeFolderWatcher);
@@ -15,7 +23,103 @@ const mockedListen = vi.mocked(listen);
 describe('WatcherService', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        runtimeMocks.isBrowserMockMode.mockReturnValue(false);
         mockedListen.mockResolvedValue(() => undefined);
+        mockedStartNativeFolderWatcher.mockResolvedValue({ status: 'ok', data: null });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('logs and skips native watcher startup in browser mock mode', async () => {
+        runtimeMocks.isBrowserMockMode.mockReturnValue(true);
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const service = new WatcherService();
+
+        await service.startWatching(['C:/watch-a', 'C:/watch-b'], vi.fn());
+
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[WatcherService] Native watcher unavailable in browser mock mode; skipped start.',
+            { pathCount: 2 }
+        );
+        expect(mockedStartNativeFolderWatcher).not.toHaveBeenCalled();
+        expect(mockedListen).not.toHaveBeenCalled();
+    });
+
+    it('logs and skips empty watcher path lists before native startup', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
+        const service = new WatcherService();
+
+        await service.startWatching([], vi.fn());
+
+        expect(infoSpy).toHaveBeenCalledWith('[WatcherService] Native watcher start skipped because no paths were configured.');
+        expect(mockedStartNativeFolderWatcher).not.toHaveBeenCalled();
+        expect(mockedListen).not.toHaveBeenCalled();
+    });
+
+    it('logs successful native starts and debounced change events with path counts', async () => {
+        type FolderChangeEvent = { payload: string[] };
+        let changeHandler: ((event: FolderChangeEvent) => void) | undefined;
+        const onChange = vi.fn();
+        const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+        mockedListen.mockImplementationOnce((_eventName, handler) => {
+            changeHandler = handler as (event: FolderChangeEvent) => void;
+            return Promise.resolve(() => undefined);
+        });
+
+        const service = new WatcherService();
+        await service.startWatching(['C:/watch'], onChange);
+        changeHandler?.({ payload: ['C:/watch/a.png', 'C:/watch/b.png'] });
+
+        expect(logSpy).toHaveBeenCalledWith('[WatcherService] Native watcher started for 1 paths');
+        expect(logSpy).toHaveBeenCalledWith('[WatcherService] Folder change detected with 2 paths');
+        expect(onChange).toHaveBeenCalledWith(['C:/watch/a.png', 'C:/watch/b.png']);
+    });
+
+    it('logs and skips a duplicate watcher request without restarting native state', async () => {
+        const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+        const service = new WatcherService();
+
+        await service.startWatching(['C:/watch'], vi.fn());
+        await service.startWatching(['C:/watch'], vi.fn());
+
+        expect(debugSpy).toHaveBeenCalledWith(
+            '[WatcherService] Native watcher already active for requested paths; skipped restart.',
+            { pathCount: 1 }
+        );
+        expect(mockedStartNativeFolderWatcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs start failures with path count context', async () => {
+        const startupError = new Error('permission denied');
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockedStartNativeFolderWatcher.mockRejectedValueOnce(startupError);
+        const service = new WatcherService();
+
+        await service.startWatching(['C:/watch-a', 'C:/watch-b'], vi.fn());
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[WatcherService] Failed to start native watcher:',
+            {
+                pathCount: 2
+            },
+            startupError
+        );
+        expect(mockedListen).not.toHaveBeenCalled();
+    });
+
+    it('logs stop failures after clearing frontend watcher state', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        mockedStartNativeFolderWatcher
+            .mockResolvedValueOnce({ status: 'ok', data: null })
+            .mockResolvedValueOnce({ status: 'error', error: 'stop failed' });
+        const service = new WatcherService();
+
+        await service.startWatching(['C:/watch'], vi.fn());
+        await service.stopWatching();
+
+        expect(errorSpy).toHaveBeenCalledWith('[WatcherService] Failed to stop native watcher:', 'stop failed');
     });
 
     it('invalidates a pending native watcher start when stop is requested before startup settles', async () => {

--- a/src/services/__tests__/importService.test.ts
+++ b/src/services/__tests__/importService.test.ts
@@ -152,6 +152,7 @@ describe('processTargetedFiles', () => {
     });
 
     it('can defer folder-import facet cleanup for startup coordination', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
         mocks.getExistingMetadata.mockResolvedValue(new Map());
         mocks.scanImagesBulk.mockResolvedValueOnce([
             {
@@ -198,9 +199,19 @@ describe('processTargetedFiles', () => {
             tools: ['ComfyUI']
         });
         expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[ImportUnified] Deferred facet cache refresh to startup catch-up coordinator.',
+            {
+                processed: 1,
+                imported: 1,
+                touchedFacetTypes: ['checkpoints', 'loras', 'tools']
+            }
+        );
+        infoSpy.mockRestore();
     });
 
     it('returns a cancelled result and skips work when aborted before discovery', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
         const abortCtrl = new AbortController();
         abortCtrl.abort();
 
@@ -219,6 +230,15 @@ describe('processTargetedFiles', () => {
         expect(mocks.scanImagesBulk).not.toHaveBeenCalled();
         expect(mocks.insertImagesBatch).not.toHaveBeenCalled();
         expect(mocks.rebuildFacetCache).not.toHaveBeenCalled();
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[ImportUnified] Import cancelled before processing.',
+            {
+                sourceCount: 1,
+                completedSourceCount: 0,
+                cancelledSourceCount: 1
+            }
+        );
+        infoSpy.mockRestore();
     });
 
     it('returns a cancelled result and skips facet cleanup when aborted after metadata scan', async () => {
@@ -311,6 +331,7 @@ describe('processTargetedFiles', () => {
     });
 
     it('marks completed and unfinished source folders when cancellation happens mid-import', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
         const abortCtrl = new AbortController();
         mocks.getExistingMetadata.mockResolvedValue(new Map());
         mocks.scanDirectoryWithStats
@@ -369,6 +390,18 @@ describe('processTargetedFiles', () => {
         expect(result.completedSourcePaths).toEqual(['C:/library-a']);
         expect(result.cancelledSourcePaths).toEqual(['C:/library-b', 'C:/library-c']);
         expect(mocks.insertImagesBatch).toHaveBeenCalledTimes(1);
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[ImportUnified] Import cancelled during processing.',
+            {
+                sourceCount: 3,
+                completedSourceCount: 1,
+                cancelledSourceCount: 2,
+                processed: 1,
+                imported: 1,
+                failed: 0
+            }
+        );
+        infoSpy.mockRestore();
     });
 
     it('keeps partial-failure sources retryable without marking them cancelled', async () => {

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -604,10 +604,16 @@ export async function processFoldersUnified(
     console.log(`[ImportUnified] Discovery Complete. Total files to process: ${grandTotalFiles}`);
 
     if (result.wasCancelled) {
+        const cancelledSourcePaths = sourcePaths.filter(sourcePath => !result.completedSourcePaths.includes(sourcePath));
         pushUniquePaths(
             result.cancelledSourcePaths,
-            sourcePaths.filter(sourcePath => !result.completedSourcePaths.includes(sourcePath))
+            cancelledSourcePaths
         );
+        console.info('[ImportUnified] Import cancelled before processing.', {
+            sourceCount: sourcePaths.length,
+            completedSourceCount: result.completedSourcePaths.length,
+            cancelledSourceCount: cancelledSourcePaths.length
+        });
         return result;
     }
 
@@ -700,6 +706,17 @@ export async function processFoldersUnified(
             pushUniquePaths(result.completedSourcePaths, task.sourcePaths);
         }
         if (result.wasCancelled) break;
+    }
+
+    if (result.wasCancelled) {
+        console.info('[ImportUnified] Import cancelled during processing.', {
+            sourceCount: sourcePaths.length,
+            completedSourceCount: result.completedSourcePaths.length,
+            cancelledSourceCount: result.cancelledSourcePaths.length,
+            processed: result.stats.processed,
+            imported: result.stats.imported,
+            failed: result.failedPaths.length
+        });
     }
 
     // 3. Post-Import Cleanup

--- a/src/services/invoke/__tests__/syncService.test.ts
+++ b/src/services/invoke/__tests__/syncService.test.ts
@@ -148,6 +148,7 @@ describe('syncImages live mode', () => {
     });
 
     it('returns early for no-op startup cycles after candidate detection without counting', async () => {
+        const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined);
         const selectMock = vi.fn(async (query: string) => {
             if (query.includes('PRAGMA table_info(images)')) {
                 return [{ name: 'metadata_json' }, { name: 'updated_at' }, { name: 'is_intermediate' }];
@@ -182,6 +183,13 @@ describe('syncImages live mode', () => {
         expect(fetchBoardMappings).not.toHaveBeenCalled();
         expect(getImagesByIds).not.toHaveBeenCalled();
         expect(insertImagesBatch).not.toHaveBeenCalled();
+        expect(infoSpy).toHaveBeenCalledWith(
+            '[Startup Catch-up] Invoke sync skipped; no candidates after saved cursor.',
+            expect.objectContaining({
+                afterTimestamp: 100
+            })
+        );
+        infoSpy.mockRestore();
     });
 
     it('keeps live changed cycles incremental and skips the final full collection sync', async () => {


### PR DESCRIPTION
## Summary
- improve runtime logging around watcher start/stop/skip/failure paths
- add import and startup skip/cancellation diagnostics for support investigations
- convert Rust watcher runtime diagnostics from println/eprintln-style output to log macros
- add focused tests covering important logging branches

## Validation
- node_modules\.bin\vitest.cmd run src/services/__tests__/WatcherService.test.ts
- node_modules\.bin\vitest.cmd run src/services/__tests__/WatcherService.test.ts src/hooks/__tests__/useThumbnailQueue.test.ts src/services/__tests__/importService.test.ts src/services/invoke/__tests__/syncService.test.ts src/hooks/__tests__/useFolderMonitor.test.ts src/components/__tests__/StartupMaintenanceGate.test.tsx src/hooks/__tests__/useImportOps.test.ts
- corepack pnpm run typecheck
- corepack pnpm run test:rust
- git diff --check

## Notes
The watcher startup failure log now keeps path count context while passing the caught Error separately so message/stack details remain visible in support logs.