### PR TITLE
docs: expand search filters collections guide

### DIFF
--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -26,7 +26,7 @@ The core app is local-first. Image records, metadata, thumbnails, and settings a
 - [Adding Folders](adding-folders.md): add monitored image folders and run one-time imports.
 - [Generator Integrations](generator-integrations.md): connect InvokeAI, ComfyUI, SD WebUI, A1111, Forge, SD.Next, and Anapnoe output locations.
 - [Browsing The Library](browsing-library.md): use grid, timeline, statistics, selection, favorites, pins, and the viewer.
-- [Search, Filters, And Collections](search-filters-collections.md): search prompts and metadata, use facets, and organize images.
+- [Search, Filters, And Collections](search-filters-collections.md): use search syntax, filter facets, date ranges, and manual or smart collections.
 - [Assets And Resource Discovery](assets-resource-discovery.md): understand used assets, local disk inventory, resource folders, and Assets tab scopes.
 - [Viewer And Metadata](viewer-and-metadata.md): inspect prompts, resources, workflow data, notes, and image versions.
 - [Maintenance](maintenance.md): choose safe repair, recovery, removal, thumbnail, duplicate, and file-deletion workflows.

--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -2,29 +2,48 @@
 
 [Back to manual index](index.md)
 
-Ambit combines search text, metadata filters, resource facets, date filters, favorites, pins, and collections to narrow large local libraries.
+Ambit combines search text, metadata filters, asset facets, date ranges, favorites, pins, and collections to narrow large local libraries. Most filters combine with AND, so each extra filter tightens the result set. Some asset sections also let you choose whether selected assets should match any selected item or every selected item.
 
-## Search Basics
+## Search Bar
 
-The search bar matches the positive prompt by default. Spaces narrow results. Use `OR` to match alternatives.
+The search bar matches the positive prompt by default. Type plain words to find prompt text; Ambit updates after typing pauses, and pressing Enter applies the current search immediately.
+
+Search bar tools include:
+
+- quoted phrases for exact multi-word prompt fragments
+- `OR` between prompt terms when either term can match
+- `-term` or `!term` to exclude a positive-prompt term
+- operator suggestions while typing
+- recent searches when the field is focused and empty
+- Clear search to remove the current search text
+- Clear in Recent Searches to remove the recent-search list
+- an ISO-date readiness hint when a date operator is incomplete or invalid
+
+When AI Search is enabled from the search bar, the placeholder changes to an assistant-style prompt. Network and AI behavior depends on your settings; see [Settings And Privacy](settings-and-privacy.md).
 
 Examples:
 
 ```text
 sunset portrait
-orc OR elf
 "dark forest"
+orc OR elf
+dragon -blurry
+model:sdxl lora:detail
+date:2026-04 after:2026-03
+steps:>30 cfg:<7 w:>1024
 ```
 
 Open Help, then Search Syntax, for the in-app operator list.
 
-## Search Operators
+## Search Syntax
 
-Useful operators include:
+Plain terms search positive prompts. Multiple plain terms narrow results. `OR` only groups adjacent positive-prompt terms, such as `orc OR elf`; resource, date, numeric, and other operator filters still combine with the rest of the query.
+
+Supported operators include:
 
 - `-term` or `!term` excludes a positive-prompt term.
-- `neg:blur` searches the negative prompt.
-- `file:portrait` searches filename or path.
+- `neg:blur` or `negative:blur` searches the negative prompt.
+- `file:portrait`, `filename:portrait`, or `path:portrait` searches the file path.
 - `all:anime` searches path and raw metadata.
 - `model:sdxl` filters by model.
 - `lora:detail` filters by LoRA.
@@ -32,16 +51,41 @@ Useful operators include:
 - `ip:adapter` or `ipadapter:adapter` filters by IP-Adapter.
 - `tool:invoke` filters by generator.
 - `sampler:euler` filters by sampler.
-- `steps:>30` filters generation steps.
-- `cfg:<7` filters CFG.
-- `seed:12345` filters seed.
+- `steps:>30`, `steps:<20`, or `steps:30` filters generation steps.
+- `cfg:<7`, `cfg:>4`, or `cfg:6` filters CFG.
+- `seed:12345` searches seed values.
 - `date:2026-04` filters by local calendar month.
 - `date:2026-04..2026-06` filters by an inclusive ISO date range.
 - `after:2026-04` and `before:2025` filter date ranges.
-- `w:>1024` and `h:<768` filter dimensions.
-- `upscaled:true` shows upscaled images.
+- `w:>1024`, `width:1024`, `h:<768`, or `height:768` filter dimensions.
+- `upscaled:true` shows upscaled images; `upscaled:false` shows images marked not upscaled.
 
-Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity. Plain terms combine with AND; `OR` only groups adjacent positive-prompt terms.
+Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity. If a `date:`, `after:`, or `before:` token is still partial, Ambit waits instead of applying the search.
+
+## Date Filters
+
+The filter panel has a Date Range section at the bottom. Use it when you want a visual date filter instead of typing date syntax.
+
+Date Range options are:
+
+- All: no date limit
+- Today: images from the current local day
+- Week: images from the last 7 days
+- Month: images from the last 30 days
+- Custom range: choose start and end days from the calendar, then Apply
+
+Search syntax can express the same idea inline:
+
+```text
+date:2026
+date:2026-04
+date:2026-04-15
+date:2026-04..2026-06
+after:2026-04
+before:2025
+```
+
+`date:YYYY` matches the year, `date:YYYY-MM` matches the month, and `date:YYYY-MM-DD` matches one local day. `date:start..end` requires both sides of the range and accepts year, month, or day values.
 
 ## Filter Panel
 
