### PR TITLE
fix: improve support log diagnostics

### DIFF
--- a/docs/manual/settings-and-privacy.md
+++ b/docs/manual/settings-and-privacy.md
@@ -63,10 +63,12 @@ Advanced includes:
 - backup settings
 - automatic update controls
 - reset onboarding
-- support diagnostics, including the active library database location
+- support diagnostics, including the active library database and app log locations
 - database reset tools
 
 The database location shown in Support Diagnostics is the local catalog path, not the Ambit installer path. On Windows, Ambit stores the catalog under Local AppData and may show a legacy Roaming AppData fallback only for older installs that could not be moved automatically.
+
+Support Diagnostics also shows the app log file location. Use Show Logs Folder or Copy Diagnostics when collecting details for an issue; the copied diagnostics include paths and aggregate counts, not image prompts or metadata.
 
 Use Purge Database only when you intentionally want to remove all imported metadata and reset application state. The confirmation explains that source image files are not touched, but Ambit's catalog and linked folders are reset.
 

--- a/src-tauri/src/db/commands/maintenance.rs
+++ b/src-tauri/src/db/commands/maintenance.rs
@@ -2,11 +2,12 @@ use super::run_blocking;
 use crate::db::{resolve_db_path, resolve_db_path_info, resolve_main_database_url};
 use rusqlite::params;
 use sha2::{Digest, Sha256};
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tauri::AppHandle;
+use tauri::{AppHandle, Manager};
 
 pub struct FileHashBackfillState {
     pub is_cancelled: Arc<AtomicBool>,
@@ -27,6 +28,8 @@ pub struct DbDiagnostics {
     pub active_db_path: String,
     pub local_db_path: String,
     pub roaming_db_path: String,
+    pub app_log_dir: String,
+    pub app_log_path: String,
     pub is_using_roaming_fallback: bool,
     pub image_count: i64,
     pub deleted_count: i64,
@@ -71,6 +74,42 @@ fn hash_file_sha256(path: &str) -> Result<String, String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
+fn resolve_app_log_path(log_dir: &Path, app_name: &str) -> PathBuf {
+    log_dir.join(app_name).with_extension("log")
+}
+
+fn ensure_log_directory(log_dir: &Path) -> Result<(), String> {
+    fs::create_dir_all(log_dir).map_err(|e| format!("Failed to prepare app log folder: {}", e))
+}
+
+fn open_folder_path(path: &Path) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        std::process::Command::new("explorer")
+            .arg(path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg(path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("xdg-open")
+            .arg(path)
+            .spawn()
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
+}
+
 #[tauri::command(rename_all = "camelCase")]
 #[specta::specta]
 pub fn get_main_database_url(app: AppHandle) -> Result<String, String> {
@@ -84,6 +123,8 @@ pub async fn get_db_diagnostics(app: AppHandle) -> Result<DbDiagnostics, String>
     run_blocking(app, move |conn| {
         let path_info = resolve_db_path_info(&app_clone)?;
         let db_path = path_info.active_path.clone();
+        let app_log_dir = app_clone.path().app_log_dir().map_err(|e| e.to_string())?;
+        let app_log_path = resolve_app_log_path(&app_log_dir, &app_clone.package_info().name);
         let image_count: i64 = conn
             .query_row("SELECT COUNT(*) FROM images", [], |r| r.get(0))
             .unwrap_or(0);
@@ -113,6 +154,8 @@ pub async fn get_db_diagnostics(app: AppHandle) -> Result<DbDiagnostics, String>
             active_db_path: path_info.active_path.to_string_lossy().to_string(),
             local_db_path: path_info.local_path.to_string_lossy().to_string(),
             roaming_db_path: path_info.roaming_path.to_string_lossy().to_string(),
+            app_log_dir: app_log_dir.to_string_lossy().to_string(),
+            app_log_path: app_log_path.to_string_lossy().to_string(),
             is_using_roaming_fallback: path_info.is_using_roaming_fallback,
             image_count,
             deleted_count,
@@ -122,6 +165,14 @@ pub async fn get_db_diagnostics(app: AppHandle) -> Result<DbDiagnostics, String>
         })
     })
     .await
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub fn show_app_log_folder(app: AppHandle) -> Result<(), String> {
+    let app_log_dir = app.path().app_log_dir().map_err(|e| e.to_string())?;
+    ensure_log_directory(&app_log_dir)?;
+    open_folder_path(&app_log_dir)
 }
 
 #[tauri::command(rename_all = "camelCase")]
@@ -316,7 +367,7 @@ pub async fn purge_database(app: AppHandle) -> Result<String, String> {
 
 #[cfg(test)]
 mod tests {
-    use super::hash_file_sha256;
+    use super::{ensure_log_directory, hash_file_sha256, resolve_app_log_path};
     use std::fs::File;
     use std::io::Write;
 
@@ -340,5 +391,30 @@ mod tests {
             first_hash,
             "f10266197016b8e8842aeba6800100997ce04f35a45a3bff974711e9615ea597"
         );
+    }
+
+    #[test]
+    fn app_log_path_matches_tauri_plugin_log_default_name() {
+        let log_dir =
+            std::path::Path::new("C:/Users/Ambit/AppData/Roaming/io.github.asuraace.ambit/logs");
+
+        let log_path = resolve_app_log_path(log_dir, "Ambit");
+
+        assert_eq!(
+            log_path.to_string_lossy().replace('\\', "/"),
+            "C:/Users/Ambit/AppData/Roaming/io.github.asuraace.ambit/logs/Ambit.log"
+        );
+    }
+
+    #[test]
+    fn log_folder_reveal_prepares_only_a_directory_target() {
+        let root = std::env::temp_dir().join("ambit_log_reveal_test");
+        let log_dir = root.join("logs");
+        let _ = std::fs::remove_dir_all(&root);
+
+        ensure_log_directory(&log_dir).unwrap();
+
+        assert!(log_dir.is_dir());
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         db::commands::image_commands::move_image_path_identities,
         db::commands::maintenance::get_main_database_url,
         db::commands::maintenance::get_db_diagnostics,
+        db::commands::maintenance::show_app_log_folder,
         db::commands::maintenance::backfill_image_file_hashes,
         db::commands::maintenance::cancel_image_file_hash_backfill,
         db::commands::image_commands::refresh_boards_native,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -61,6 +61,14 @@ async getDbDiagnostics() : Promise<Result<DbDiagnostics, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async showAppLogFolder() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("show_app_log_folder") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async backfillImageFileHashes(limit: number | null) : Promise<Result<FileHashBackfillResult, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("backfill_image_file_hashes", { limit }) };
@@ -557,7 +565,7 @@ async getInvokeDbSnapshot(rootPath: string) : Promise<Result<InvokeDbSnapshot, s
 export type A1111DiscoveryCandidate = { path: string; name: string; imageCount: number; inferredType: string; isPriority: boolean; variant: string }
 export type A1111DiscoveryResult = { detectedVariant: string; candidates: A1111DiscoveryCandidate[]; logs: string[]; warnings: string[] }
 export type BackupInfo = { name: string; path: string; createdAt: string; sizeBytes: number }
-export type DbDiagnostics = { dbPath: string; activeDbPath: string; localDbPath: string; roamingDbPath: string; isUsingRoamingFallback: boolean; imageCount: number; deletedCount: number; modelCount: number; cacheCount: number; toolNullCount: number }
+export type DbDiagnostics = { dbPath: string; activeDbPath: string; localDbPath: string; roamingDbPath: string; appLogDir: string; appLogPath: string; isUsingRoamingFallback: boolean; imageCount: number; deletedCount: number; modelCount: number; cacheCount: number; toolNullCount: number }
 export type FacetResourceTouches = { checkpoints: string[]; loras: string[]; embeddings: string[]; hypernetworks: string[]; controlNets: string[]; ipAdapters: string[]; tools: string[] }
 export type FileEntry = { path: string; modified: number; size: number }
 export type FileHashBackfillResult = { scanned: number; updated: number; missing: number; errors: number; remaining: number; wasCancelled: boolean }

--- a/src/features/settings/components/AdvancedTab.tsx
+++ b/src/features/settings/components/AdvancedTab.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { Trash2, History as HistoryIcon, Loader2, Database, AlertTriangle, Monitor, RefreshCw, ExternalLink } from 'lucide-react';
+import { getVersion } from '@tauri-apps/api/app';
+import { Trash2, History as HistoryIcon, Loader2, Database, AlertTriangle, Monitor, RefreshCw, ExternalLink, FolderOpen, Copy } from 'lucide-react';
 import { AppSettings, LogLevel } from '../../../types';
 import { commands, type DbDiagnostics } from '../../../bindings';
 import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
@@ -120,6 +121,53 @@ export const AdvancedTab: React.FC<TabProps> = ({
     const handleOpenMaintenance = () => {
         onNavigateToMaintenance();
         onClose?.();
+    };
+
+    const handleShowAppLogFolder = async () => {
+        try {
+            await unwrap(commands.showAppLogFolder());
+            addToast('Opened app logs folder', 'success');
+        } catch (error) {
+            console.error('[Support] Failed to open app logs folder:', error);
+            addToast('Failed to open app logs folder', 'error');
+        }
+    };
+
+    const handleCopyDiagnostics = async () => {
+        if (!dbDiagnostics) {
+            addToast('Diagnostics are still loading', 'info');
+            return;
+        }
+
+        try {
+            if (!navigator.clipboard?.writeText) {
+                throw new Error('Clipboard is not available');
+            }
+
+            const version = await getVersion().catch(() => 'unknown');
+            const diagnosticsText = [
+                `${APP_NAME} Support Diagnostics`,
+                `App version: ${version}`,
+                `Console log level: ${settings.logLevel || 'info'}`,
+                `Active catalog: ${dbDiagnostics.activeDbPath || dbDiagnostics.dbPath}`,
+                `Local AppData target: ${dbDiagnostics.localDbPath}`,
+                `Legacy Roaming fallback: ${dbDiagnostics.roamingDbPath}`,
+                `Using Roaming fallback: ${dbDiagnostics.isUsingRoamingFallback ? 'yes' : 'no'}`,
+                `App log folder: ${dbDiagnostics.appLogDir}`,
+                `App log file: ${dbDiagnostics.appLogPath}`,
+                `Images: ${dbDiagnostics.imageCount}`,
+                `Deleted images: ${dbDiagnostics.deletedCount}`,
+                `Models: ${dbDiagnostics.modelCount}`,
+                `Facet cache rows: ${dbDiagnostics.cacheCount}`,
+                `Images missing tool metadata: ${dbDiagnostics.toolNullCount}`,
+            ].join('\n');
+
+            await navigator.clipboard.writeText(diagnosticsText);
+            addToast('Diagnostics copied to clipboard', 'success');
+        } catch (error) {
+            console.error('[Support] Failed to copy diagnostics:', error);
+            addToast('Failed to copy diagnostics', 'error');
+        }
     };
 
     React.useEffect(() => {
@@ -350,6 +398,52 @@ export const AdvancedTab: React.FC<TabProps> = ({
                                 <div className="flex items-center gap-2 text-xs font-medium text-gray-500">
                                     <Loader2 className="h-3.5 w-3.5 animate-spin" />
                                     Loading database location...
+                                </div>
+                            )}
+                        </div>
+
+                        <div className="p-6 space-y-3">
+                            <div className="flex items-start justify-between gap-4">
+                                <div>
+                                    <div className="text-sm font-bold text-gray-900 dark:text-gray-200">App Logs</div>
+                                    <div className="text-xs text-gray-500 mt-1">
+                                        Runtime logs are written to Ambit's app log folder for support investigations.
+                                    </div>
+                                </div>
+                                <div className="flex flex-col gap-2 sm:flex-row">
+                                    <button
+                                        type="button"
+                                        onClick={() => void handleShowAppLogFolder()}
+                                        className="px-3 py-2 bg-gray-100 dark:bg-white/10 hover:bg-gray-200 dark:hover:bg-white/20 text-gray-700 dark:text-gray-200 rounded-lg text-xs font-bold transition-all flex items-center justify-center gap-2 whitespace-nowrap"
+                                    >
+                                        <FolderOpen className="w-3.5 h-3.5" /> Show Logs Folder
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => void handleCopyDiagnostics()}
+                                        disabled={!dbDiagnostics}
+                                        className="px-3 py-2 bg-gray-100 dark:bg-white/10 hover:bg-gray-200 dark:hover:bg-white/20 text-gray-700 dark:text-gray-200 rounded-lg text-xs font-bold transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                                    >
+                                        <Copy className="w-3.5 h-3.5" /> Copy Diagnostics
+                                    </button>
+                                </div>
+                            </div>
+
+                            {dbDiagnostics ? (
+                                <div className="rounded-lg bg-gray-50 p-3 text-xs dark:bg-black/20">
+                                    <div className="font-bold uppercase tracking-wider text-gray-400">App log file</div>
+                                    <div className="mt-1 break-all font-mono text-gray-700 dark:text-gray-300">
+                                        {dbDiagnostics.appLogPath}
+                                    </div>
+                                </div>
+                            ) : dbDiagnosticsError ? (
+                                <div className="rounded-lg border border-rose-200 bg-rose-50 p-3 text-xs font-medium text-rose-800 dark:border-rose-400/20 dark:bg-rose-500/10 dark:text-rose-200">
+                                    Could not load app log location: {dbDiagnosticsError}
+                                </div>
+                            ) : (
+                                <div className="flex items-center gap-2 text-xs font-medium text-gray-500">
+                                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                    Loading app log location...
                                 </div>
                             )}
                         </div>

--- a/src/features/settings/components/__tests__/AdvancedTab.test.tsx
+++ b/src/features/settings/components/__tests__/AdvancedTab.test.tsx
@@ -6,6 +6,8 @@ import { AdvancedTab } from '../AdvancedTab';
 
 const addToastMock = vi.hoisted(() => vi.fn());
 const getDbDiagnosticsMock = vi.hoisted(() => vi.fn());
+const showAppLogFolderMock = vi.hoisted(() => vi.fn());
+const clipboardWriteTextMock = vi.hoisted(() => vi.fn());
 const libraryContextMock = vi.hoisted(() => ({
     setSettings: vi.fn(),
     cleanLibrary: vi.fn().mockResolvedValue(undefined),
@@ -28,6 +30,7 @@ vi.mock('../BackupSettings', () => ({
 vi.mock('../../../../bindings', () => ({
     commands: {
         getDbDiagnostics: getDbDiagnosticsMock,
+        showAppLogFolder: showAppLogFolderMock,
     },
 }));
 
@@ -68,6 +71,14 @@ const renderAdvanced = (settings = createSettings(), onClose = vi.fn(), onNaviga
 describe('AdvancedTab', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        Object.defineProperty(navigator, 'clipboard', {
+            value: {
+                writeText: clipboardWriteTextMock,
+            },
+            configurable: true,
+        });
+        clipboardWriteTextMock.mockResolvedValue(undefined);
+        showAppLogFolderMock.mockResolvedValue({ status: 'ok', data: null });
         getDbDiagnosticsMock.mockResolvedValue({
             status: 'ok',
             data: {
@@ -75,6 +86,8 @@ describe('AdvancedTab', () => {
                 activeDbPath: 'C:\\Users\\AmbitTester\\AppData\\Local\\io.github.asuraace.ambit\\images.db',
                 localDbPath: 'C:\\Users\\AmbitTester\\AppData\\Local\\io.github.asuraace.ambit\\images.db',
                 roamingDbPath: 'C:\\Users\\AmbitTester\\AppData\\Roaming\\io.github.asuraace.ambit\\images.db',
+                appLogDir: 'C:\\Users\\AmbitTester\\AppData\\Roaming\\io.github.asuraace.ambit\\logs',
+                appLogPath: 'C:\\Users\\AmbitTester\\AppData\\Roaming\\io.github.asuraace.ambit\\logs\\Ambit.log',
                 isUsingRoamingFallback: false,
                 imageCount: 12,
                 deletedCount: 1,
@@ -119,6 +132,60 @@ describe('AdvancedTab', () => {
             expect(screen.getByText('Legacy Roaming fallback')).not.toBeNull();
             expect(screen.getAllByText(/AppData\\Local\\io\.github\.asuraace\.ambit\\images\.db/)).toHaveLength(2);
         });
+    });
+
+    it('renders app log location and reveals only the backend-resolved logs folder', async () => {
+        renderAdvanced();
+
+        fireEvent.click(screen.getByRole('button', { name: /support/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('App Logs')).not.toBeNull();
+            expect(screen.getByText(/Ambit\.log/)).not.toBeNull();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /show logs folder/i }));
+
+        await waitFor(() => {
+            expect(showAppLogFolderMock).toHaveBeenCalledWith();
+            expect(addToastMock).toHaveBeenCalledWith('Opened app logs folder', 'success');
+        });
+    });
+
+    it('shows a failure toast when the logs folder cannot be revealed', async () => {
+        showAppLogFolderMock.mockResolvedValue({ status: 'error', error: 'folder unavailable' });
+        renderAdvanced();
+
+        fireEvent.click(screen.getByRole('button', { name: /support/i }));
+        fireEvent.click(screen.getByRole('button', { name: /show logs folder/i }));
+
+        await waitFor(() => {
+            expect(addToastMock).toHaveBeenCalledWith('Failed to open app logs folder', 'error');
+        });
+    });
+
+    it('copies support diagnostics without image metadata or secret fields', async () => {
+        renderAdvanced(createSettings({ logLevel: 'warn' }));
+
+        fireEvent.click(screen.getByRole('button', { name: /support/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText(/Ambit\.log/)).not.toBeNull();
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /copy diagnostics/i }));
+
+        await waitFor(() => {
+            expect(clipboardWriteTextMock).toHaveBeenCalledOnce();
+            expect(addToastMock).toHaveBeenCalledWith('Diagnostics copied to clipboard', 'success');
+        });
+
+        const payload = clipboardWriteTextMock.mock.calls[0][0] as string;
+        expect(payload).toContain('Ambit Support Diagnostics');
+        expect(payload).toContain('Console log level: warn');
+        expect(payload).toContain('App log file: C:\\Users\\AmbitTester\\AppData\\Roaming\\io.github.asuraace.ambit\\logs\\Ambit.log');
+        expect(payload).toContain('Images: 12');
+        expect(payload).not.toMatch(/prompt|metadata_json|api[_-]?key|secret/i);
     });
 
     it('warns when debug logging is selected', () => {


### PR DESCRIPTION
## Summary
- expose the app log directory and default log file in Support Diagnostics
- add a backend-safe Show Logs Folder command that resolves the log folder internally
- add Copy Diagnostics with version, log level, database paths/counts, and log paths only
- document the support log location workflow

## Validation
- node_modules\.bin\vitest.cmd run src/features/settings/components/__tests__/AdvancedTab.test.tsx
- corepack pnpm run bindings:generate
- corepack pnpm run typecheck
- corepack pnpm run test:rust
- cargo fmt --manifest-path src-tauri\Cargo.toml --check
- git diff --check

## Notes
The log reveal command takes no frontend path argument, so it cannot be redirected to arbitrary filesystem targets. The copied diagnostics payload is built from support paths and aggregate counts, not prompts, image metadata, or secrets.