### PR TITLE
fix: stabilize targeted import ordering

### DIFF
--- a/src/services/__tests__/importService.test.ts
+++ b/src/services/__tests__/importService.test.ts
@@ -109,6 +109,9 @@ describe('processTargetedFiles', () => {
     });
 
     it('returns touched facet types for new and updated live imports', async () => {
+        const nowSpy = vi.spyOn(Date, 'now')
+            .mockReturnValueOnce(1000)
+            .mockReturnValueOnce(2000);
         const result = await processTargetedFiles(
             [
                 'C:/library/updated-image.png',
@@ -116,6 +119,7 @@ describe('processTargetedFiles', () => {
             ],
             { forceRescan: true }
         );
+        nowSpy.mockRestore();
 
         expect(result.stats.imported).toBe(2);
         expect(result.wasCancelled).toBe(false);

--- a/src/services/importService.ts
+++ b/src/services/importService.ts
@@ -863,9 +863,10 @@ export const processTargetedFiles = async (
     if (paths.length === 0) return result;
     const targetedImportStartedAt = liveWatchNow();
 
+    const targetedImportTimestamp = Date.now();
     const entries: FileEntry[] = paths.map(p => ({ 
         path: p, 
-        modified: Date.now(), 
+        modified: targetedImportTimestamp,
         size: 0 // Will be read by rust metadata extractor anyway
     }));
 


### PR DESCRIPTION
## What changed

- assign one synthetic discovery timestamp to a targeted import batch
- add a regression test that forces clock values which previously reversed path order

## Why

`processTargetedFiles` called `Date.now()` once per path and then sorted entries by that synthetic timestamp. When calls crossed a millisecond boundary, the importer reversed caller order and made the coverage suite flaky on otherwise unrelated dependency PRs.

## Impact

Targeted imports now retain caller order when real file modification times are unavailable. Import contents, facet tracking, and persistence behavior are unchanged.

## Validation

- focused import-service test: passed
- focused import-service test repeated 20 times: passed 20/20
- `pnpm run lint`: passed
- `pnpm run typecheck`: passed
- `git diff --check`: passed
- full local coverage: started but exceeded the 240-second command timeout without reporting a test failure; CI remains the authoritative full-suite check