@@ -51,11 +95,13 @@ The Library filter panel is organized into tabs:
 - Assets: checkpoints, LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter resources.
 - Filters: generator tools, generation parameters, and guidance-related filters.
 
-The date filter is available at the bottom of the panel.
+Dirty dots on tab buttons show where active filters live. Active filter chips appear above the library; chips from a smart collection are locked rules, while manual chips can be removed directly. Use Reset All to clear active filters and collection selection.
 
-Use Reset All to clear active filters. When filter state changes inside a smart collection, Ambit can show an Update action for saving the adjusted rules.
+When you select a smart collection and then add manual refinements, Ambit can show Update. Update saves the refinement back to that smart collection's rules, then clears the manual refinements while keeping the collection selected.
 
-## Asset Scope
+## Assets Tab
+
+The Assets tab filters by resources that Ambit has indexed from image metadata. It can also show local disk inventory when resource folders are configured.
 
 The Assets tab can switch between:
 
@@ -63,20 +109,80 @@ The Assets tab can switch between:
 - Local on Disk: resources discovered from configured resource folders.
 - All Assets: both library-used and locally discovered resources.
 
-If Local on Disk is empty, add resource folders from Settings > Connections > Resources. For setup details and local-only inventory behavior, see [Assets And Resource Discovery](assets-resource-discovery.md).
+Resource sections include checkpoints, LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter resources. Each section can offer list or grid view, sorting, search within the section, and resource thumbnails when available.
+
+For LoRAs, embeddings, hypernetworks, ControlNet, and IP-Adapter resources:
+
+- Match Any shows images that contain at least one selected resource in that category.
+- Match All shows images that contain every selected resource in that category.
+
+Checkpoints do not show the Match Any or Match All toggle because each image has one main checkpoint or model.
+
+Local markers mean Ambit found the asset on disk. A local-only inventory item has no indexed image count yet, so it is inventory only and does not filter images until Ambit matches it to image metadata. If Local on Disk is empty, add resource folders from Settings > Connections > Resources. For setup details, sidecar preview behavior, broad `models` root warnings, and local-only inventory limits, see [Assets And Resource Discovery](assets-resource-discovery.md).
+
+## Filters Tab
+
+The Filters tab groups generation metadata filters.
+
+Generator filters show detected generator tools. When another active filter leaves no matching images for a tool, that tool can appear unavailable until the surrounding filter context changes.
+
+Parameters appear when Ambit has matching metadata for them:
+
+- Steps slider filters generation step ranges.
+- CFG Scale slider filters CFG ranges.
+- Sampler groups organize sampler names by family.
+- Generation Type chips can filter text-to-image, image-to-image, extras/upscale, grid, saved, and unknown generations.
+
+Guidance filters group detected ControlNet and IP-Adapter usage by subtype when Ambit can classify it. ControlNet groups can include Canny, Depth, Pose, Scribble, Lineart, Normal, Inpaint, Tile, MLSD, Seg, Instruct, Shuffle, Recolor, and Other. IP-Adapter groups can include FaceID Plus, FaceID, Plus Face, Plus, Portrait, Full Face, Light, Comp, Style, Standard, and Other.
 
 ## Collections
 
-Collections help organize images without moving files on disk.
+Collections organize images without moving source files on disk.
 
-Use collections to:
+There are two collection types:
 
-- group images manually
-- open a saved group from the library panel
-- rename, archive, pin, color, export, or reset collection thumbnails when those actions are available
-- save search/filter rules as smart collections
+- Manual collections contain images you add explicitly.
+- Smart collections save filter rules and update their results from the current library.
 
-Manual collections contain selected images. Smart collections represent saved filter rules.
+In the Organize tab, use New Empty Collection to create a manual collection. When filters are active, use Save Filters as Collection to create a smart collection from the current search and filter state.
+
+Collection workflows include:
+
+- select a collection to filter the library to that collection
+- select the active collection again to clear the collection filter
+- drag selected images into a manual collection
+- search collections by name
+- sort by recently used, created date, name, or image count
+- switch between list and grid collection views
+- include archived collections when needed
+- keep pinned collections at the top
+- rename, color, pin, archive, play slideshow, export to ZIP, reset custom thumbnails, or delete a collection from the context menu
+
+Deleting a collection removes the collection, not the source image files.
+
+Smart collection editing is available from Edit Filters in the collection context menu. In the editor you can remove individual rule chips, Save Changes, Update with Current View to overwrite the saved rules with your active filters, or Remove All Rules (Make Static) to turn the collection into a manual collection.
+
+## Common Workflows
+
+To find images and save the result:
+
+1. Search by prompt text or syntax.
+2. Add Assets, Filters, or Date Range refinements.
+3. Open Organize.
+4. Use Save Filters as Collection and name the smart collection.
+
+To refine a smart collection:
+
+1. Select the smart collection.
+2. Add manual search or filter refinements.
+3. Use Update when it appears in the Library panel header.
+
+To filter by assets:
+
+1. Open Assets.
+2. Choose Used in Library when you want filterable resources.
+3. Select resources from one or more sections.
+4. Use Match Any or Match All where supported.
 
 ## Next Step
 


### PR DESCRIPTION
## Summary
- Expanded the Search, Filters, And Collections manual into a workflow guide covering search syntax, dates, filter tabs, asset facets, and collection management.
- Updated the manual index wording for the expanded page.

## Verification
- git diff --check
- Required coverage search for OR, date:, Match Any, Match All, Reset All, Update, Local on Disk, smart collection, and Remove All Rules

No frontend or Rust tests were run because this is docs-only.