### PR TITLE
chore: format rust sources

### DIFF
--- a/src-tauri/src/app_data_migration.rs
+++ b/src-tauri/src/app_data_migration.rs
@@ -2,7 +2,8 @@ const PRODUCTION_IDENTIFIER: &str = "io.github.asuraace.ambit";
 const LEGACY_PRODUCTION_IDENTIFIER: &str = "com.ambit.app";
 const MAIN_DATABASE_FILES: [&str; 3] = ["images.db", "images.db-wal", "images.db-shm"];
 const PURGE_MARKER_FILE: &str = ".purge_on_restart";
-const PRODUCTION_IDENTIFIER_PATHS: [&str; 2] = [PRODUCTION_IDENTIFIER, LEGACY_PRODUCTION_IDENTIFIER];
+const PRODUCTION_IDENTIFIER_PATHS: [&str; 2] =
+    [PRODUCTION_IDENTIFIER, LEGACY_PRODUCTION_IDENTIFIER];
 const APP_IDENTIFIER_PATHS: [&str; 5] = [
     PRODUCTION_IDENTIFIER,
     LEGACY_PRODUCTION_IDENTIFIER,
@@ -416,7 +417,10 @@ fn is_production_identifier(identifier: &str) -> bool {
 }
 
 fn push_unique_profile(profiles: &mut Vec<AppProfileDir>, profile: AppProfileDir) {
-    if profiles.iter().any(|existing| existing.path == profile.path) {
+    if profiles
+        .iter()
+        .any(|existing| existing.path == profile.path)
+    {
         return;
     }
     profiles.push(profile);
@@ -1270,7 +1274,10 @@ mod identifier_migration_tests {
 
         assert_eq!(outcome.database_files_deleted, 3);
         assert_eq!(outcome.markers_deleted, 1);
-        assert_eq!(migration_outcome, DatabaseLocalMigrationOutcome::SourceMissing);
+        assert_eq!(
+            migration_outcome,
+            DatabaseLocalMigrationOutcome::SourceMissing
+        );
         assert_db_triplet_missing(&roaming_profile);
         assert!(!local_profile.join("images.db").exists());
         cleanup(&root);

--- a/src-tauri/src/db/commands/filter_commands.rs
+++ b/src-tauri/src/db/commands/filter_commands.rs
@@ -220,7 +220,10 @@ mod tests {
             .expect("collect seed rows");
 
         assert_eq!(rows.iter().find(|row| row.0 == "zero").unwrap().1, Some(0));
-        assert_eq!(rows.iter().find(|row| row.0 == "known").unwrap().1, Some(123));
+        assert_eq!(
+            rows.iter().find(|row| row.0 == "known").unwrap().1,
+            Some(123)
+        );
         for id in ["missing", "string", "malformed", "bool"] {
             assert_eq!(
                 rows.iter().find(|row| row.0 == id).unwrap().1,

--- a/src-tauri/src/db/commands/reparse_commands.rs
+++ b/src-tauri/src/db/commands/reparse_commands.rs
@@ -22,7 +22,7 @@ pub async fn get_images_needing_reparse(
             "SELECT id, COALESCE(tool, 'Unknown'), original_metadata_json FROM images WHERE (parser_version IS NULL OR parser_version < {}) AND is_deleted = 0 AND original_metadata_json IS NOT NULL AND original_metadata_json != '' LIMIT {}",
             CURRENT_PARSER_VERSION, limit
         )).map_err(|e| e.to_string())?;
-        
+
         let rows = stmt.query_map([], |row| {
             Ok(ImageToReparse {
                 id: row.get(0)?,
@@ -32,7 +32,7 @@ pub async fn get_images_needing_reparse(
         }).map_err(|e| e.to_string())?
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| e.to_string())?;
-        
+
         Ok(rows)
     }).await
 }
@@ -73,7 +73,7 @@ pub async fn reparse_metadata_batch(
             let mut update_stmt = tx.prepare_cached(
                 "UPDATE images SET metadata_json = ?1, model_hash = json_extract(?1, '$.modelHash'), model_name = json_extract(?1, '$.model'), tool = json_extract(?1, '$.tool'), resolved_model_name = COALESCE((SELECT m.name FROM models m WHERE m.hash = json_extract(?1, '$.modelHash')), json_extract(?1, '$.model')), steps = CAST(json_extract(?1, '$.steps') AS INTEGER), seed = CAST(json_extract(?1, '$.seed') AS INTEGER), cfg = CAST(json_extract(?1, '$.cfg') AS REAL), sampler = REPLACE(REPLACE(LOWER(json_extract(?1, '$.sampler')), '_', ' '), '-', ' '), generation_type = json_extract(?1, '$.generationType'), parser_version = ?2 WHERE id = ?3"
             ).map_err(|e| e.to_string())?;
-            
+
             for img in &images {
                 processed += 1;
                 match reparse_from_json(&img.original_metadata_json, &img.tool) {

--- a/src-tauri/src/db/facets.rs
+++ b/src-tauri/src/db/facets.rs
@@ -436,7 +436,11 @@ fn clean_live_resource_name(raw: &str) -> Option<String> {
         }
     }
 
-    if name.is_empty() { None } else { Some(name) }
+    if name.is_empty() {
+        None
+    } else {
+        Some(name)
+    }
 }
 
 fn normalize_live_names(names: &[String], fallback: Option<&str>) -> Vec<String> {

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -120,7 +120,8 @@ mod tests {
     }
 
     #[test]
-    fn database_at_mainline_49_has_migrations_through_auxiliary_resource_inventory_cleanup_61_pending() {
+    fn database_at_mainline_49_has_migrations_through_auxiliary_resource_inventory_cleanup_61_pending(
+    ) {
         let migrations = get_migrations();
         let has_49 = migrations.iter().any(|migration| migration.version == 49);
         let pending_after_49: Vec<i64> = migrations

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -477,7 +477,11 @@ mod tests {
 
         assert_eq!(
             urls,
-            vec![expected_local, expected_roaming, LEGACY_MAIN_DB_URL.to_string()]
+            vec![
+                expected_local,
+                expected_roaming,
+                LEGACY_MAIN_DB_URL.to_string()
+            ]
         );
         cleanup(&root);
     }

--- a/src-tauri/src/db/reparse.rs
+++ b/src-tauri/src/db/reparse.rs
@@ -70,11 +70,11 @@ pub async fn start_reparse_job(
     tauri::async_runtime::spawn_blocking(move || {
         let start_time = std::time::Instant::now();
         log::info!("[Refresh] Starting optimized refresh job. Force: {}, Filter: {:?}, Tool: {:?}", force_reparse, filter_root, filter_tool);
-        
+
         log::info!("[Reparse] Thread started, opening connection...");
         let db_path = resolve_db_path(&app)?;
         let mut conn = rusqlite::Connection::open(&db_path).map_err(|e| e.to_string())?;
-        
+
         // Normalize filter_root to forward slashes for consistency with frontend/DB
         let normalized_filter_root = filter_root.as_ref().map(|r| r.replace('\\', "/"));
 
@@ -82,7 +82,7 @@ pub async fn start_reparse_job(
         crate::db::configure_connection(&conn).map_err(|e| e.to_string())?;
         conn.execute_batch("PRAGMA synchronous = NORMAL;").map_err(|e| e.to_string())?;
         conn.busy_timeout(std::time::Duration::from_secs(60)).map_err(|e| e.to_string())?; // Longer timeout
-        
+
         log::info!("[Reparse] Connection ready, counting total images...");
         // Signal FE that we are actually in the backend
         let _ = app.emit("refresh-progress", ReparseProgress {
@@ -111,7 +111,7 @@ pub async fn start_reparse_job(
                 // Already normalized to forward slashes at the start of the thread
                 let r_fwd = r.replace('\\', "/").trim_end_matches('/').to_string();
                 let r_back = r.replace('/', "\\").trim_end_matches('\\').to_string();
-                
+
                 // Match exact path OR subfolders with either slash type
                 clauses.push("(path = ? OR path = ? OR path LIKE ? || '/%' OR path LIKE ? || '\\%' OR path LIKE ? || '/%' OR path LIKE ? || '\\%')".to_string());
                 params.push(Box::new(r_fwd.clone()));
@@ -140,9 +140,9 @@ pub async fn start_reparse_job(
             rusqlite::params_from_iter(count_params.iter()),
             |r| r.get::<_, i64>(0)
         ).unwrap_or(0) as usize;
-        
+
         log::info!("[Reparse] Total query complete: {}", total);
-        
+
         if total == 0 {
             log::info!("[Reparse] No images need refreshing");
             let _ = app.emit("refresh-complete", ReparseJobResult {
@@ -158,7 +158,7 @@ pub async fn start_reparse_job(
                 was_cancelled: false,
             });
         }
-        
+
         log::info!("[Refresh] Found {} images to process", total);
         let _ = app.emit("refresh-progress", ReparseProgress {
             current: 0,
@@ -168,16 +168,16 @@ pub async fn start_reparse_job(
             phase: "starting".to_string(),
             message: format!("Found {} images to refresh", total),
         });
-        
+
         let mut processed = 0;
         let mut updated = 0;
         let mut errors = 0;
         let batch_size = 500;
-        let progress_interval = 50; 
+        let progress_interval = 50;
         let mut last_emit_time = std::time::Instant::now();
         let min_emit_interval = std::time::Duration::from_millis(50);
         let mut was_cancelled = false;
-        
+
         let should_use_prefetch = filter_root.is_some();
 
         // SHARED UPDATE LOGIC CLOSURE
@@ -185,7 +185,7 @@ pub async fn start_reparse_job(
         // It takes a batch of rows, processes them, and updates the DB.
         let mut process_and_update_batch = |conn: &mut rusqlite::Connection, batch: Vec<(String, String, String, String)>, fetch_ms: u128| -> Result<(), String> {
             let parse_start = std::time::Instant::now();
-            
+
             // PARALLEL PHASE: Parse structure on all cores
             let batch_results: Vec<(String, String, String, String, Option<crate::metadata::reparse::ReparseResult>)> = batch
                 .par_iter()
@@ -194,7 +194,7 @@ pub async fn start_reparse_job(
                     (id.clone(), tool.clone(), original_json.clone(), old_meta_json.clone(), result)
                 })
                 .collect();
-            
+
             let parse_duration = parse_start.elapsed();
             let update_start = std::time::Instant::now();
 
@@ -202,7 +202,7 @@ pub async fn start_reparse_job(
             let tx = conn.transaction().map_err(|e| e.to_string())?;
             {
                 let mut update_stmt = tx.prepare_cached(
-                    "UPDATE images SET 
+                    "UPDATE images SET
                         metadata_json = ?1,
                         original_parsed_json = ?1,
                         model_hash = ?2,
@@ -219,7 +219,7 @@ pub async fn start_reparse_job(
                         negative_prompt = ?12
                      WHERE id = ?13"
                 ).map_err(|e| e.to_string())?;
-                
+
                 let mut skip_stmt = tx.prepare_cached(
                     "UPDATE images SET parser_version = ?1 WHERE id = ?2"
                 ).map_err(|e| e.to_string())?;
@@ -245,16 +245,16 @@ pub async fn start_reparse_job(
 
                 let mut ip_del = tx.prepare_cached("DELETE FROM image_ipadapters WHERE image_id = ?1").map_err(|e| e.to_string())?;
                 let mut ip_ins = tx.prepare_cached("INSERT OR IGNORE INTO image_ipadapters (image_id, ipadapter_name) VALUES (?1, ?2)").map_err(|e| e.to_string())?;
-                
+
                 for (id, _tool, _original_json, old_meta_json, parse_result) in batch_results {
                     processed += 1;
-                    
+
                     match parse_result {
                         Some(result) => {
                             // Smart Diffing: skip updates if metadata is identical
                             // BUT: if filter_root and force_reparse are both set, we bypass this to force update
                             let mut meta_changed = force_reparse || result.metadata_json != *old_meta_json;
-                            
+
                             // Deep Object Diffing (only if not forced)
                             if meta_changed && !force_reparse {
                                 if let Ok(old_meta) = serde_json::from_str::<ImageMetadata>(&old_meta_json) {
@@ -274,7 +274,7 @@ pub async fn start_reparse_job(
                                     .to_lowercase()
                                     .replace('_', " ")
                                     .replace('-', " ");
-                                
+
                                 update_stmt.execute(params![
                                     result.metadata_json,
                                     meta.model_hash,
@@ -345,7 +345,7 @@ pub async fn start_reparse_job(
                             updated,
                             errors,
                             phase: "processing".to_string(),
-                            message: format!("Processed {}/{} (Updated: {}). Timings: Fetch {}ms, Parse {}ms, DB {}ms", 
+                            message: format!("Processed {}/{} (Updated: {}). Timings: Fetch {}ms, Parse {}ms, DB {}ms",
                                 processed, total, updated, fetch_ms, parse_duration.as_millis(), update_ms),
                         });
                         last_emit_time = std::time::Instant::now();
@@ -360,21 +360,21 @@ pub async fn start_reparse_job(
             // === STRATEGY 1: ID PRE-FETCHING (Filtered) ===
             log::info!("[Reparse] Strategy: ID Pre-fetching (Targeted)");
             let prefetch_start = std::time::Instant::now();
-            
+
             // 1. Pre-fetch all IDs (Fast O(Folder Size) using Path Index)
             let (where_sql, params_vec) = build_filters(force_reparse, normalized_filter_root.as_ref(), filter_tool.as_ref());
 
              let query = format!("SELECT id FROM images WHERE {}", where_sql);
-             
+
              let ids: Vec<String> = {
                  let mut stmt = conn.prepare(&query).map_err(|e| e.to_string())?;
                  let rows = stmt.query_map(rusqlite::params_from_iter(params_vec.iter()), |row| row.get(0))
                      .map_err(|e| e.to_string())?;
                  rows.collect::<Result<Vec<_>, _>>().map_err(|e| e.to_string())?
              };
-             
+
              let prefetch_duration = prefetch_start.elapsed();
-             log::info!("[Reparse] Pre-fetched {} IDs in {:.2}ms. Starting batched processing...", 
+             log::info!("[Reparse] Pre-fetched {} IDs in {:.2}ms. Starting batched processing...",
                 ids.len(), prefetch_duration.as_millis());
 
              // 2. Loop through chunks
@@ -382,16 +382,16 @@ pub async fn start_reparse_job(
                  if is_cancelled.load(Ordering::SeqCst) {
                      break;
                  }
-                 
+
                  let fetch_start = std::time::Instant::now();
                  let placeholders = std::iter::repeat("?").take(chunk.len()).collect::<Vec<_>>().join(",");
                  let batch_query = format!(
-                    "SELECT id, COALESCE(json_extract(original_parsed_json, '$.tool'), tool, 'Unknown'), original_metadata_json, COALESCE(metadata_json, '') 
-                     FROM images 
-                     WHERE id IN ({})", 
+                    "SELECT id, COALESCE(json_extract(original_parsed_json, '$.tool'), tool, 'Unknown'), original_metadata_json, COALESCE(metadata_json, '')
+                     FROM images
+                     WHERE id IN ({})",
                     placeholders
                  );
-                 
+
                  let batch: Vec<(String, String, String, String)> = {
                      let mut stmt = conn.prepare(&batch_query).map_err(|e| e.to_string())?;
                      let rows = stmt.query_map(rusqlite::params_from_iter(chunk.iter()), |row| {
@@ -425,10 +425,10 @@ pub async fn start_reparse_job(
                 let batch: Vec<(String, String, String, String)> = {
                     let (base_filters, mut params) = build_filters(force_reparse, filter_root.as_ref(), filter_tool.as_ref());
                     params.push(Box::new(last_seen_id.clone()));
-                    
+
                     let query = format!(
-                        "SELECT id, COALESCE(json_extract(original_parsed_json, '$.tool'), tool, 'Unknown'), original_metadata_json, COALESCE(metadata_json, '') 
-                         FROM images 
+                        "SELECT id, COALESCE(json_extract(original_parsed_json, '$.tool'), tool, 'Unknown'), original_metadata_json, COALESCE(metadata_json, '')
+                         FROM images
                          WHERE {} AND id > ?
                          ORDER BY id ASC
                          LIMIT {}",
@@ -446,18 +446,18 @@ pub async fn start_reparse_job(
                     }).map_err(|e| e.to_string())?
                     .collect::<Result<Vec<_>, rusqlite::Error>>()
                     .map_err(|e| e.to_string())?;
-                    
+
                     rows
                 };
                 let fetch_duration = fetch_start.elapsed();
-                
+
                 if batch.is_empty() { break; }
                 if let Some(last) = batch.last() { last_seen_id = last.0.clone(); }
 
                 process_and_update_batch(&mut conn, batch, fetch_duration.as_millis())?;
             }
         }
-        
+
         if is_cancelled.load(Ordering::SeqCst) {
             log::info!("[Refresh] Job cancelled by user");
             was_cancelled = true;
@@ -472,22 +472,22 @@ pub async fn start_reparse_job(
             phase: "complete".to_string(),
             message: format!("Completed {} / {} images", processed, total),
         });
-        
+
         let duration = start_time.elapsed();
         log::info!(
             "[Refresh] Job complete in {:.2}s: {} processed, {} updated, {} errors, cancelled: {}",
             duration.as_secs_f64(), processed, updated, errors, was_cancelled
         );
-        
+
         let result = ReparseJobResult {
             processed,
             updated,
             errors,
             was_cancelled,
         };
-        
+
         let _ = app.emit("refresh-complete", result.clone());
-        
+
         Ok(result)
     })
     .await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,9 +138,7 @@ pub fn run() {
                 .level(log_level)
                 .build(),
         )
-        .plugin(
-            sql_builder.build(),
-        )
+        .plugin(sql_builder.build())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())

--- a/src-tauri/src/metadata/civitai.rs
+++ b/src-tauri/src/metadata/civitai.rs
@@ -312,7 +312,8 @@ fn extract_a1111_cache_entries(
                 }
             }
             if added == 0 {
-                debug_info.push_str("Fallback: top-level object was empty or had non-string values. ");
+                debug_info
+                    .push_str("Fallback: top-level object was empty or had non-string values. ");
             }
         } else {
             debug_info.push_str("Root is not an object. ");
@@ -337,8 +338,7 @@ pub fn import_a1111_cache(
         .unwrap()
         .as_secs();
 
-    let (entries, debug_info, skipped_malformed_hashes) =
-        extract_a1111_cache_entries(&json, now);
+    let (entries, debug_info, skipped_malformed_hashes) = extract_a1111_cache_entries(&json, now);
 
     if entries.is_empty() {
         return Ok(ImportResult {

--- a/src-tauri/src/metadata/resources.rs
+++ b/src-tauri/src/metadata/resources.rs
@@ -50,9 +50,7 @@ impl ResourceScanBudget {
             self.note_limit("skipping oversized nested JSON string");
             return false;
         }
-        if self
-            .nested_json_string_bytes
-            .saturating_add(byte_len)
+        if self.nested_json_string_bytes.saturating_add(byte_len)
             > MAX_AGGREGATE_NESTED_JSON_STRING_BYTES
         {
             self.exhaust("maximum aggregate nested JSON string bytes reached");
@@ -292,10 +290,7 @@ fn scan_for_resources_inner(
                     // Try to parse string as JSON if it looks like one
                     let trimmed = s.trim_start();
                     if trimmed.starts_with('{')
-                        && budget.allow_nested_json_string(
-                            nested_json_string_depth,
-                            trimmed.len(),
-                        )
+                        && budget.allow_nested_json_string(nested_json_string_depth, trimmed.len())
                     {
                         if let Ok(nested) = serde_json::from_str(s) {
                             scan_for_resources_inner(
@@ -308,13 +303,7 @@ fn scan_for_resources_inner(
                         }
                     }
                 } else if v.is_object() || v.is_array() {
-                    scan_for_resources_inner(
-                        v,
-                        res,
-                        budget,
-                        depth + 1,
-                        nested_json_string_depth,
-                    );
+                    scan_for_resources_inner(v, res, budget, depth + 1, nested_json_string_depth);
                 }
             }
         }
@@ -323,13 +312,7 @@ fn scan_for_resources_inner(
                 if budget.exhausted {
                     break;
                 }
-                scan_for_resources_inner(
-                    v,
-                    res,
-                    budget,
-                    depth + 1,
-                    nested_json_string_depth,
-                );
+                scan_for_resources_inner(v, res, budget, depth + 1, nested_json_string_depth);
             }
         }
         _ => {}
@@ -487,10 +470,7 @@ mod tests {
     fn test_scan_for_resources_skips_oversized_nested_json_string() {
         let mut res = Resources::default();
         let huge_name = "x".repeat(MAX_NESTED_JSON_STRING_BYTES);
-        let oversized = format!(
-            "{{\"loras\":[{{\"lora_name\":\"{}\"}}]}}",
-            huge_name
-        );
+        let oversized = format!("{{\"loras\":[{{\"lora_name\":\"{}\"}}]}}", huge_name);
         let valid = json!({
             "loras": [{ "lora_name": "small_valid" }]
         });

--- a/src-tauri/src/metadata/thumbs_scan.rs
+++ b/src-tauri/src/metadata/thumbs_scan.rs
@@ -252,13 +252,18 @@ fn normalized_model_path_parts(model_path: &str) -> (String, Vec<String>) {
 }
 
 fn path_has_segment(parts: &[String], candidates: &[&str]) -> bool {
-    parts
-        .iter()
-        .any(|part| candidates.iter().any(|candidate| part.as_str() == *candidate))
+    parts.iter().any(|part| {
+        candidates
+            .iter()
+            .any(|candidate| part.as_str() == *candidate)
+    })
 }
 
 fn path_or_filename_contains(normalized_path: &str, candidates: &[&str]) -> bool {
-    let filename = normalized_path.rsplit('/').next().unwrap_or(normalized_path);
+    let filename = normalized_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(normalized_path);
     candidates
         .iter()
         .any(|candidate| normalized_path.contains(candidate) || filename.contains(candidate))
@@ -1006,7 +1011,9 @@ fn scan_dir_for_resources(
                     .unwrap_or("")
                     .to_lowercase();
 
-                if is_model_resource_ext(&ext) && resource_type_for_model_path(&path.to_string_lossy()).is_some() {
+                if is_model_resource_ext(&ext)
+                    && resource_type_for_model_path(&path.to_string_lossy()).is_some()
+                {
                     models.push(path.to_string_lossy().to_string());
                 } else if is_sidecar_image_ext(&ext) {
                     images.insert(path.to_string_lossy().to_string());
@@ -1326,7 +1333,11 @@ mod tests {
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .unwrap();
-            touch_resource(&mut resources, resource_type_for_model_path(path).unwrap(), stem);
+            touch_resource(
+                &mut resources,
+                resource_type_for_model_path(path).unwrap(),
+                stem,
+            );
         }
 
         assert_eq!(resources.checkpoints, vec!["Pony Diffusion V6 XL"]);

--- a/src-tauri/src/scanner/traversal.rs
+++ b/src-tauri/src/scanner/traversal.rs
@@ -471,7 +471,8 @@ mod tests {
 
         let mut with_stats = Vec::new();
         collect_images_with_stats_recursive(root, &mut with_stats);
-        let mut with_stats_paths: Vec<_> = with_stats.iter().map(|entry| entry.path.clone()).collect();
+        let mut with_stats_paths: Vec<_> =
+            with_stats.iter().map(|entry| entry.path.clone()).collect();
         with_stats_paths.sort();
         assert_eq!(with_stats_paths, expected_absolute);
 


### PR DESCRIPTION
## Summary

Runs repo-wide Rust formatting for the Tauri crate so `cargo fmt` / `cargo fmt --check` can be used cleanly again.

## What changed

- Applied `cargo fmt --manifest-path src-tauri/Cargo.toml`.
- Removed trailing whitespace that caused rustfmt to abort in reparse-related Rust files.
- Kept this PR formatting-only and separate from the JPG/WebP metadata fix in PR #179.

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

No behavioral tests were run because this is a formatting-only change.