### PR TITLE
feat: add ComfyUI parser diagnostics

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,7 @@ pub fn create_builder() -> tauri_specta::Builder<tauri::Wry> {
         // metadata commands
         metadata::civitai::import_a1111_cache,
         metadata::civitai::resolve_hashes_online,
+        metadata::comfyui::inspect_comfyui_metadata_chunks,
         metadata::models::clear_model_cache,
         metadata::models::cancel_model_resolution,
         metadata::models::cancel_model_discovery,

--- a/src-tauri/src/metadata/comfyui/mod.rs
+++ b/src-tauri/src/metadata/comfyui/mod.rs
@@ -1,5 +1,5 @@
 use super::ImageMetadata;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 mod conditioning;
 mod diagnostics;
@@ -14,13 +14,139 @@ mod strategies;
 #[cfg(test)]
 mod tests;
 
-use self::diagnostics::{ComfyMetadataSnapshot, ComfyParseDiagnostics, ComfyParseLayer};
+use self::diagnostics::{
+    ComfyMetadataField, ComfyMetadataSnapshot, ComfyParseDiagnostics, ComfyParseLayer,
+};
 use self::evaluator::ComfyEvaluator;
 use self::graph::ComfyGraph;
 use self::strategies::{global_scan, scan_explicit_nodes};
 
 pub fn extract_comfyui_metadata(chunks: &HashMap<String, String>) -> ImageMetadata {
     extract_comfyui_metadata_with_diagnostics(chunks).0
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ComfyMetadataPreview {
+    pub tool: String,
+    pub model: String,
+    pub seed: Option<i64>,
+    pub steps: u32,
+    pub cfg: f32,
+    pub sampler: String,
+    pub positive_prompt: String,
+    pub negative_prompt: String,
+    pub loras: Vec<String>,
+    pub control_nets: Vec<String>,
+    pub ip_adapters: Vec<String>,
+    pub embeddings: Vec<String>,
+    pub hypernetworks: Vec<String>,
+    pub generation_type: String,
+    pub has_workflow_hint: bool,
+    pub has_workflow_json: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ComfyParserDiagnosticsReport {
+    pub chunk_keys: Vec<String>,
+    pub has_prompt_chunk: bool,
+    pub has_workflow_chunk: bool,
+    pub graph_node_count: usize,
+    pub attempted_layers: Vec<String>,
+    pub field_sources: BTreeMap<String, String>,
+    pub metadata: ComfyMetadataPreview,
+}
+
+#[tauri::command(rename_all = "camelCase")]
+#[specta::specta]
+pub async fn inspect_comfyui_metadata_chunks(
+    chunks: HashMap<String, String>,
+) -> Result<ComfyParserDiagnosticsReport, String> {
+    Ok(build_comfyui_diagnostics_report(&chunks))
+}
+
+pub(crate) fn build_comfyui_diagnostics_report(
+    chunks: &HashMap<String, String>,
+) -> ComfyParserDiagnosticsReport {
+    let (metadata, diagnostics) = extract_comfyui_metadata_with_diagnostics(chunks);
+    let mut chunk_keys: Vec<String> = chunks.keys().cloned().collect();
+    chunk_keys.sort();
+
+    ComfyParserDiagnosticsReport {
+        chunk_keys,
+        has_prompt_chunk: chunks.contains_key("prompt"),
+        has_workflow_chunk: chunks.contains_key("workflow"),
+        graph_node_count: diagnostics.graph_node_count,
+        attempted_layers: diagnostics
+            .attempted_layers
+            .iter()
+            .map(|layer| parse_layer_label(*layer).to_string())
+            .collect(),
+        field_sources: diagnostics
+            .field_sources
+            .iter()
+            .map(|(field, layer)| {
+                (
+                    metadata_field_label(*field).to_string(),
+                    parse_layer_label(*layer).to_string(),
+                )
+            })
+            .collect(),
+        metadata: ComfyMetadataPreview::from_metadata(&metadata),
+    }
+}
+
+impl ComfyMetadataPreview {
+    fn from_metadata(metadata: &ImageMetadata) -> Self {
+        Self {
+            tool: metadata.tool.clone(),
+            model: metadata.model.clone(),
+            seed: metadata.seed,
+            steps: metadata.steps,
+            cfg: metadata.cfg,
+            sampler: metadata.sampler.clone(),
+            positive_prompt: metadata.positive_prompt.clone(),
+            negative_prompt: metadata.negative_prompt.clone(),
+            loras: metadata.loras.clone(),
+            control_nets: metadata.control_nets.clone(),
+            ip_adapters: metadata.ip_adapters.clone(),
+            embeddings: metadata.embeddings.clone(),
+            hypernetworks: metadata.hypernetworks.clone(),
+            generation_type: metadata.generation_type.clone(),
+            has_workflow_hint: metadata.has_workflow_hint,
+            has_workflow_json: metadata.workflow_json.is_some(),
+        }
+    }
+}
+
+fn parse_layer_label(layer: ComfyParseLayer) -> &'static str {
+    match layer {
+        ComfyParseLayer::WorkflowChunk => "workflow_chunk",
+        ComfyParseLayer::ExplicitNode => "explicit_node",
+        ComfyParseLayer::SamplerTraversal => "sampler_traversal",
+        ComfyParseLayer::SamplerFallback => "sampler_fallback",
+        ComfyParseLayer::GlobalScan => "global_scan",
+    }
+}
+
+fn metadata_field_label(field: ComfyMetadataField) -> &'static str {
+    match field {
+        ComfyMetadataField::Model => "model",
+        ComfyMetadataField::Seed => "seed",
+        ComfyMetadataField::Steps => "steps",
+        ComfyMetadataField::Cfg => "cfg",
+        ComfyMetadataField::Sampler => "sampler",
+        ComfyMetadataField::PositivePrompt => "positive_prompt",
+        ComfyMetadataField::NegativePrompt => "negative_prompt",
+        ComfyMetadataField::Loras => "loras",
+        ComfyMetadataField::ControlNets => "control_nets",
+        ComfyMetadataField::IpAdapters => "ip_adapters",
+        ComfyMetadataField::Embeddings => "embeddings",
+        ComfyMetadataField::Hypernetworks => "hypernetworks",
+        ComfyMetadataField::WorkflowJson => "workflow_json",
+        ComfyMetadataField::WorkflowHint => "workflow_hint",
+    }
 }
 
 pub(crate) fn extract_comfyui_metadata_with_diagnostics(

--- a/src-tauri/src/metadata/comfyui/strategies.rs
+++ b/src-tauri/src/metadata/comfyui/strategies.rs
@@ -4,7 +4,17 @@ use super::parse_helper::parse_a1111_parameters;
 use crate::metadata::guidance::GuidanceClassifier;
 use crate::metadata::ImageMetadata;
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::collections::HashSet;
+
+fn compare_node_ids(left_id: &str, right_id: &str) -> Ordering {
+    match (left_id.parse::<u64>(), right_id.parse::<u64>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right).then_with(|| left_id.cmp(right_id)),
+        (Ok(_), Err(_)) => Ordering::Less,
+        (Err(_), Ok(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => left_id.cmp(right_id),
+    }
+}
 
 /// Layer 2: Explicit Metadata Nodes
 /// Scans for nodes specifically designed to embed metadata.
@@ -13,12 +23,7 @@ pub fn scan_explicit_nodes(graph: &ComfyGraph) -> Option<ImageMetadata> {
     let mut found = false;
 
     let mut nodes: Vec<(&String, &Value)> = graph.nodes().iter().collect();
-    nodes.sort_by(|(left_id, _), (right_id, _)| {
-        match (left_id.parse::<u64>(), right_id.parse::<u64>()) {
-            (Ok(left), Ok(right)) => left.cmp(&right),
-            _ => left_id.cmp(right_id),
-        }
-    });
+    nodes.sort_by(|(left_id, _), (right_id, _)| compare_node_ids(left_id, right_id));
 
     for (id, node) in nodes {
         let t = get_node_type(node);
@@ -109,7 +114,6 @@ pub fn scan_explicit_nodes(graph: &ComfyGraph) -> Option<ImageMetadata> {
                 }
             }
         }
-
     }
 
     if found {
@@ -219,12 +223,7 @@ pub fn global_scan(graph: &ComfyGraph) -> ImageMetadata {
     // Generic model discovery is fallback evidence only. Text metadata can be
     // more intentional than an arbitrary disconnected loader node.
     let mut model_nodes: Vec<(&String, &Value)> = graph.nodes().iter().collect();
-    model_nodes.sort_by(|(left_id, _), (right_id, _)| {
-        match (left_id.parse::<u64>(), right_id.parse::<u64>()) {
-            (Ok(left), Ok(right)) => left.cmp(&right),
-            _ => left_id.cmp(right_id),
-        }
-    });
+    model_nodes.sort_by(|(left_id, _), (right_id, _)| compare_node_ids(left_id, right_id));
 
     for (_id, node) in model_nodes {
         if meta.model != "Unknown" && !meta.model.is_empty() && meta.model != "None" {

--- a/src-tauri/src/metadata/comfyui/tests/diagnostics.rs
+++ b/src-tauri/src/metadata/comfyui/tests/diagnostics.rs
@@ -1,6 +1,7 @@
 use super::super::diagnostics::{ComfyMetadataField, ComfyParseLayer};
 use crate::metadata::comfyui::{
-    extract_comfyui_metadata, extract_comfyui_metadata_with_diagnostics,
+    build_comfyui_diagnostics_report, extract_comfyui_metadata,
+    extract_comfyui_metadata_with_diagnostics,
 };
 use std::collections::HashMap;
 
@@ -234,4 +235,96 @@ fn test_public_extractor_matches_diagnostic_helper_metadata() {
 
     assert_eq!(diagnostic_meta, public_meta);
     assert!(diagnostics.graph_node_count > 0);
+}
+
+#[test]
+fn test_diagnostics_report_serializes_chunk_summary_and_field_sources() {
+    let prompt = r#"{
+        "3": {
+            "class_type": "KSampler",
+            "inputs": {
+                "cfg": 7.0,
+                "model": ["4", 0],
+                "positive": ["6", 0],
+                "seed": 12345,
+                "steps": 25,
+                "sampler_name": "euler",
+                "scheduler": "simple"
+            }
+        },
+        "4": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": { "ckpt_name": "diagnostic-model.safetensors" }
+        },
+        "6": {
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": "diagnostic prompt" }
+        },
+        "8": {
+            "class_type": "VAEDecode",
+            "inputs": { "samples": ["3", 0] }
+        },
+        "9": {
+            "class_type": "SaveImage",
+            "inputs": { "images": ["8", 0] }
+        }
+    }"#;
+    let workflow = r#"{"nodes":[]}"#;
+    let mut chunks = chunks_with_prompt(prompt);
+    chunks.insert("workflow".to_string(), workflow.to_string());
+
+    let report = build_comfyui_diagnostics_report(&chunks);
+
+    assert_eq!(report.chunk_keys, vec!["prompt", "workflow"]);
+    assert!(report.has_prompt_chunk);
+    assert!(report.has_workflow_chunk);
+    assert_eq!(report.graph_node_count, 5);
+    assert_eq!(report.metadata.model, "diagnostic_model");
+    assert_eq!(report.metadata.seed, Some(12345));
+    assert_eq!(report.metadata.steps, 25);
+    assert_eq!(report.metadata.cfg, 7.0);
+    assert_eq!(report.metadata.sampler, "euler (simple)");
+    assert_eq!(report.metadata.positive_prompt, "diagnostic prompt");
+    assert!(report.metadata.has_workflow_json);
+    assert!(report.metadata.has_workflow_hint);
+    assert_eq!(
+        report.attempted_layers,
+        vec!["workflow_chunk", "explicit_node", "sampler_traversal"]
+    );
+    assert_eq!(
+        report
+            .field_sources
+            .get("workflow_json")
+            .map(String::as_str),
+        Some("workflow_chunk")
+    );
+    assert_eq!(
+        report.field_sources.get("model").map(String::as_str),
+        Some("sampler_traversal")
+    );
+    assert_eq!(
+        report
+            .field_sources
+            .get("positive_prompt")
+            .map(String::as_str),
+        Some("sampler_traversal")
+    );
+}
+
+#[test]
+fn test_diagnostics_report_handles_non_graph_chunks_without_panicking() {
+    let mut chunks = HashMap::new();
+    chunks.insert("parameters".to_string(), "not a comfy graph".to_string());
+
+    let report = build_comfyui_diagnostics_report(&chunks);
+
+    assert_eq!(report.chunk_keys, vec!["parameters"]);
+    assert!(!report.has_prompt_chunk);
+    assert!(!report.has_workflow_chunk);
+    assert_eq!(report.graph_node_count, 0);
+    assert!(report.attempted_layers.is_empty());
+    assert!(report.field_sources.is_empty());
+    assert_eq!(report.metadata.tool, "ComfyUI");
+    assert_eq!(report.metadata.model, "Unknown");
+    assert!(!report.metadata.has_workflow_json);
 }

--- a/src-tauri/src/metadata/comfyui/tests/strategies.rs
+++ b/src-tauri/src/metadata/comfyui/tests/strategies.rs
@@ -130,3 +130,44 @@ fn test_extract_comfyui_wireless_titled_nodes() {
     assert_eq!(meta.positive_prompt, "landscape, sunset");
     assert_eq!(meta.negative_prompt, "ugly hands");
 }
+
+#[test]
+fn test_mixed_numeric_and_subgraph_node_ids_do_not_panic() {
+    // Official templates and expanded subgraphs can mix plain numeric ids with
+    // subgraph/custom ids. Fallback scans must sort those ids with one total
+    // order so background metadata refresh cannot panic while parsing them.
+    let prompt = r#"{
+        "10a": {
+            "class_type": "String",
+            "inputs": { "STRING": "decorative subgraph text" }
+        },
+        "2": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": { "ckpt_name": "base.safetensors" }
+        },
+        "10": {
+            "class_type": "KSampler",
+            "inputs": {
+                "cfg": 3.5,
+                "seed": 42,
+                "steps": 12,
+                "sampler_name": "euler",
+                "scheduler": "simple"
+            }
+        },
+        "30:19": {
+            "class_type": "String",
+            "inputs": { "STRING": "subgraph prompt" }
+        }
+    }"#;
+
+    let mut chunks = HashMap::new();
+    chunks.insert("prompt".to_string(), prompt.to_string());
+
+    let meta = extract_comfyui_metadata(&chunks);
+
+    assert_eq!(meta.tool, "ComfyUI");
+    assert_eq!(meta.model, "base");
+    assert_eq!(meta.steps, 12);
+    assert_eq!(meta.seed, Some(42));
+}

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -18,7 +18,7 @@ pub use parsers::{extract_png_chunks, scan_jpeg_metadata, scan_webp_metadata};
 /// Current parser version. Increment when any parser logic changes.
 /// Images with parser_version < CURRENT_PARSER_VERSION will be queued
 /// for background re-parsing from their stored original_metadata_json.
-pub const CURRENT_PARSER_VERSION: u32 = 9;
+pub const CURRENT_PARSER_VERSION: u32 = 10;
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, specta::Type, PartialEq)]
 pub struct ImageMetadata {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -456,6 +456,14 @@ async resolveHashesOnline(skipHarvest: boolean) : Promise<Result<ResolutionResul
     else return { status: "error", error: e  as any };
 }
 },
