### PR TITLE
fix(deps): update crossbeam-epoch

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1018,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

- update `crossbeam-epoch` from 0.9.18 to 0.9.20 in the Rust lockfile
- clear the newly reported RUSTSEC-2026-0204 dependency audit failure affecting release PR #182

## Root cause

The dependency security workflow began rejecting the existing `crossbeam-epoch` 0.9.18 lockfile entry after RUSTSEC-2026-0204 was published. The crate is resolved transitively through `crossbeam-deque` and `rayon-core`.

## Impact

This restores the Rust dependency audit without changing application code or dependency manifests. Cargo resolves only the patched crate version and checksum.

## Validation

- `node ./scripts/audit-rust.mjs` — passed with 0 unignored vulnerabilities across 797 dependencies
- `cargo test --locked` — 308 tests passed
- `git diff --check` — passed