### PR TITLE
feat(updater): show release notes in update dialog

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -40,8 +40,8 @@ jobs:
       - name: verify version consistency
         run: pnpm check:versions
 
-      - name: test release tag guard
-        run: node --test scripts/check-release-tag.node-test.mjs
+      - name: test release automation scripts
+        run: node --test scripts/check-release-tag.node-test.mjs scripts/extract-release-notes.node-test.mjs
 
       - name: install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,20 @@ jobs:
           fi
           rm -f .tmp/updater-signing-smoke-test.txt .tmp/updater-signing-smoke-test.txt.sig
 
+      - name: extract updater release notes
+        id: release-notes
+        shell: pwsh
+        run: |
+          $notes = node ./scripts/extract-release-notes.mjs $env:GITHUB_REF_NAME
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          $delimiter = "ambit_release_notes_$([Guid]::NewGuid().ToString('N'))"
+          "body<<$delimiter" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $notes | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          $delimiter | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # action-v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -100,7 +114,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: "Ambit ${{ github.ref_name }}"
-          releaseBody: "See the assets below to download the latest version of Ambit."
+          releaseBody: ${{ steps.release-notes.outputs.body }}
           releaseDraft: false
           prerelease: false
           updaterJsonPreferNsis: true

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -111,7 +111,7 @@ Use **Actions > updater-signing-preflight > Run workflow** before publishing. Th
 6. Merge the release PR only when a release should be published.
 7. Confirm the generated `vX.Y.Z` tag starts `release.yml`.
 