+async inspectComfyuiMetadataChunks(chunks: Partial<{ [key in string]: string }>) : Promise<Result<ComfyParserDiagnosticsReport, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("inspect_comfyui_metadata_chunks", { chunks }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async clearModelCache() : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("clear_model_cache") };
@@ -565,6 +573,8 @@ async getInvokeDbSnapshot(rootPath: string) : Promise<Result<InvokeDbSnapshot, s
 export type A1111DiscoveryCandidate = { path: string; name: string; imageCount: number; inferredType: string; isPriority: boolean; variant: string }
 export type A1111DiscoveryResult = { detectedVariant: string; candidates: A1111DiscoveryCandidate[]; logs: string[]; warnings: string[] }
 export type BackupInfo = { name: string; path: string; createdAt: string; sizeBytes: number }
+export type ComfyMetadataPreview = { tool: string; model: string; seed: number | null; steps: number; cfg: number; sampler: string; positivePrompt: string; negativePrompt: string; loras: string[]; controlNets: string[]; ipAdapters: string[]; embeddings: string[]; hypernetworks: string[]; generationType: string; hasWorkflowHint: boolean; hasWorkflowJson: boolean }
+export type ComfyParserDiagnosticsReport = { chunkKeys: string[]; hasPromptChunk: boolean; hasWorkflowChunk: boolean; graphNodeCount: number; attemptedLayers: string[]; fieldSources: Partial<{ [key in string]: string }>; metadata: ComfyMetadataPreview }
 export type DbDiagnostics = { dbPath: string; activeDbPath: string; localDbPath: string; roamingDbPath: string; appLogDir: string; appLogPath: string; isUsingRoamingFallback: boolean; imageCount: number; deletedCount: number; modelCount: number; cacheCount: number; toolNullCount: number }
 export type FacetResourceTouches = { checkpoints: string[]; loras: string[]; embeddings: string[]; hypernetworks: string[]; controlNets: string[]; ipAdapters: string[]; tools: string[] }
 export type FileEntry = { path: string; modified: number; size: number }

--- a/src/features/viewer/components/WorkflowInspector.tsx
+++ b/src/features/viewer/components/WorkflowInspector.tsx
@@ -1,10 +1,12 @@
 
 import * as React from 'react';
 import { useMemo, useState } from 'react';
-import { Box, Workflow, Search, ChevronDown, ChevronRight, Copy, Check, Download } from 'lucide-react';
+import { Box, Workflow, Search, ChevronDown, ChevronRight, Copy, Check, Download, Activity } from 'lucide-react';
 import { AIImage } from '../../../types';
 import { scanImageWorkflow } from '../../../services/metadataParser';
 import { updateImageWorkflow, updateImageWorkflowHint } from '../../../services/db/imageRepo';
+import { commands, type ComfyParserDiagnosticsReport } from '../../../bindings';
+import { useSettingsStore } from '../../../stores/settingsStore';
 import {
     isWorkflowGraph,
     selectWorkflowGraphSource,
@@ -16,6 +18,139 @@ interface WorkflowInspectorProps {
     image: AIImage;
     onWorkflowLoaded?: (workflowJson: string) => void;
 }
+
+const formatDiagnosticLabel = (value: string) =>
+    value.replace(/_/g, ' ').replace(/\b\w/g, (char) => char.toUpperCase());
+
+const formatDiagnosticValue = (value: string | number | null | undefined) =>
+    value === null || value === undefined || value === '' ? 'None' : String(value);
+
+const ComfyDiagnosticsPanel: React.FC<{
+    imageId: string;
+    chunks?: Record<string, string>;
+}> = ({ imageId, chunks }) => {
+    const [diagnostics, setDiagnostics] = useState<ComfyParserDiagnosticsReport | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const chunkCount = chunks ? Object.keys(chunks).length : 0;
+
+    React.useEffect(() => {
+        if (!chunks || chunkCount === 0) {
+            setDiagnostics(null);
+            setError(null);
+            setIsLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+        setIsLoading(true);
+        setError(null);
+
+        commands.inspectComfyuiMetadataChunks(chunks)
+            .then((result) => {
+                if (cancelled) return;
+                if (result.status === 'ok') {
+                    setDiagnostics(result.data);
+                } else {
+                    setDiagnostics(null);
+                    setError(result.error);
+                }
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setDiagnostics(null);
+                setError(err instanceof Error ? err.message : String(err));
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [chunks, chunkCount, imageId]);
+
+    const fieldSources = diagnostics
+        ? Object.entries(diagnostics.fieldSources).sort(([a], [b]) => a.localeCompare(b))
+        : [];
+
+    return (
+        <div className="rounded-xl border border-amber-200 dark:border-amber-500/20 bg-amber-50/70 dark:bg-amber-500/10 p-3 text-xs">
+            <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 font-bold text-amber-900 dark:text-amber-300">
+                    <Activity className="w-3.5 h-3.5" />
+                    Parser Diagnostics
+                </div>
+                {diagnostics && (
+                    <span className="font-mono text-[10px] text-amber-800/70 dark:text-amber-300/70">
+                        {diagnostics.graphNodeCount} nodes
+                    </span>
+                )}
+            </div>
+
+            {!chunks || chunkCount === 0 ? (
+                <div className="mt-2 text-amber-800/70 dark:text-amber-200/70">Raw chunks unavailable.</div>
+            ) : isLoading ? (
+                <div className="mt-2 text-amber-800/70 dark:text-amber-200/70">Loading diagnostics...</div>
+            ) : error ? (
+                <div className="mt-2 text-rose-700 dark:text-rose-300">Diagnostics unavailable: {error}</div>
+            ) : diagnostics ? (
+                <div className="mt-3 space-y-3 text-amber-950 dark:text-amber-100">
+                    <div className="grid grid-cols-2 gap-2">
+                        <div>
+                            <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Chunks</div>
+                            <div className="font-mono break-all">{diagnostics.chunkKeys.join(', ') || 'None'}</div>
+                        </div>
+                        <div>
+                            <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Layers</div>
+                            <div className="font-mono break-all">{diagnostics.attemptedLayers.join(' -> ') || 'None'}</div>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-2">
+                        <div>
+                            <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Model</div>
+                            <div className="font-mono break-all">{formatDiagnosticValue(diagnostics.metadata.model)}</div>
+                        </div>
+                        <div>
+                            <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Sampler</div>
+                            <div className="font-mono break-all">{formatDiagnosticValue(diagnostics.metadata.sampler)}</div>
+                        </div>
+                        <div>
+                            <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Seed</div>
+                            <div className="font-mono break-all">{formatDiagnosticValue(diagnostics.metadata.seed)}</div>
+                        </div>
+                        <div>
+                            <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Steps / CFG</div>
+                            <div className="font-mono break-all">{diagnostics.metadata.steps} / {diagnostics.metadata.cfg}</div>
+                        </div>
+                    </div>
+
+                    <div>
+                        <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Positive Prompt</div>
+                        <div className="font-mono line-clamp-3 break-words">{formatDiagnosticValue(diagnostics.metadata.positivePrompt)}</div>
+                    </div>
+
+                    <div>
+                        <div className="text-[10px] uppercase font-bold text-amber-800/60 dark:text-amber-200/60">Field Sources</div>
+                        <div className="mt-1 flex flex-wrap gap-1.5">
+                            {fieldSources.length > 0 ? fieldSources.map(([field, layer]) => (
+                                <span
+                                    key={field}
+                                    className="rounded-md border border-amber-300/70 dark:border-amber-400/20 bg-white/70 dark:bg-black/20 px-1.5 py-0.5 font-mono text-[10px]"
+                                >
+                                    {formatDiagnosticLabel(field)}: {formatDiagnosticLabel(layer ?? '')}
+                                </span>
+                            )) : (
+                                <span className="text-amber-800/70 dark:text-amber-200/70">None</span>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+};
 
 const WorkflowNode: React.FC<{ title: string; type: string; inputs: WorkflowInputs }> = ({ title, type, inputs }) => {
     const [isExpanded, setIsExpanded] = useState(false);
@@ -69,6 +204,8 @@ export const WorkflowInspector: React.FC<WorkflowInspectorProps> = ({ image, onW
     const [localWorkflow, setLocalWorkflow] = useState<string | undefined>(image.metadata.workflowJson);
     const [isLoading, setIsLoading] = useState(false);
     const hasAttempted = React.useRef<string | null>(null);
+    const showParserDiagnostics = useSettingsStore((state) => state.settings.devMode === true)
+        && image.metadata.tool === 'ComfyUI';
     const originalWorkflow = image.originalChunks?.workflow;
     const originalPrompt = image.originalChunks?.prompt;
     const originalChunks = useMemo(() => ({
@@ -227,6 +364,10 @@ export const WorkflowInspector: React.FC<WorkflowInspectorProps> = ({ image, onW
                             className="w-full bg-white dark:bg-zinc-800 border border-gray-200 dark:border-white/10 rounded-xl py-2 pl-9 pr-3 text-xs focus:border-sage-500 focus:ring-1 focus:ring-sage-500/20 outline-none transition-all text-gray-700 dark:text-gray-200"
                         />
                     </div>
+                )}
+
+                {showParserDiagnostics && (
+                    <ComfyDiagnosticsPanel imageId={image.id} chunks={image.originalChunks} />
                 )}
             </div>
 

--- a/src/features/viewer/components/__tests__/WorkflowInspector.test.tsx
+++ b/src/features/viewer/components/__tests__/WorkflowInspector.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GeneratorTool, type AIImage } from '../../../../types';
+import { WorkflowInspector } from '../WorkflowInspector';
+
+const mockInspectComfyuiMetadataChunks = vi.hoisted(() => vi.fn());
+const mockSettings = vi.hoisted(() => ({ devMode: true }));
+
+vi.mock('../../../../bindings', () => ({
+    commands: {
+        inspectComfyuiMetadataChunks: (...args: unknown[]) => mockInspectComfyuiMetadataChunks(...args)
+    }
+}));
+
+vi.mock('../../../../stores/settingsStore', () => ({
+    useSettingsStore: (selector: (state: { settings: { devMode: boolean } }) => unknown) =>
+        selector({ settings: { devMode: mockSettings.devMode } })
+}));
+
+vi.mock('../../../../services/metadataParser', () => ({
+    scanImageWorkflow: vi.fn()
+}));
+
+vi.mock('../../../../services/db/imageRepo', () => ({
+    updateImageWorkflow: vi.fn(),
+    updateImageWorkflowHint: vi.fn()
+}));
+
+const workflowJson = JSON.stringify({
+    nodes: [
+        {
+            id: 9,
+            type: 'SaveImage',
+            inputs: [{ name: 'images', link: 1 }]
+        }
+    ]
+});
+
+const promptJson = JSON.stringify({
+    '3': {
+        class_type: 'KSampler',
+        inputs: { steps: 8, cfg: 1, sampler_name: 'euler' }
+    },
+    '9': {
+        class_type: 'SaveImage',
+        inputs: { images: ['3', 0] }
+    }
+});
+
+const diagnosticsReport = {
+    chunkKeys: ['prompt', 'workflow'],
+    hasPromptChunk: true,
+    hasWorkflowChunk: true,
+    graphNodeCount: 2,
+    attemptedLayers: ['workflow_chunk', 'sampler_traversal'],
+    fieldSources: {
+        model: 'sampler_traversal',
+        positive_prompt: 'sampler_traversal',
+        workflow_json: 'workflow_chunk'
+    },
+    metadata: {
+        tool: 'ComfyUI',
+        model: 'diagnostic_model',
+        seed: 123,
+        steps: 8,
+        cfg: 1,
+        sampler: 'euler (simple)',
+        positivePrompt: 'diagnostic prompt',
+        negativePrompt: '',
+        loras: [],
+        controlNets: [],
+        ipAdapters: [],
+        embeddings: [],
+        hypernetworks: [],
+        generationType: 'txt2img',
+        hasWorkflowHint: true,
+        hasWorkflowJson: true
+    }
+};
+
+const makeImage = (tool: GeneratorTool = GeneratorTool.COMFYUI): AIImage => ({
+    id: 'C:/library/comfy.png',
+    url: 'asset://comfy.png',
+    thumbnailUrl: 'asset://thumb.webp',
+    filename: 'comfy.png',
+    timestamp: 1,
+    width: 512,
+    height: 512,
+    isFavorite: false,
+    metadata: {
+        tool,
+        model: 'diagnostic_model',
+        seed: 123,
+        steps: 8,
+        cfg: 1,
+        sampler: 'euler (simple)',
+        positivePrompt: 'diagnostic prompt',
+        negativePrompt: '',
+        workflowJson,
+        hasWorkflowHint: true
+    },
+    originalChunks: {
+        workflow: workflowJson,
+        prompt: promptJson
+    }
+});
+
+describe('WorkflowInspector ComfyUI parser diagnostics', () => {
+    beforeEach(() => {
+        mockSettings.devMode = true;
+        mockInspectComfyuiMetadataChunks.mockReset();
+        mockInspectComfyuiMetadataChunks.mockResolvedValue({
+            status: 'ok',
+            data: diagnosticsReport
+        });
+    });
+
+    it('renders parser diagnostics for ComfyUI images in developer mode', async () => {
+        render(<WorkflowInspector image={makeImage()} />);
+
+        expect(await screen.findByText('Parser Diagnostics')).toBeTruthy();
+        expect(screen.getByText('diagnostic_model')).toBeTruthy();
+        expect(screen.getAllByText(/Sampler Traversal/i).length).toBeGreaterThan(0);
+        expect(mockInspectComfyuiMetadataChunks).toHaveBeenCalledWith({
+            workflow: workflowJson,
+            prompt: promptJson
+        });
+    });
+
+    it('hides parser diagnostics outside developer mode', () => {
+        mockSettings.devMode = false;
+
+        render(<WorkflowInspector image={makeImage()} />);
+
+        expect(screen.queryByText('Parser Diagnostics')).toBeNull();
+        expect(mockInspectComfyuiMetadataChunks).not.toHaveBeenCalled();
+    });
+
+    it('hides parser diagnostics for non-ComfyUI images', () => {
+        render(<WorkflowInspector image={makeImage(GeneratorTool.AUTOMATIC1111)} />);
+
+        expect(screen.queryByText('Parser Diagnostics')).toBeNull();
+        expect(mockInspectComfyuiMetadataChunks).not.toHaveBeenCalled();
+    });
+
+    it('renders a diagnostics failure without breaking workflow display', async () => {
+        mockInspectComfyuiMetadataChunks.mockResolvedValue({
+            status: 'error',
+            error: 'parse failed'
+        });
+
+        render(<WorkflowInspector image={makeImage()} />);
+
+        expect(screen.getAllByText('SaveImage').length).toBeGreaterThan(0);
+        await waitFor(() => {
+            expect(screen.getByText(/Diagnostics unavailable: parse failed/i)).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- add a Developer Mode ComfyUI parser diagnostics panel in the image viewer
- expose an internal Tauri/Specta diagnostics command for raw ComfyUI chunks
- fix a ComfyUI metadata refresh panic by making mixed node-id sorting a total order

## Why
The diagnostics view makes future ComfyUI metadata gaps easier to debug from real images. While validating this work, we found background refresh could panic when ComfyUI graphs mixed numeric node ids with subgraph/custom ids such as `30:19`; the fallback sorter could violate Rust's total-order requirement.

## Impact
Normal metadata extraction, storage, copy/download behavior, and database schema are unchanged. Developer Mode users get a parser provenance summary for ComfyUI images. Parser version is bumped to `10` so affected images can be reparsed with the crash fix.

## Validation
- `cargo test metadata::comfyui`
- `pnpm run test:run -- src/features/viewer/components/__tests__/WorkflowInspector.test.tsx`
- `pnpm run typecheck`
- `git diff --check`

Note: `cargo fmt --check` still reports pre-existing formatting drift in `src-tauri/src/metadata/comfyui/tests/multi_stage.rs` and `src-tauri/src/metadata/comfyui/tests/official_examples.rs`; touched files for this PR were formatted.