-The release workflow currently publishes Windows NSIS and MSI artifacts, updater signatures, and `latest.json`. Release tags must use the exact `vX.Y.Z` format, match `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/tauri.dev.json`, and `src-tauri/Cargo.toml`, and point to a commit reachable from `main`.
+The release workflow currently publishes Windows NSIS and MSI artifacts, updater signatures, and `latest.json`. It copies the matching version section from `CHANGELOG.md` into the updater metadata so installed apps can show the same release notes. Release tags must use the exact `vX.Y.Z` format, match `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/tauri.dev.json`, and `src-tauri/Cargo.toml`, and point to a commit reachable from `main`.
 
 Release Please remains the normal and preferred tag creator. Do not create manual release tags except for recovery work after confirming the tag target is already on `main` and all version files match.
 

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const VERSION_RE = /^v?(\d+\.\d+\.\d+)$/;
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+export const extractReleaseNotes = (changelog, versionOrTag) => {
+  const versionMatch = versionOrTag.match(VERSION_RE);
+
+  if (!versionMatch) {
+    throw new Error(`Release version must use X.Y.Z or vX.Y.Z format. Received: ${versionOrTag}`);
+  }
+
+  const version = versionMatch[1];
+  const headingPattern = new RegExp(
+    `^## \\[${escapeRegExp(version)}\\](?:\\([^\\n]+\\))?(?: \\([^\\n]+\\))?\\s*$`,
+    'm',
+  );
+  const headingMatch = headingPattern.exec(changelog);
+
+  if (!headingMatch) {
+    throw new Error(`Could not find release ${version} in CHANGELOG.md.`);
+  }
+
+  const afterHeading = changelog.slice(headingMatch.index + headingMatch[0].length);
+  const nextReleaseIndex = afterHeading.search(/^## \[/m);
+  const notes = afterHeading.slice(0, nextReleaseIndex === -1 ? undefined : nextReleaseIndex).trim();
+
+  if (!notes) {
+    throw new Error(`Release ${version} has no notes in CHANGELOG.md.`);
+  }
+
+  return notes;
+};
+
+const isCli = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCli) {
+  try {
+    const versionOrTag = process.argv[2];
+
+    if (!versionOrTag) {
+      throw new Error('Usage: node scripts/extract-release-notes.mjs <version-or-tag>');
+    }
+
+    const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
+    const notes = extractReleaseNotes(fs.readFileSync(changelogPath, 'utf8'), versionOrTag);
+    console.log(notes);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/scripts/extract-release-notes.node-test.mjs
+++ b/scripts/extract-release-notes.node-test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractReleaseNotes } from './extract-release-notes.mjs';
+
+const changelog = `# Changelog
+
+## [0.8.0](https://github.com/AsuraAce/ambit/compare/v0.7.0...v0.8.0) (2026-07-11)
+
+### Features
+
+* show useful update notes
+
+### Bug Fixes
+
+* preserve the installer flow
+
+## [0.7.0](https://github.com/AsuraAce/ambit/compare/v0.6.4...v0.7.0) (2026-07-10)
+
+### Features
+
+* older change
+`;
+
+test('extracts only the requested release section for updater metadata', () => {
+  assert.equal(
+    extractReleaseNotes(changelog, 'v0.8.0'),
+    `### Features
+
+* show useful update notes
+
+### Bug Fixes
+
+* preserve the installer flow`,
+  );
+});
+
+test('accepts a version without the tag prefix', () => {
+  assert.match(extractReleaseNotes(changelog, '0.7.0'), /older change/);
+});
+
+test('rejects missing and malformed release versions', () => {
+  assert.throws(() => extractReleaseNotes(changelog, 'v0.9.0'), /Could not find release 0\.9\.0/);
+  assert.throws(() => extractReleaseNotes(changelog, 'latest'), /must use X\.Y\.Z or vX\.Y\.Z/);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { AnimatePresence } from 'framer-motion';
 import { AppLayout } from './components/AppLayout';
 import { GlobalModals } from './components/GlobalModals';
 import { AppContextMenu } from './components/ui/AppContextMenu';
-import { UpdateDialog } from './components/ui/UpdateDialog';
 import { OnboardingWizard } from './components/ui/OnboardingWizard';
 import { ImportModal } from './components/ui/ImportModal';
 import { TitleBar } from './components/ui/TitleBar';
@@ -37,6 +36,7 @@ import { useWatchers } from './contexts/WatcherContext';
 import { derivePromptHighlightSpec } from './features/viewer/utils/searchHighlights';
 
 const ImageViewer = React.lazy(() => import('./features/viewer/components/ImageViewer').then(module => ({ default: module.ImageViewer })));
+const UpdateDialog = React.lazy(() => import('./components/ui/UpdateDialog').then(module => ({ default: module.UpdateDialog })));
 
 export default function App() {
     const { addToast } = useToast();
@@ -541,17 +541,19 @@ export default function App() {
             />
 
             {updater.update && (
-                <UpdateDialog
-                    isOpen={updater.isDialogOpen}
-                    currentVersion={appVersion}
-                    availableVersion={updater.update.version}
-                    notes={updater.update.body}
-                    publishedAt={updater.update.date}
-                    status={updater.status}
-                    errorMessage={updater.errorMessage}
-                    onClose={updater.dismissUpdateDialog}
-                    onInstall={updater.installUpdate}
-                />
+                <React.Suspense fallback={null}>
+                    <UpdateDialog
+                        isOpen={updater.isDialogOpen}
+                        currentVersion={appVersion}
+                        availableVersion={updater.update.version}
+                        notes={updater.update.body}
+                        publishedAt={updater.update.date}
+                        status={updater.status}
+                        errorMessage={updater.errorMessage}
+                        onClose={updater.dismissUpdateDialog}
+                        onInstall={updater.installUpdate}
+                    />
+                </React.Suspense>
             )}
 
             <React.Suspense fallback={null}>

--- a/src/components/ui/UpdateDialog.tsx
+++ b/src/components/ui/UpdateDialog.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { AlertTriangle, Download, Loader2, RefreshCw, X } from 'lucide-react';
+import { AlertTriangle, Download, ExternalLink, Loader2, RefreshCw, X } from 'lucide-react';
+import ReactMarkdown, { type Components } from 'react-markdown';
 import { AppUpdaterStatus } from '../../hooks/useAppUpdater';
+import { RELEASES_URL } from '../../constants/support';
+import { openExternalUrl } from '../../utils/externalLinks';
 
 interface UpdateDialogProps {
   availableVersion: string;
@@ -29,6 +32,20 @@ const formatPublishedDate = (publishedAt?: string | null) => {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(parsedDate);
+};
+
+const releaseNotesComponents: Components = {
+  h1: ({ children }) => <h4 className="mb-2 text-base font-bold text-slate-900 dark:text-white">{children}</h4>,
+  h2: ({ children }) => <h4 className="mb-2 text-base font-bold text-slate-900 dark:text-white">{children}</h4>,
+  h3: ({ children }) => <h4 className="mb-2 text-sm font-bold text-slate-900 dark:text-white">{children}</h4>,
+  h4: ({ children }) => <h4 className="mb-2 text-sm font-bold text-slate-900 dark:text-white">{children}</h4>,
+  p: ({ children }) => <p className="mb-3 last:mb-0">{children}</p>,
+  ul: ({ children }) => <ul className="mb-3 list-disc space-y-1 pl-5 last:mb-0">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-3 list-decimal space-y-1 pl-5 last:mb-0">{children}</ol>,
+  strong: ({ children }) => <strong className="font-semibold text-slate-900 dark:text-white">{children}</strong>,
+  code: ({ children }) => <code className="rounded bg-slate-200/70 px-1 py-0.5 text-xs dark:bg-white/10">{children}</code>,
+  a: ({ children }) => <span>{children}</span>,
+  img: () => null,
 };
 
 export const UpdateDialog: React.FC<UpdateDialogProps> = ({
@@ -68,12 +85,16 @@ export const UpdateDialog: React.FC<UpdateDialogProps> = ({
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.96, y: 16 }}
             transition={{ type: 'spring', stiffness: 340, damping: 28 }}
-            className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-white/10 bg-white/95 shadow-[0_32px_80px_-20px_rgba(15,23,42,0.45)] dark:bg-slate-900/95"
+            className="relative flex max-h-[calc(100vh-2rem)] w-full max-w-lg flex-col overflow-hidden rounded-3xl border border-white/10 bg-white/95 shadow-[0_32px_80px_-20px_rgba(15,23,42,0.45)] dark:bg-slate-900/95"
             onClick={(event) => event.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="update-dialog-title"
+            aria-describedby="update-dialog-description"
           >
-            <div className="h-1.5 w-full bg-gradient-to-r from-sage-500 via-emerald-500 to-teal-500" />
+            <div className="h-1.5 w-full shrink-0 bg-gradient-to-r from-sage-500 via-emerald-500 to-teal-500" />
 
-            <div className="p-8">
+            <div className="overflow-y-auto p-8">
               <div className="flex items-start justify-between gap-4">
                 <div className="flex items-start gap-4">
                   <div className="rounded-2xl bg-sage-50 p-3 text-sage-600 shadow-sm dark:bg-sage-500/10 dark:text-sage-300">
@@ -81,10 +102,10 @@ export const UpdateDialog: React.FC<UpdateDialogProps> = ({
                   </div>
                   <div>
                     <p className="text-xs font-black uppercase tracking-[0.22em] text-sage-600 dark:text-sage-300">Update Available</p>
-                    <h3 className="mt-2 text-2xl font-bold tracking-tight text-slate-900 dark:text-white">
+                    <h3 id="update-dialog-title" className="mt-2 text-2xl font-bold tracking-tight text-slate-900 dark:text-white">
                       Ambit {availableVersion}
                     </h3>
-                    <p className="mt-2 max-w-md text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                    <p id="update-dialog-description" className="mt-2 max-w-md text-sm leading-relaxed text-slate-600 dark:text-slate-300">
                       A newer build is ready to install. After you confirm, Ambit will download the update and then restart or close to finish the installation.
                     </p>
                   </div>
@@ -94,6 +115,7 @@ export const UpdateDialog: React.FC<UpdateDialogProps> = ({
                   type="button"
                   onClick={onClose}
                   disabled={isBusy}
+                  aria-label="Close update dialog"
                   className={`rounded-full p-2 text-slate-400 transition-colors hover:bg-black/5 hover:text-slate-700 dark:hover:bg-white/5 dark:hover:text-white ${isBusy ? 'pointer-events-none opacity-0' : ''}`}
                 >
                   <X className="h-4 w-4" />
@@ -122,10 +144,20 @@ export const UpdateDialog: React.FC<UpdateDialogProps> = ({
               </div>
 
               <div className="mt-6">
-                <div className="text-[11px] font-black uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">Release Notes</div>
+                <div className="flex items-center justify-between gap-4">
+                  <div className="text-[11px] font-black uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">What's New</div>
+                  <button
+                    type="button"
+                    onClick={() => void openExternalUrl(RELEASES_URL)}
+                    className="inline-flex items-center gap-1.5 text-xs font-semibold text-sage-700 transition-colors hover:text-sage-900 dark:text-sage-300 dark:hover:text-sage-100"
+                  >
+                    View release on GitHub
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </button>
+                </div>
                 <div className="mt-2 max-h-56 overflow-y-auto rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm leading-relaxed text-slate-700 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
                   {notes && notes.trim().length > 0 ? (
-                    <pre className="whitespace-pre-wrap font-sans">{notes.trim()}</pre>
+                    <ReactMarkdown components={releaseNotesComponents}>{notes.trim()}</ReactMarkdown>
                   ) : (
                     <p>No release notes were included with this update.</p>
                   )}

--- a/src/components/ui/__tests__/UpdateDialog.test.tsx
+++ b/src/components/ui/__tests__/UpdateDialog.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from '../../../test/testUtils';
+import { describe, expect, it, vi } from 'vitest';
+import { open } from '@tauri-apps/plugin-shell';
+import { UpdateDialog } from '../UpdateDialog';
+
+const defaultProps = {
+    availableVersion: '0.8.0',
+    currentVersion: '0.7.0',
+    errorMessage: null,
+    isOpen: true,
+    publishedAt: '2026-07-11T12:00:00Z',
+    status: 'available' as const,
+    onClose: vi.fn(),
+    onInstall: vi.fn().mockResolvedValue(undefined),
+};
+
+describe('UpdateDialog', () => {
+    it("presents Markdown release notes as What's New", () => {
+        render(
+            <UpdateDialog
+                {...defaultProps}
+                notes={'### Features\n\n- **Faster** library browsing\n- Safer updates'}
+            />
+        );
+
+        expect(screen.getByRole('dialog', { name: 'Ambit 0.8.0' })).toBeTruthy();
+        expect(screen.getByText("What's New")).toBeTruthy();
+        expect(screen.getByText('Features')).toBeTruthy();
+        expect(screen.getByText('Faster')).toBeTruthy();
+        expect(screen.getByText('library browsing')).toBeTruthy();
+        expect(screen.queryByText('### Features')).toBeNull();
+    });
+
+    it('opens the allowlisted GitHub Releases page', async () => {
+        render(<UpdateDialog {...defaultProps} notes="A smaller update." />);
+
+        fireEvent.click(screen.getByRole('button', { name: /view release on github/i }));
+
+        await waitFor(() => {
+            expect(open).toHaveBeenCalledWith('https://github.com/AsuraAce/ambit/releases');
+        });
+    });
+
+    it('explains when the updater feed has no release notes', () => {
+        render(<UpdateDialog {...defaultProps} notes={null} />);
+
+        expect(screen.getByText('No release notes were included with this update.')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

- render updater release notes as a formatted **What's New** section
- add an allowlisted GitHub Releases link and accessible dialog semantics
- keep update actions reachable in Ambit's default 800×600 window
- populate `latest.json` notes from the matching `CHANGELOG.md` release section
- lazy-load the update dialog and cover the UI and release-note extraction with tests

## Why

The updater already passed release metadata to the modal, but the release workflow supplied a fixed boilerplate body. Users therefore could not see the actual changes before installing, and the dialog could exceed the default desktop window height.

## Impact

Future releases will show their generated changelog notes in-app before installation. The existing signed download/install and explicit confirmation flow are unchanged.

## Validation

- `node --test scripts/check-release-tag.node-test.mjs scripts/extract-release-notes.node-test.mjs`
- focused Vitest updater suite: 9 tests passed
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build`
- rendered QA at 800×600 with clean console, scrolling, and dismissal verified