### PR TITLE
fix: harden ComfyUI metadata graph extraction

### DIFF
--- a/src-tauri/src/metadata/comfyui/diagnostics.rs
+++ b/src-tauri/src/metadata/comfyui/diagnostics.rs
@@ -3,11 +3,25 @@ use std::collections::BTreeMap;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) enum ComfyParseLayer {
+    FlatParameters,
     WorkflowChunk,
     ExplicitNode,
     SamplerTraversal,
     SamplerFallback,
     GlobalScan,
+}
+
+impl ComfyParseLayer {
+    pub(crate) fn precedence(self) -> u8 {
+        match self {
+            Self::ExplicitNode => 5,
+            Self::SamplerTraversal => 4,
+            Self::FlatParameters => 3,
+            Self::SamplerFallback => 2,
+            Self::GlobalScan => 1,
+            Self::WorkflowChunk => 0,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -180,7 +194,11 @@ impl ComfyParseDiagnostics {
         has_value: bool,
         layer: ComfyParseLayer,
     ) {
-        if changed && has_value {
+        let is_stronger_source = self
+            .field_sources
+            .get(&field)
+            .is_none_or(|current| layer.precedence() > current.precedence());
+        if changed && has_value && is_stronger_source {
             self.field_sources.insert(field, layer);
         }
     }

--- a/src-tauri/src/metadata/comfyui/diagnostics.rs
+++ b/src-tauri/src/metadata/comfyui/diagnostics.rs
@@ -45,6 +45,9 @@ pub(crate) enum ComfyMetadataField {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub(crate) struct ComfyParseDiagnostics {
     pub(crate) graph_node_count: usize,
+    pub(crate) selected_output_candidate_count: usize,
+    pub(crate) unique_output_root_sampler_count: usize,
+    pub(crate) output_ambiguous: bool,
     pub(crate) attempted_layers: Vec<ComfyParseLayer>,
     pub(crate) field_sources: BTreeMap<ComfyMetadataField, ComfyParseLayer>,
 }

--- a/src-tauri/src/metadata/comfyui/evaluator.rs
+++ b/src-tauri/src/metadata/comfyui/evaluator.rs
@@ -1,7 +1,27 @@
-use super::graph::{get_node_input_link, get_node_type, get_source_id, ComfyGraph};
+use super::graph::{
+    compare_node_ids, get_node_input_link, get_node_input_links, get_node_type, get_source_id,
+    ComfyGraph,
+};
 use crate::metadata::ImageMetadata;
 use serde_json::Value;
 use std::collections::HashSet;
+
+const IMAGE_LIKE_INPUT_NAMES: [&str; 6] =
+    ["images", "image", "pixels", "samples", "latent", "latents"];
+const SAMPLER_LATENT_INPUT_NAMES: [&str; 4] = ["latent_image", "samples", "latent", "latents"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputCandidateKind {
+    PersistedSave,
+    Preview,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct OutputTraversalDiagnostics {
+    pub(crate) selected_output_candidate_count: usize,
+    pub(crate) unique_root_sampler_count: usize,
+    pub(crate) ambiguous: bool,
+}
 
 pub struct ComfyEvaluator<'a> {
     pub graph: &'a ComfyGraph,
@@ -12,53 +32,72 @@ impl<'a> ComfyEvaluator<'a> {
         Self { graph }
     }
 
-    /// Primary entry point: Evaluate the graph from likely output nodes
-    pub fn extract(&self) -> ImageMetadata {
-        let mut meta = ImageMetadata::default();
-        let mut visited_samplers = HashSet::new();
-
+    pub(crate) fn extract_with_output_diagnostics(
+        &self,
+    ) -> (ImageMetadata, OutputTraversalDiagnostics) {
         let output_nodes = self.find_output_nodes();
+        let mut diagnostics = OutputTraversalDiagnostics {
+            selected_output_candidate_count: output_nodes.len(),
+            ..OutputTraversalDiagnostics::default()
+        };
+        let mut root_sampler_ids = Vec::new();
 
         for output_id in output_nodes {
-            if let Some(node) = self.graph.get_node(&output_id) {
-                if self.is_muted(node) {
-                    continue;
-                }
+            let mut visited = HashSet::new();
+            let mut sampler_ids = Vec::new();
+            self.find_upstream_samplers(&output_id, &mut visited, 0, &mut sampler_ids);
 
-                let mut visited = HashSet::new();
-                if let Some(sampler_id) = self.find_upstream_sampler(&output_id, &mut visited, 0) {
-                    if visited_samplers.contains(&sampler_id) {
-                        continue;
-                    }
-                    visited_samplers.insert(sampler_id.clone());
-
-                    let root_sampler_id = self.find_root_sampler_id(&sampler_id);
-
-                    if let Some(root_node) = self.graph.get_node(&root_sampler_id) {
-                        let mut loras = Vec::new();
-                        let mut ip_adapters = Vec::new();
-                        let mut hypernetworks = Vec::new();
-                        let partial = super::eval_core::extract_from_sampler(
-                            self.graph,
-                            &root_sampler_id,
-                            root_node,
-                            &mut loras,
-                            &mut ip_adapters,
-                            &mut hypernetworks,
-                        );
-                        meta.merge(partial);
+            for sampler_id in sampler_ids {
+                for root_sampler_id in self.find_root_sampler_ids(&sampler_id) {
+                    if !root_sampler_ids.contains(&root_sampler_id) {
+                        root_sampler_ids.push(root_sampler_id);
                     }
                 }
             }
         }
 
-        meta
+        root_sampler_ids.sort_by(|left, right| compare_node_ids(left, right));
+        diagnostics.unique_root_sampler_count = root_sampler_ids.len();
+        diagnostics.ambiguous = root_sampler_ids.len() > 1;
+
+        if diagnostics.ambiguous {
+            return (ImageMetadata::default(), diagnostics);
+        }
+
+        let Some(root_sampler_id) = root_sampler_ids.first() else {
+            return (ImageMetadata::default(), diagnostics);
+        };
+        let Some(root_node) = self.graph.get_node(root_sampler_id) else {
+            return (ImageMetadata::default(), diagnostics);
+        };
+
+        let mut loras = Vec::new();
+        let mut ip_adapters = Vec::new();
+        let mut hypernetworks = Vec::new();
+        let metadata = super::eval_core::extract_from_sampler(
+            self.graph,
+            root_sampler_id,
+            root_node,
+            &mut loras,
+            &mut ip_adapters,
+            &mut hypernetworks,
+        );
+
+        (metadata, diagnostics)
     }
 
     pub fn extract_from_all_samplers(&self) -> ImageMetadata {
         let mut meta = ImageMetadata::default();
 
-        for (id, node) in self.graph.nodes() {
+        let mut sampler_nodes: Vec<(&String, &Value)> = self
+            .graph
+            .nodes()
+            .iter()
+            .filter(|(_, node)| is_sampler_node(node))
+            .collect();
+        sampler_nodes.sort_by(|(left_id, _), (right_id, _)| compare_node_ids(left_id, right_id));
+
+        for (id, node) in sampler_nodes {
             let t = get_node_type(node);
             if (t.contains("KSampler") && !t.contains("Select") && !t.contains("Provider"))
                 || t == "SamplerCustomAdvanced"
@@ -88,21 +127,31 @@ impl<'a> ComfyEvaluator<'a> {
     }
 
     fn find_output_nodes(&self) -> Vec<String> {
-        let mut nodes = Vec::new();
+        let mut persisted = Vec::new();
+        let mut previews = Vec::new();
+
         for (id, node) in self.graph.nodes() {
-            let t = get_node_type(node);
-            if t == "SaveImage"
-                || t == "PreviewImage"
-                || t == "ImageSave"
-                || t == "SDPromptSaver"
-                || t == "Save Image w/Metadata"
-                || t.contains("SaveImage")
+            if self.is_disabled_output(node)
+                || self.direct_image_like_source_ids(id, node).is_empty()
             {
-                nodes.push(id.clone());
+                continue;
+            }
+
+            match classify_output_candidate(get_node_type(node)) {
+                Some(OutputCandidateKind::PersistedSave) => persisted.push(id.clone()),
+                Some(OutputCandidateKind::Preview) => previews.push(id.clone()),
+                None => {}
             }
         }
-        nodes.sort();
-        nodes
+
+        persisted.sort_by(|left, right| compare_node_ids(left, right));
+        previews.sort_by(|left, right| compare_node_ids(left, right));
+
+        if persisted.is_empty() {
+            previews
+        } else {
+            persisted
+        }
     }
 
     pub fn is_muted(&self, node: &Value) -> bool {
@@ -112,85 +161,206 @@ impl<'a> ComfyEvaluator<'a> {
         false
     }
 
-    fn find_upstream_sampler(
+    fn is_disabled_output(&self, node: &Value) -> bool {
+        matches!(node.get("mode").and_then(Value::as_i64), Some(2 | 4))
+    }
+
+    fn find_upstream_samplers(
         &self,
         start_id: &str,
         visited: &mut HashSet<String>,
         depth: u32,
-    ) -> Option<String> {
+        sampler_ids: &mut Vec<String>,
+    ) {
         if depth > 50 || !visited.insert(start_id.to_string()) {
-            return None;
+            return;
         }
 
-        let node = self.graph.get_node(start_id)?;
+        let Some(node) = self.graph.get_node(start_id) else {
+            return;
+        };
 
-        let t = get_node_type(node);
-        if t.contains("KSampler")
-            || t == "SamplerCustomAdvanced"
-            || t == "SamplerCustom"
-            || t.contains("StyleAlignedReferenceSampler")
-        {
-            return Some(start_id.to_string());
-        }
-
-        let image_inputs = ["images", "image", "samples"];
-        for input_name in image_inputs {
-            if let Some(source_id) = get_source_id(self.graph, start_id, input_name) {
-                if let Some(found) = self.find_upstream_sampler(&source_id, visited, depth + 1) {
-                    return Some(found);
-                }
+        if is_sampler_node(node) {
+            if !sampler_ids.iter().any(|id| id == start_id) {
+                sampler_ids.push(start_id.to_string());
             }
+            return;
         }
 
-        None
+        for source_id in self.image_like_source_ids(start_id, node) {
+            self.find_upstream_samplers(&source_id, visited, depth + 1, sampler_ids);
+        }
     }
 
-    fn find_root_sampler_id(&self, start_sampler_id: &str) -> String {
-        let mut current_id = start_sampler_id.to_string();
-        let mut depth = 0;
+    fn image_like_source_ids(&self, node_id: &str, node: &Value) -> Vec<String> {
+        self.image_like_source_ids_with_wireless(node_id, node, true)
+    }
 
-        while depth < 10 {
-            if self.graph.get_node(&current_id).is_some() {
-                if let Some(source_id) = get_source_id(self.graph, &current_id, "latent_image") {
-                    if let Some(source_node) = self.graph.get_node(&source_id) {
-                        let t = get_node_type(source_node);
-                        if t.contains("KSampler")
-                            || t == "SamplerCustomAdvanced"
-                            || t == "SamplerCustom"
-                            || t.contains("StyleAlignedReferenceSampler")
-                        {
-                            current_id = source_id;
-                            depth += 1;
-                            continue;
-                        }
+    fn direct_image_like_source_ids(&self, node_id: &str, node: &Value) -> Vec<String> {
+        self.image_like_source_ids_with_wireless(node_id, node, false)
+    }
+
+    fn image_like_source_ids_with_wireless(
+        &self,
+        node_id: &str,
+        node: &Value,
+        allow_wireless: bool,
+    ) -> Vec<String> {
+        let mut sources = Vec::new();
+
+        for input_name in IMAGE_LIKE_INPUT_NAMES {
+            for source_id in self.input_source_ids(node_id, node, input_name, allow_wireless) {
+                self.push_existing_source(&mut sources, source_id);
+            }
+        }
+
+        if let Some(inputs) = node.get("inputs").and_then(Value::as_array) {
+            for input in inputs {
+                let input_type = input.get("type").and_then(Value::as_str).unwrap_or("");
+                if !input_type.eq_ignore_ascii_case("IMAGE")
+                    && !input_type.eq_ignore_ascii_case("LATENT")
+                {
+                    continue;
+                }
+
+                if let Some(input_name) = input.get("name").and_then(Value::as_str) {
+                    for source_id in
+                        self.input_source_ids(node_id, node, input_name, allow_wireless)
+                    {
+                        self.push_existing_source(&mut sources, source_id);
                     }
                 }
-                if let Some(conditioning_id) = get_source_id(self.graph, &current_id, "positive") {
-                    if let Some(conditioning_node) = self.graph.get_node(&conditioning_id) {
-                        if get_node_type(conditioning_node) == "StableCascade_StageB_Conditioning" {
-                            if let Some(stage_c_id) =
-                                get_source_id(self.graph, &conditioning_id, "stage_c")
-                            {
-                                if let Some(stage_c_node) = self.graph.get_node(&stage_c_id) {
-                                    let t = get_node_type(stage_c_node);
-                                    if t.contains("KSampler")
-                                        || t == "SamplerCustomAdvanced"
-                                        || t == "SamplerCustom"
-                                        || t.contains("StyleAlignedReferenceSampler")
-                                    {
-                                        current_id = stage_c_id;
-                                        depth += 1;
-                                        continue;
-                                    }
-                                }
-                            }
+            }
+        }
+
+        sources.sort_by(|left, right| compare_node_ids(left, right));
+        sources
+    }
+
+    fn input_source_ids(
+        &self,
+        node_id: &str,
+        node: &Value,
+        input_name: &str,
+        allow_wireless: bool,
+    ) -> Vec<String> {
+        let direct = get_node_input_links(node, input_name);
+        if !direct.is_empty() || !allow_wireless {
+            return direct;
+        }
+
+        get_source_id(self.graph, node_id, input_name)
+            .into_iter()
+            .collect()
+    }
+
+    fn push_existing_source(&self, sources: &mut Vec<String>, source_id: String) {
+        if self.graph.get_node(&source_id).is_some() && !sources.contains(&source_id) {
+            sources.push(source_id);
+        }
+    }
+
+    fn find_root_sampler_ids(&self, start_sampler_id: &str) -> Vec<String> {
+        let mut roots = Vec::new();
+        let mut visited = HashSet::new();
+        self.collect_root_sampler_ids(start_sampler_id, &mut visited, 0, &mut roots);
+
+        if roots.is_empty() {
+            roots.push(start_sampler_id.to_string());
+        }
+        roots.sort_by(|left, right| compare_node_ids(left, right));
+        roots.dedup();
+        roots
+    }
+
+    fn collect_root_sampler_ids(
+        &self,
+        sampler_id: &str,
+        visited: &mut HashSet<String>,
+        depth: u32,
+        roots: &mut Vec<String>,
+    ) {
+        if depth > 20 || !visited.insert(sampler_id.to_string()) {
+            return;
+        }
+
+        let upstream = self.find_upstream_sampler_ids_for_sampler(sampler_id);
+        if upstream.is_empty() {
+            if !roots.iter().any(|root| root == sampler_id) {
+                roots.push(sampler_id.to_string());
+            }
+            return;
+        }
+
+        for upstream_id in upstream {
+            self.collect_root_sampler_ids(&upstream_id, visited, depth + 1, roots);
+        }
+    }
+
+    fn find_upstream_sampler_ids_for_sampler(&self, sampler_id: &str) -> Vec<String> {
+        let Some(node) = self.graph.get_node(sampler_id) else {
+            return Vec::new();
+        };
+        let source_ids = self.sampler_latent_source_ids(sampler_id, node);
+
+        let mut upstream_sampler_ids = Vec::new();
+        for source_id in source_ids {
+            let mut visited = HashSet::new();
+            self.find_upstream_samplers(&source_id, &mut visited, 0, &mut upstream_sampler_ids);
+        }
+
+        if let Some(conditioning_id) = get_source_id(self.graph, sampler_id, "positive") {
+            if let Some(conditioning_node) = self.graph.get_node(&conditioning_id) {
+                if get_node_type(conditioning_node) == "StableCascade_StageB_Conditioning" {
+                    if let Some(stage_c_id) = get_source_id(self.graph, &conditioning_id, "stage_c")
+                    {
+                        if self
+                            .graph
+                            .get_node(&stage_c_id)
+                            .is_some_and(is_sampler_node)
+                            && !upstream_sampler_ids.contains(&stage_c_id)
+                        {
+                            upstream_sampler_ids.push(stage_c_id);
                         }
                     }
                 }
             }
-            break;
         }
-        current_id
+
+        upstream_sampler_ids.sort_by(|left, right| compare_node_ids(left, right));
+        upstream_sampler_ids.dedup();
+        upstream_sampler_ids
+    }
+
+    fn sampler_latent_source_ids(&self, sampler_id: &str, node: &Value) -> Vec<String> {
+        let mut sources = Vec::new();
+
+        for input_name in SAMPLER_LATENT_INPUT_NAMES {
+            for source_id in self.input_source_ids(sampler_id, node, input_name, true) {
+                self.push_existing_source(&mut sources, source_id);
+            }
+        }
+
+        if let Some(inputs) = node.get("inputs").and_then(Value::as_array) {
+            for input in inputs {
+                if !input
+                    .get("type")
+                    .and_then(Value::as_str)
+                    .is_some_and(|input_type| input_type.eq_ignore_ascii_case("LATENT"))
+                {
+                    continue;
+                }
+
+                if let Some(input_name) = input.get("name").and_then(Value::as_str) {
+                    for source_id in self.input_source_ids(sampler_id, node, input_name, true) {
+                        self.push_existing_source(&mut sources, source_id);
+                    }
+                }
+            }
+        }
+
+        sources.sort_by(|left, right| compare_node_ids(left, right));
+        sources
     }
 
     pub fn get_any_input_link(node: &Value) -> Option<String> {
@@ -203,4 +373,39 @@ impl<'a> ComfyEvaluator<'a> {
         }
         None
     }
+}
+
+fn classify_output_candidate(node_type: &str) -> Option<OutputCandidateKind> {
+    let normalized: String = node_type
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect();
+
+    if normalized.contains("preview")
+        && normalized.contains("image")
+        && !normalized.contains("save")
+    {
+        return Some(OutputCandidateKind::Preview);
+    }
+
+    if normalized == "sdpromptsaver"
+        || normalized == "saveimage"
+        || normalized == "imagesave"
+        || (normalized.contains("save") && normalized.contains("image"))
+    {
+        return Some(OutputCandidateKind::PersistedSave);
+    }
+
+    None
+}
+
+fn is_sampler_node(node: &Value) -> bool {
+    let node_type = get_node_type(node);
+    (node_type.contains("KSampler")
+        && !node_type.contains("Select")
+        && !node_type.contains("Provider"))
+        || node_type == "SamplerCustomAdvanced"
+        || node_type == "SamplerCustom"
+        || node_type.contains("StyleAlignedReferenceSampler")
 }

--- a/src-tauri/src/metadata/comfyui/graph.rs
+++ b/src-tauri/src/metadata/comfyui/graph.rs
@@ -2,6 +2,8 @@ use serde_json::Value;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
+use super::workflow_normalizer::normalize_workflow;
+
 /// Normalizes ComfyUI metadata into a graph representation.
 pub struct ComfyGraph {
     pub(crate) nodes: HashMap<String, Value>,
@@ -38,148 +40,110 @@ impl ComfyGraph {
         if nodes_map.is_empty() {
             if let Some(workflow_json) = chunks.get("workflow") {
                 if let Ok(json) = serde_json::from_str::<Value>(workflow_json) {
-                    // Link Map: Link ID -> (Source Node ID, Type)
-                    let mut link_source_map = HashMap::new();
-                    if let Some(links) = json.get("links").and_then(|v| v.as_array()) {
-                        for link in links {
-                            if let Some(arr) = link.as_array() {
-                                if arr.len() >= 2 {
-                                    if let (Some(link_id), Some(source_id)) =
-                                        (arr[0].as_i64(), arr[1].as_i64())
-                                    {
-                                        let link_type = if arr.len() > 5 {
-                                            arr[5].as_str().unwrap_or("*").to_string()
-                                        } else {
-                                            "*".to_string()
-                                        };
-                                        link_source_map
-                                            .insert(link_id, (source_id.to_string(), link_type));
-                                    }
-                                }
+                    if let Some(normalized) = normalize_workflow(&json) {
+                        let mut incoming = HashMap::new();
+                        let mut incoming_by_link = HashMap::new();
+                        for edge in &normalized.edges {
+                            incoming.insert(
+                                (edge.target_id.clone(), edge.target_slot),
+                                (edge.source_id.clone(), edge.link_type.clone()),
+                            );
+                            if let Some(link_id) = &edge.link_id {
+                                incoming_by_link.insert(
+                                    (edge.target_id.clone(), link_id.clone()),
+                                    (edge.source_id.clone(), edge.link_type.clone()),
+                                );
                             }
                         }
-                    }
 
-                    // Pre-pass: Find SetNode variables (Name -> Source Node ID, Type)
-                    let mut var_map = HashMap::new();
-                    if let Some(nodes_arr) = json.get("nodes").and_then(|v| v.as_array()) {
-                        for node in nodes_arr {
-                            if let Some(t) = node.get("type").and_then(|v| v.as_str()) {
-                                if t == "SetNode" {
-                                    if let Some(var_name) = node
-                                        .get("widgets_values")
-                                        .and_then(|v| v.get(0))
-                                        .and_then(|v| v.as_str())
-                                    {
-                                        // Link is in inputs[0] usually
-                                        if let Some(inputs) =
-                                            node.get("inputs").and_then(|v| v.as_array())
-                                        {
-                                            for input in inputs {
-                                                if let Some(link_id) =
-                                                    input.get("link").and_then(|v| v.as_i64())
-                                                {
-                                                    if let Some((source_id, link_type)) =
-                                                        link_source_map.get(&link_id)
-                                                    {
-                                                        var_map.insert(
-                                                            var_name.to_string(),
-                                                            (source_id.clone(), link_type.clone()),
-                                                        );
-                                                    }
-                                                }
-                                            }
+                        let mut var_map = HashMap::new();
+                        for node in &normalized.nodes {
+                            if get_node_type(node) != "SetNode" {
+                                continue;
+                            }
+                            let Some(id) = node.get("id").and_then(value_as_id) else {
+                                continue;
+                            };
+                            let Some(var_name) = node
+                                .get("widgets_values")
+                                .and_then(|value| value.get(0))
+                                .and_then(Value::as_str)
+                            else {
+                                continue;
+                            };
+                            if let Some((source_id, link_type)) = incoming.get(&(id, 0)) {
+                                var_map.insert(
+                                    var_name.to_string(),
+                                    (source_id.clone(), link_type.clone()),
+                                );
+                            }
+                        }
+
+                        for mut node in normalized.nodes {
+                            let Some(id) = node.get("id").and_then(value_as_id) else {
+                                continue;
+                            };
+                            let node_type = get_node_type(&node).to_string();
+                            let mut resolved = serde_json::Map::new();
+
+                            if let Some(inputs) = node.get("inputs").and_then(Value::as_array) {
+                                for (slot, input) in inputs.iter().enumerate() {
+                                    let Some(name) = input.get("name").and_then(Value::as_str)
+                                    else {
+                                        continue;
+                                    };
+                                    let linked_source = input
+                                        .get("link")
+                                        .and_then(value_as_id)
+                                        .and_then(|link_id| {
+                                            incoming_by_link.get(&(id.clone(), link_id))
+                                        })
+                                        .or_else(|| incoming.get(&(id.clone(), slot)));
+                                    if let Some((source_id, _)) = linked_source {
+                                        let value = resolved
+                                            .entry(name.to_string())
+                                            .or_insert(Value::Array(Vec::new()));
+                                        if let Some(values) = value.as_array_mut() {
+                                            values.push(Value::String(source_id.clone()));
                                         }
                                     }
                                 }
                             }
-                        }
-                    }
 
-                    // Process Nodes
-                    if let Some(nodes_arr) = json.get("nodes").and_then(|v| v.as_array()) {
-                        for node in nodes_arr {
-                            if let Some(id) =
-                                node.get("id").and_then(|v| v.as_u64()).or_else(|| {
-                                    node.get("id").and_then(|v| v.as_i64()).map(|v| v as u64)
-                                })
-                            {
-                                let mut node_obj = node.clone();
-                                let t = node.get("type").and_then(|v| v.as_str()).unwrap_or("");
-
-                                let mut resolved = serde_json::Map::new();
-
-                                // Resolve Links
-                                if let Some(inputs) = node.get("inputs").and_then(|v| v.as_array())
+                            if node_type == "GetNode" {
+                                if let Some(var_name) = node
+                                    .get("widgets_values")
+                                    .and_then(|value| value.get(0))
+                                    .and_then(Value::as_str)
                                 {
-                                    for input in inputs {
-                                        if let Some(name) =
-                                            input.get("name").and_then(|v| v.as_str())
-                                        {
-                                            if let Some(link_id) =
-                                                input.get("link").and_then(|v| v.as_i64())
-                                            {
-                                                if let Some((source_node_id, _)) =
-                                                    link_source_map.get(&link_id)
-                                                {
-                                                    // Handle multiple inputs with same name (like in Prompts Everywhere)
-                                                    let val = resolved
-                                                        .entry(name.to_string())
-                                                        .or_insert(Value::Array(Vec::new()));
-                                                    if let Some(arr) = val.as_array_mut() {
-                                                        arr.push(Value::String(
-                                                            source_node_id.clone(),
-                                                        ));
-                                                    }
-                                                }
-                                            }
+                                    if let Some((source_id, link_type)) = var_map.get(var_name) {
+                                        resolved.insert(
+                                            var_name.to_string(),
+                                            Value::String(source_id.clone()),
+                                        );
+                                        resolved.insert(
+                                            "source".to_string(),
+                                            Value::String(source_id.clone()),
+                                        );
+                                        if !link_type.is_empty() && link_type != "*" {
+                                            resolved.insert(
+                                                link_type.clone(),
+                                                Value::String(source_id.clone()),
+                                            );
                                         }
                                     }
                                 }
-
-                                // Virtual Inputs for GetNode
-                                if t == "GetNode" {
-                                    if let Some(var_name) = node
-                                        .get("widgets_values")
-                                        .and_then(|v| v.get(0))
-                                        .and_then(|v| v.as_str())
-                                    {
-                                        if let Some((source_id, link_type)) = var_map.get(var_name)
-                                        {
-                                            resolved.insert(
-                                                var_name.to_string(),
-                                                Value::String(source_id.clone()),
-                                            );
-                                            resolved.insert(
-                                                "source".to_string(),
-                                                Value::String(source_id.clone()),
-                                            );
-                                            // Inject type as key for robust type-based traversal (e.g. "CONDITIONING")
-                                            if !link_type.is_empty() && link_type != "*" {
-                                                resolved.insert(
-                                                    link_type.clone(),
-                                                    Value::String(source_id.clone()),
-                                                );
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if let Some(obj) = node_obj.as_object_mut() {
-                                    obj.insert(
-                                        "_resolved_inputs".to_string(),
-                                        Value::Object(resolved),
-                                    );
-                                }
-
-                                nodes_map.insert(id.to_string(), node_obj);
                             }
+
+                            if let Some(object) = node.as_object_mut() {
+                                object.insert(
+                                    "_resolved_inputs".to_string(),
+                                    Value::Object(resolved),
+                                );
+                            }
+                            nodes_map.insert(id, node);
                         }
                     }
-
-                    // Post-Process: Flatten GetNode chains (Optional, but helps if evaluator checks type)
-                    // If a node points to a GetNode, we can replace the link with the GetNode's source.
-                    // (Logic omitted for simplicity, relying on evaluator traversing "source" input of GetNode)
                 }
             }
         }
@@ -290,6 +254,14 @@ pub fn get_node_id(node: &Value) -> String {
         .unwrap_or_default()
 }
 
+fn value_as_id(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| value.as_i64().map(|id| id.to_string()))
+        .or_else(|| value.as_u64().map(|id| id.to_string()))
+}
+
 pub fn get_node_type(node: &Value) -> &str {
     node.get("class_type")
         .or_else(|| node.get("type"))
@@ -369,6 +341,23 @@ pub fn get_node_param<'a>(node: &'a Value, key: &str) -> Option<&'a Value> {
     // 1. Check in API format "inputs"
     if let Some(val) = node.get("inputs").and_then(|v| v.get(key)) {
         return Some(val);
+    }
+
+    // UI workflows retain widget defaults even when the input is linked. The
+    // link is authoritative, so evaluators must follow `_resolved_inputs`.
+    if node
+        .get("_resolved_inputs")
+        .and_then(|inputs| inputs.get(key))
+        .is_some()
+    {
+        return None;
+    }
+
+    if let Some(value) = node
+        .get("_widget_overrides")
+        .and_then(|overrides| overrides.get(key))
+    {
+        return Some(value);
     }
 
     // 2. Check in UI format "widgets_values"

--- a/src-tauri/src/metadata/comfyui/graph.rs
+++ b/src-tauri/src/metadata/comfyui/graph.rs
@@ -1,4 +1,5 @@
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 
 /// Normalizes ComfyUI metadata into a graph representation.
@@ -209,15 +210,32 @@ impl ComfyGraph {
 }
 
 // Helpers
+pub(crate) fn compare_node_ids(left_id: &str, right_id: &str) -> Ordering {
+    match (left_id.parse::<u64>(), right_id.parse::<u64>()) {
+        (Ok(left), Ok(right)) => left.cmp(&right).then_with(|| left_id.cmp(right_id)),
+        (Ok(_), Err(_)) => Ordering::Less,
+        (Err(_), Ok(_)) => Ordering::Greater,
+        (Err(_), Err(_)) => left_id.cmp(right_id),
+    }
+}
+
 pub fn get_node_input_link(node: &Value, key: &str) -> Option<String> {
+    get_node_input_links(node, key).into_iter().next()
+}
+
+pub(crate) fn get_node_input_links(node: &Value, key: &str) -> Vec<String> {
     // 0. Check pre-resolved check inputs
     if let Some(val) = node.get("_resolved_inputs").and_then(|m| m.get(key)) {
         if let Some(id) = val.as_str() {
-            return Some(id.to_string());
+            return vec![id.to_string()];
         }
         if let Some(arr) = val.as_array() {
-            if let Some(id) = arr.first().and_then(|v| v.as_str()) {
-                return Some(id.to_string());
+            let ids: Vec<String> = arr
+                .iter()
+                .filter_map(|value| value.as_str().map(str::to_string))
+                .collect();
+            if !ids.is_empty() {
+                return ids;
             }
         }
     }
@@ -227,19 +245,19 @@ pub fn get_node_input_link(node: &Value, key: &str) -> Option<String> {
             if let Some(arr) = link.as_array() {
                 if !arr.is_empty() {
                     if let Some(s) = arr[0].as_str() {
-                        return Some(s.to_string());
+                        return vec![s.to_string()];
                     }
                     if let Some(n) = arr[0].as_u64() {
-                        return Some(n.to_string());
+                        return vec![n.to_string()];
                     }
                 }
             }
             if let Some(s) = link.as_str() {
-                return Some(s.to_string());
+                return vec![s.to_string()];
             }
         }
     }
-    None
+    Vec::new()
 }
 
 /// Helper to resolve links (including wireless)

--- a/src-tauri/src/metadata/comfyui/mod.rs
+++ b/src-tauri/src/metadata/comfyui/mod.rs
@@ -1,4 +1,4 @@
-use super::{merge_metadata, ImageMetadata};
+use super::{extract_a1111_metadata, is_missing_prompt_value, ImageMetadata};
 use std::collections::{BTreeMap, HashMap};
 
 mod conditioning;
@@ -29,37 +29,439 @@ pub(crate) fn merge_comfyui_metadata(
     base: &mut ImageMetadata,
     chunks: &HashMap<String, String>,
 ) -> ComfyParseDiagnostics {
-    let (comfy_meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(chunks);
-    let original_model = base.model.clone();
-    let trusted_model = diagnostics
-        .field_sources
-        .get(&ComfyMetadataField::Model)
-        .is_some_and(|layer| {
-            matches!(
-                layer,
-                ComfyParseLayer::ExplicitNode | ComfyParseLayer::SamplerTraversal
-            )
-        });
-    let trusted_model_override = if trusted_model && is_known_model(&comfy_meta.model) {
-        Some((comfy_meta.model.clone(), comfy_meta.model_hash.clone()))
-    } else {
-        None
-    };
+    let mut diagnostics = ComfyParseDiagnostics::default();
 
-    merge_metadata(base, comfy_meta);
-
-    if let Some((model, model_hash)) = trusted_model_override {
-        if original_model != model || model_hash.is_some() {
-            base.model_hash = model_hash;
-        }
-        base.model = model;
+    if let Some(parameters) = flat_parameters_chunk(chunks) {
+        diagnostics.attempt(ComfyParseLayer::FlatParameters);
+        let flat_meta = extract_a1111_metadata(parameters, Some("ComfyUI".to_string()));
+        merge_flat_parameters(base, &flat_meta);
+        record_flat_parameter_sources(&mut diagnostics, base, &flat_meta);
     }
+
+    let (mut graph_meta, graph_diagnostics) = extract_comfyui_graph_with_diagnostics(chunks);
+    diagnostics.graph_node_count = graph_diagnostics.graph_node_count;
+    for layer in &graph_diagnostics.attempted_layers {
+        diagnostics.attempt(*layer);
+    }
+
+    merge_graph_metadata(base, &mut graph_meta, &graph_diagnostics, &mut diagnostics);
+    base.tool = "ComfyUI".to_string();
 
     diagnostics
 }
 
 fn is_known_model(model: &str) -> bool {
     !model.is_empty() && model != "Unknown" && model != "None"
+}
+
+fn has_same_model_identity(left: &str, right: &str) -> bool {
+    let left = crate::metadata::guidance::GuidanceClassifier::clean_name(left);
+    let right = crate::metadata::guidance::GuidanceClassifier::clean_name(right);
+    !left.is_empty() && left == right
+}
+
+fn is_known_sampler(sampler: &str) -> bool {
+    !sampler.is_empty()
+        && sampler != "Unknown"
+        && sampler != "_"
+        && !sampler.starts_with("Unknown (")
+        && !sampler.starts_with("_ (")
+}
+
+fn flat_parameters_chunk(chunks: &HashMap<String, String>) -> Option<&str> {
+    chunks
+        .get("parameters")
+        .or_else(|| chunks.get("Parameters"))
+        .or_else(|| chunks.get("PARAMETERS"))
+        .map(String::as_str)
+}
+
+fn merge_flat_parameters(base: &mut ImageMetadata, flat: &ImageMetadata) {
+    if base.tool == "Unknown" && flat.tool != "Unknown" {
+        base.tool = flat.tool.clone();
+    }
+    if !is_known_model(&base.model) && is_known_model(&flat.model) {
+        base.model = flat.model.clone();
+    }
+    if base.steps == 0 && flat.steps > 0 {
+        base.steps = flat.steps;
+    }
+    if base.cfg == 0.0 && flat.cfg > 0.0 {
+        base.cfg = flat.cfg;
+    }
+    if base.seed.is_none() {
+        base.seed = flat.seed;
+    }
+    if !is_known_sampler(&base.sampler) && is_known_sampler(&flat.sampler) {
+        base.sampler = flat.sampler.clone();
+    }
+    if is_missing_prompt_value(&base.positive_prompt)
+        && !is_missing_prompt_value(&flat.positive_prompt)
+    {
+        base.positive_prompt = flat.positive_prompt.clone();
+    }
+    if is_missing_prompt_value(&base.negative_prompt)
+        && !is_missing_prompt_value(&flat.negative_prompt)
+    {
+        base.negative_prompt = flat.negative_prompt.clone();
+    }
+    if base.raw_parameters.is_none() {
+        base.raw_parameters = flat.raw_parameters.clone();
+    }
+    if base.model_hash.is_none() {
+        base.model_hash = flat.model_hash.clone();
+    }
+    if base.vae.is_none() {
+        base.vae = flat.vae.clone();
+    }
+    if base.clip_skip.is_none() {
+        base.clip_skip = flat.clip_skip;
+    }
+    if base.denoising_strength.is_none() {
+        base.denoising_strength = flat.denoising_strength;
+    }
+    if base.hires_upscale.is_none() {
+        base.hires_upscale = flat.hires_upscale;
+    }
+    if base.hires_steps.is_none() {
+        base.hires_steps = flat.hires_steps;
+    }
+    if base.hires_upscaler.is_none() {
+        base.hires_upscaler = flat.hires_upscaler.clone();
+    }
+    if (base.generation_type.is_empty() || base.generation_type == "unknown")
+        && !flat.generation_type.is_empty()
+        && flat.generation_type != "unknown"
+    {
+        base.generation_type = flat.generation_type.clone();
+    }
+    base.is_favorite |= flat.is_favorite;
+
+    merge_unique(&mut base.loras, flat.loras.iter().cloned());
+    merge_unique(&mut base.control_nets, flat.control_nets.iter().cloned());
+    merge_unique(&mut base.ip_adapters, flat.ip_adapters.iter().cloned());
+    merge_unique(&mut base.embeddings, flat.embeddings.iter().cloned());
+    merge_unique(&mut base.hypernetworks, flat.hypernetworks.iter().cloned());
+}
+
+fn record_flat_parameter_sources(
+    diagnostics: &mut ComfyParseDiagnostics,
+    selected: &ImageMetadata,
+    flat: &ImageMetadata,
+) {
+    let layer = ComfyParseLayer::FlatParameters;
+    if is_known_model(&flat.model) && selected.model == flat.model {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::Model, layer);
+    }
+    if flat.seed.is_some() && selected.seed == flat.seed {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::Seed, layer);
+    }
+    if flat.steps > 0 && selected.steps == flat.steps {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::Steps, layer);
+    }
+    if flat.cfg > 0.0 && selected.cfg == flat.cfg {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::Cfg, layer);
+    }
+    if is_known_sampler(&flat.sampler) && selected.sampler == flat.sampler {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::Sampler, layer);
+    }
+    if !is_missing_prompt_value(&flat.positive_prompt)
+        && selected.positive_prompt == flat.positive_prompt
+    {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::PositivePrompt, layer);
+    }
+    if !is_missing_prompt_value(&flat.negative_prompt)
+        && selected.negative_prompt == flat.negative_prompt
+    {
+        diagnostics
+            .field_sources
+            .insert(ComfyMetadataField::NegativePrompt, layer);
+    }
+
+    for (field, contributes) in [
+        (
+            ComfyMetadataField::Loras,
+            flat.loras
+                .iter()
+                .any(|value| selected.loras.contains(value)),
+        ),
+        (
+            ComfyMetadataField::ControlNets,
+            flat.control_nets
+                .iter()
+                .any(|value| selected.control_nets.contains(value)),
+        ),
+        (
+            ComfyMetadataField::IpAdapters,
+            flat.ip_adapters
+                .iter()
+                .any(|value| selected.ip_adapters.contains(value)),
+        ),
+        (
+            ComfyMetadataField::Embeddings,
+            flat.embeddings
+                .iter()
+                .any(|value| selected.embeddings.contains(value)),
+        ),
+        (
+            ComfyMetadataField::Hypernetworks,
+            flat.hypernetworks
+                .iter()
+                .any(|value| selected.hypernetworks.contains(value)),
+        ),
+    ] {
+        if contributes {
+            diagnostics.field_sources.insert(field, layer);
+        }
+    }
+}
+
+fn merge_graph_metadata(
+    base: &mut ImageMetadata,
+    graph: &mut ImageMetadata,
+    graph_diagnostics: &ComfyParseDiagnostics,
+    diagnostics: &mut ComfyParseDiagnostics,
+) {
+    if is_known_model(&graph.model) {
+        if let Some(layer) = selected_graph_layer(
+            graph_diagnostics,
+            ComfyMetadataField::Model,
+            !is_known_model(&base.model),
+        ) {
+            let previous_model = base.model.clone();
+            base.model = std::mem::take(&mut graph.model);
+            if graph.model_hash.is_some() {
+                base.model_hash = graph.model_hash.take();
+            } else if is_strong_graph_layer(layer)
+                && !has_same_model_identity(&previous_model, &base.model)
+            {
+                base.model_hash = None;
+            }
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::Model, layer);
+        }
+    }
+
+    if graph.seed.is_some() {
+        if let Some(layer) = selected_graph_layer(
+            graph_diagnostics,
+            ComfyMetadataField::Seed,
+            base.seed.is_none(),
+        ) {
+            base.seed = graph.seed;
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::Seed, layer);
+        }
+    }
+    if graph.steps > 0 {
+        if let Some(layer) = selected_graph_layer(
+            graph_diagnostics,
+            ComfyMetadataField::Steps,
+            base.steps == 0,
+        ) {
+            base.steps = graph.steps;
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::Steps, layer);
+        }
+    }
+    if graph.cfg > 0.0 {
+        if let Some(layer) =
+            selected_graph_layer(graph_diagnostics, ComfyMetadataField::Cfg, base.cfg == 0.0)
+        {
+            base.cfg = graph.cfg;
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::Cfg, layer);
+        }
+    }
+    if is_known_sampler(&graph.sampler) {
+        if let Some(layer) = selected_graph_layer(
+            graph_diagnostics,
+            ComfyMetadataField::Sampler,
+            !is_known_sampler(&base.sampler),
+        ) {
+            base.sampler = std::mem::take(&mut graph.sampler);
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::Sampler, layer);
+        }
+    }
+    if !is_missing_prompt_value(&graph.positive_prompt) {
+        if let Some(layer) = selected_graph_layer(
+            graph_diagnostics,
+            ComfyMetadataField::PositivePrompt,
+            is_missing_prompt_value(&base.positive_prompt),
+        ) {
+            base.positive_prompt = std::mem::take(&mut graph.positive_prompt);
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::PositivePrompt, layer);
+        }
+    }
+    if !is_missing_prompt_value(&graph.negative_prompt) {
+        if let Some(layer) = selected_graph_layer(
+            graph_diagnostics,
+            ComfyMetadataField::NegativePrompt,
+            is_missing_prompt_value(&base.negative_prompt),
+        ) {
+            base.negative_prompt = std::mem::take(&mut graph.negative_prompt);
+            diagnostics
+                .field_sources
+                .insert(ComfyMetadataField::NegativePrompt, layer);
+        }
+    }
+
+    if graph.workflow_json.is_some() {
+        base.workflow_json = graph.workflow_json.take();
+        copy_graph_source(
+            diagnostics,
+            graph_diagnostics,
+            ComfyMetadataField::WorkflowJson,
+        );
+    }
+    if graph.has_workflow_hint {
+        base.has_workflow_hint = true;
+        copy_graph_source(
+            diagnostics,
+            graph_diagnostics,
+            ComfyMetadataField::WorkflowHint,
+        );
+    }
+
+    if base.vae.is_none() {
+        base.vae = graph.vae.take();
+    }
+    if base.clip_skip.is_none() {
+        base.clip_skip = graph.clip_skip;
+    }
+    if base.denoising_strength.is_none() {
+        base.denoising_strength = graph.denoising_strength;
+    }
+    if base.hires_upscale.is_none() {
+        base.hires_upscale = graph.hires_upscale;
+    }
+    if base.hires_steps.is_none() {
+        base.hires_steps = graph.hires_steps;
+    }
+    if base.hires_upscaler.is_none() {
+        base.hires_upscaler = graph.hires_upscaler.take();
+    }
+    if (base.generation_type.is_empty() || base.generation_type == "unknown")
+        && !graph.generation_type.is_empty()
+        && graph.generation_type != "unknown"
+    {
+        base.generation_type = std::mem::take(&mut graph.generation_type);
+    }
+    base.is_favorite |= graph.is_favorite;
+
+    merge_graph_resources(
+        &mut base.loras,
+        std::mem::take(&mut graph.loras),
+        ComfyMetadataField::Loras,
+        graph_diagnostics,
+        diagnostics,
+    );
+    merge_graph_resources(
+        &mut base.control_nets,
+        std::mem::take(&mut graph.control_nets),
+        ComfyMetadataField::ControlNets,
+        graph_diagnostics,
+        diagnostics,
+    );
+    merge_graph_resources(
+        &mut base.ip_adapters,
+        std::mem::take(&mut graph.ip_adapters),
+        ComfyMetadataField::IpAdapters,
+        graph_diagnostics,
+        diagnostics,
+    );
+    merge_graph_resources(
+        &mut base.embeddings,
+        std::mem::take(&mut graph.embeddings),
+        ComfyMetadataField::Embeddings,
+        graph_diagnostics,
+        diagnostics,
+    );
+    merge_graph_resources(
+        &mut base.hypernetworks,
+        std::mem::take(&mut graph.hypernetworks),
+        ComfyMetadataField::Hypernetworks,
+        graph_diagnostics,
+        diagnostics,
+    );
+}
+
+fn selected_graph_layer(
+    diagnostics: &ComfyParseDiagnostics,
+    field: ComfyMetadataField,
+    base_is_missing: bool,
+) -> Option<ComfyParseLayer> {
+    let layer = *diagnostics.field_sources.get(&field)?;
+    (is_strong_graph_layer(layer) || base_is_missing).then_some(layer)
+}
+
+fn is_strong_graph_layer(layer: ComfyParseLayer) -> bool {
+    matches!(
+        layer,
+        ComfyParseLayer::ExplicitNode | ComfyParseLayer::SamplerTraversal
+    )
+}
+
+fn copy_graph_source(
+    diagnostics: &mut ComfyParseDiagnostics,
+    graph_diagnostics: &ComfyParseDiagnostics,
+    field: ComfyMetadataField,
+) {
+    if let Some(layer) = graph_diagnostics.field_sources.get(&field) {
+        diagnostics.field_sources.insert(field, *layer);
+    }
+}
+
+fn merge_graph_resources(
+    selected: &mut Vec<String>,
+    graph_values: Vec<String>,
+    field: ComfyMetadataField,
+    graph_diagnostics: &ComfyParseDiagnostics,
+    diagnostics: &mut ComfyParseDiagnostics,
+) {
+    let contributed = !graph_values.is_empty();
+    merge_unique(selected, graph_values);
+    if !contributed {
+        return;
+    }
+
+    if let Some(graph_layer) = graph_diagnostics.field_sources.get(&field) {
+        let selected_layer = diagnostics.field_sources.get(&field).copied();
+        if selected_layer
+            .map(|layer| graph_layer.precedence() > layer.precedence())
+            .unwrap_or(true)
+        {
+            diagnostics.field_sources.insert(field, *graph_layer);
+        }
+    }
+}
+
+fn merge_unique(values: &mut Vec<String>, additions: impl IntoIterator<Item = String>) {
+    for value in additions {
+        if !values.contains(&value) {
+            values.push(value);
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, specta::Type)]
@@ -159,6 +561,7 @@ impl ComfyMetadataPreview {
 
 fn parse_layer_label(layer: ComfyParseLayer) -> &'static str {
     match layer {
+        ComfyParseLayer::FlatParameters => "flat_parameters",
         ComfyParseLayer::WorkflowChunk => "workflow_chunk",
         ComfyParseLayer::ExplicitNode => "explicit_node",
         ComfyParseLayer::SamplerTraversal => "sampler_traversal",
@@ -187,6 +590,17 @@ fn metadata_field_label(field: ComfyMetadataField) -> &'static str {
 }
 
 pub(crate) fn extract_comfyui_metadata_with_diagnostics(
+    chunks: &HashMap<String, String>,
+) -> (ImageMetadata, ComfyParseDiagnostics) {
+    let mut metadata = ImageMetadata {
+        tool: "ComfyUI".to_string(),
+        ..ImageMetadata::default()
+    };
+    let diagnostics = merge_comfyui_metadata(&mut metadata, chunks);
+    (metadata, diagnostics)
+}
+
+fn extract_comfyui_graph_with_diagnostics(
     chunks: &HashMap<String, String>,
 ) -> (ImageMetadata, ComfyParseDiagnostics) {
     // Breadcrumb for ComfyUI parsing

--- a/src-tauri/src/metadata/comfyui/mod.rs
+++ b/src-tauri/src/metadata/comfyui/mod.rs
@@ -40,6 +40,10 @@ pub(crate) fn merge_comfyui_metadata(
 
     let (mut graph_meta, graph_diagnostics) = extract_comfyui_graph_with_diagnostics(chunks);
     diagnostics.graph_node_count = graph_diagnostics.graph_node_count;
+    diagnostics.selected_output_candidate_count = graph_diagnostics.selected_output_candidate_count;
+    diagnostics.unique_output_root_sampler_count =
+        graph_diagnostics.unique_output_root_sampler_count;
+    diagnostics.output_ambiguous = graph_diagnostics.output_ambiguous;
     for layer in &graph_diagnostics.attempted_layers {
         diagnostics.attempt(*layer);
     }
@@ -644,7 +648,11 @@ fn extract_comfyui_graph_with_diagnostics(
     // Only run if we are missing critical info, OR if we want to fill in gaps.
     diagnostics.attempt(ComfyParseLayer::SamplerTraversal);
     let evaluator = ComfyEvaluator::new(&graph);
-    let traversal_meta = evaluator.extract();
+    let (traversal_meta, output_diagnostics) = evaluator.extract_with_output_diagnostics();
+    diagnostics.selected_output_candidate_count =
+        output_diagnostics.selected_output_candidate_count;
+    diagnostics.unique_output_root_sampler_count = output_diagnostics.unique_root_sampler_count;
+    diagnostics.output_ambiguous = output_diagnostics.ambiguous;
     let before = ComfyMetadataSnapshot::from_metadata(&meta);
     meta.merge_if_missing(traversal_meta);
     diagnostics.record_diff(&before, &meta, ComfyParseLayer::SamplerTraversal);

--- a/src-tauri/src/metadata/comfyui/mod.rs
+++ b/src-tauri/src/metadata/comfyui/mod.rs
@@ -10,6 +10,7 @@ mod graph;
 mod heuristics;
 mod parse_helper;
 mod strategies;
+mod workflow_normalizer;
 
 #[cfg(test)]
 mod tests;

--- a/src-tauri/src/metadata/comfyui/strategies.rs
+++ b/src-tauri/src/metadata/comfyui/strategies.rs
@@ -1,20 +1,10 @@
 use super::conditioning::evaluate_string_node;
-use super::graph::{get_node_param, get_node_title, get_node_type, ComfyGraph};
+use super::graph::{compare_node_ids, get_node_param, get_node_title, get_node_type, ComfyGraph};
 use super::parse_helper::parse_a1111_parameters;
 use crate::metadata::guidance::GuidanceClassifier;
 use crate::metadata::{is_missing_prompt_value, ImageMetadata};
 use serde_json::Value;
-use std::cmp::Ordering;
 use std::collections::HashSet;
-
-fn compare_node_ids(left_id: &str, right_id: &str) -> Ordering {
-    match (left_id.parse::<u64>(), right_id.parse::<u64>()) {
-        (Ok(left), Ok(right)) => left.cmp(&right).then_with(|| left_id.cmp(right_id)),
-        (Ok(_), Err(_)) => Ordering::Less,
-        (Err(_), Ok(_)) => Ordering::Greater,
-        (Err(_), Err(_)) => left_id.cmp(right_id),
-    }
-}
 
 /// Layer 2: Explicit Metadata Nodes
 /// Scans for nodes specifically designed to embed metadata.

--- a/src-tauri/src/metadata/comfyui/tests/diagnostics.rs
+++ b/src-tauri/src/metadata/comfyui/tests/diagnostics.rs
@@ -312,9 +312,13 @@ fn test_diagnostics_report_serializes_chunk_summary_and_field_sources() {
 }
 
 #[test]
-fn test_diagnostics_report_handles_non_graph_chunks_without_panicking() {
+fn test_diagnostics_report_includes_flat_parameters_without_graph_chunks() {
     let mut chunks = HashMap::new();
-    chunks.insert("parameters".to_string(), "not a comfy graph".to_string());
+    chunks.insert(
+        "parameters".to_string(),
+        "flat prompt\nSteps: 12, CFG scale: 5.0, Seed: 0, Model: flat_model, Version: ComfyUI"
+            .to_string(),
+    );
 
     let report = build_comfyui_diagnostics_report(&chunks);
 
@@ -322,9 +326,23 @@ fn test_diagnostics_report_handles_non_graph_chunks_without_panicking() {
     assert!(!report.has_prompt_chunk);
     assert!(!report.has_workflow_chunk);
     assert_eq!(report.graph_node_count, 0);
-    assert!(report.attempted_layers.is_empty());
-    assert!(report.field_sources.is_empty());
+    assert_eq!(report.attempted_layers, vec!["flat_parameters"]);
+    assert_eq!(
+        report.field_sources.get("model").map(String::as_str),
+        Some("flat_parameters")
+    );
+    assert_eq!(
+        report
+            .field_sources
+            .get("positive_prompt")
+            .map(String::as_str),
+        Some("flat_parameters")
+    );
     assert_eq!(report.metadata.tool, "ComfyUI");
-    assert_eq!(report.metadata.model, "Unknown");
+    assert_eq!(report.metadata.model, "flat_model");
+    assert_eq!(report.metadata.seed, Some(0));
+    assert_eq!(report.metadata.steps, 12);
+    assert_eq!(report.metadata.cfg, 5.0);
+    assert_eq!(report.metadata.positive_prompt, "flat prompt");
     assert!(!report.metadata.has_workflow_json);
 }

--- a/src-tauri/src/metadata/comfyui/tests/merge_precedence.rs
+++ b/src-tauri/src/metadata/comfyui/tests/merge_precedence.rs
@@ -1,0 +1,383 @@
+use super::super::diagnostics::{ComfyMetadataField, ComfyParseLayer};
+use crate::metadata::comfyui::{
+    build_comfyui_diagnostics_report, extract_comfyui_metadata_with_diagnostics,
+    merge_comfyui_metadata,
+};
+use crate::metadata::reparse::reparse_from_json;
+use crate::metadata::{extract_a1111_metadata, ImageMetadata};
+use std::collections::HashMap;
+
+const FLAT_COMPLETE: &str = "flat positive <lora:flat-style:0.5> <lora:graph-style:1>\nNegative prompt: flat negative\nSteps: 20, Sampler: flat_sampler, CFG scale: 7.0, Seed: 42, Model hash: flat_hash, Model: flat_model, Version: ComfyUI";
+
+const TRAVERSAL_PROMPT: &str = r#"{
+    "1": {
+        "class_type": "CheckpointLoaderSimple",
+        "inputs": { "ckpt_name": "graph-model.safetensors" }
+    },
+    "2": {
+        "class_type": "LoraLoader",
+        "inputs": {
+            "model": ["1", 0],
+            "clip": ["1", 1],
+            "lora_name": "graph-style.safetensors",
+            "strength_model": 1.0,
+            "strength_clip": 1.0
+        }
+    },
+    "3": {
+        "class_type": "CLIPTextEncode",
+        "inputs": { "text": "graph positive", "clip": ["2", 1] }
+    },
+    "4": {
+        "class_type": "CLIPTextEncode",
+        "inputs": { "text": "graph negative", "clip": ["2", 1] }
+    },
+    "5": {
+        "class_type": "EmptyLatentImage",
+        "inputs": { "width": 512, "height": 512, "batch_size": 1 }
+    },
+    "6": {
+        "class_type": "KSampler",
+        "inputs": {
+            "model": ["2", 0],
+            "positive": ["3", 0],
+            "negative": ["4", 0],
+            "latent_image": ["5", 0],
+            "seed": 999,
+            "steps": 8,
+            "cfg": 1.5,
+            "sampler_name": "euler",
+            "scheduler": "simple",
+            "denoise": 1.0
+        }
+    },
+    "7": {
+        "class_type": "VAEDecode",
+        "inputs": { "samples": ["6", 0], "vae": ["1", 2] }
+    },
+    "8": {
+        "class_type": "SaveImage",
+        "inputs": { "images": ["7", 0], "filename_prefix": "test" }
+    }
+}"#;
+
+fn mixed_chunks(parameters: &str, prompt: &str) -> HashMap<String, String> {
+    HashMap::from([
+        ("parameters".to_string(), parameters.to_string()),
+        ("prompt".to_string(), prompt.to_string()),
+    ])
+}
+
+fn assert_source(
+    diagnostics: &super::super::diagnostics::ComfyParseDiagnostics,
+    field: ComfyMetadataField,
+    expected: ComfyParseLayer,
+) {
+    assert_eq!(diagnostics.field_sources.get(&field), Some(&expected));
+}
+
+#[test]
+fn strong_sampler_traversal_overrides_flat_core_fields_and_unions_resources() {
+    let chunks = mixed_chunks(FLAT_COMPLETE, TRAVERSAL_PROMPT);
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "graph_model");
+    assert_eq!(meta.model_hash, None);
+    assert_eq!(meta.seed, Some(999));
+    assert_eq!(meta.steps, 8);
+    assert_eq!(meta.cfg, 1.5);
+    assert_eq!(meta.sampler, "euler (simple)");
+    assert_eq!(meta.positive_prompt, "graph positive");
+    assert_eq!(meta.negative_prompt, "graph negative");
+    assert_eq!(meta.loras, ["flat_style (0.50)", "graph_style"]);
+    assert_eq!(
+        diagnostics.attempted_layers.first(),
+        Some(&ComfyParseLayer::FlatParameters)
+    );
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Seed,
+        ComfyMetadataField::Steps,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+        ComfyMetadataField::PositivePrompt,
+        ComfyMetadataField::NegativePrompt,
+        ComfyMetadataField::Loras,
+    ] {
+        assert_source(&diagnostics, field, ComfyParseLayer::SamplerTraversal);
+    }
+}
+
+#[test]
+fn explicit_metadata_overrides_conflicting_flat_fields() {
+    let prompt = r#"{
+        "1": {
+            "class_type": "SDParameterGenerator",
+            "inputs": {
+                "ckpt_name": "explicit-model.safetensors",
+                "seed": 314,
+                "steps": 12,
+                "cfg": 4.5,
+                "sampler_name": "dpmpp_2m",
+                "scheduler": "karras"
+            }
+        }
+    }"#;
+    let chunks = mixed_chunks(FLAT_COMPLETE, prompt);
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "explicit_model");
+    assert_eq!(meta.model_hash, None);
+    assert_eq!(meta.seed, Some(314));
+    assert_eq!(meta.steps, 12);
+    assert_eq!(meta.cfg, 4.5);
+    assert_eq!(meta.sampler, "dpmpp_2m (karras)");
+    assert_eq!(
+        meta.positive_prompt,
+        "flat positive <lora:flat-style:0.5> <lora:graph-style:1>"
+    );
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Seed,
+        ComfyMetadataField::Steps,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+    ] {
+        assert_source(&diagnostics, field, ComfyParseLayer::ExplicitNode);
+    }
+    assert_source(
+        &diagnostics,
+        ComfyMetadataField::PositivePrompt,
+        ComfyParseLayer::FlatParameters,
+    );
+}
+
+#[test]
+fn sampler_fallback_only_fills_fields_missing_from_flat_parameters() {
+    let parameters = "flat positive\nSteps: 20, Sampler: flat_sampler, CFG scale: 7.0, Model hash: flat_hash, Model: flat_model, Version: ComfyUI";
+    let prompt = r#"{
+        "1": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": { "ckpt_name": "fallback-model.safetensors" }
+        },
+        "2": {
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": "fallback positive", "clip": ["1", 1] }
+        },
+        "3": {
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": "fallback negative", "clip": ["1", 1] }
+        },
+        "4": {
+            "class_type": "KSampler",
+            "inputs": {
+                "model": ["1", 0],
+                "positive": ["2", 0],
+                "negative": ["3", 0],
+                "seed": 456,
+                "steps": 9,
+                "cfg": 2.0,
+                "sampler_name": "heun",
+                "scheduler": "normal"
+            }
+        }
+    }"#;
+    let chunks = mixed_chunks(parameters, prompt);
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "flat_model");
+    assert_eq!(meta.model_hash.as_deref(), Some("flat_hash"));
+    assert_eq!(meta.steps, 20);
+    assert_eq!(meta.cfg, 7.0);
+    assert_eq!(meta.sampler, "flat_sampler");
+    assert_eq!(meta.positive_prompt, "flat positive");
+    assert_eq!(meta.seed, Some(456));
+    assert_eq!(meta.negative_prompt, "fallback negative");
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Steps,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+        ComfyMetadataField::PositivePrompt,
+    ] {
+        assert_source(&diagnostics, field, ComfyParseLayer::FlatParameters);
+    }
+    for field in [ComfyMetadataField::Seed, ComfyMetadataField::NegativePrompt] {
+        assert_source(&diagnostics, field, ComfyParseLayer::SamplerFallback);
+    }
+}
+
+#[test]
+fn global_scan_only_fills_fields_missing_from_flat_parameters() {
+    let parameters = "flat positive\nSteps: 20, Sampler: flat_sampler, CFG scale: 7.0, Model hash: flat_hash, Model: flat_model, Version: ComfyUI";
+    let prompt = r#"{
+        "1": {
+            "class_type": "String",
+            "inputs": {
+                "value": "global positive\nNegative prompt: global negative\nSteps: 6, Sampler: global_sampler, CFG scale: 2.5, Seed: 777, Model: global_model"
+            }
+        }
+    }"#;
+    let chunks = mixed_chunks(parameters, prompt);
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "flat_model");
+    assert_eq!(meta.model_hash.as_deref(), Some("flat_hash"));
+    assert_eq!(meta.steps, 20);
+    assert_eq!(meta.cfg, 7.0);
+    assert_eq!(meta.sampler, "flat_sampler");
+    assert_eq!(meta.positive_prompt, "flat positive");
+    assert_eq!(meta.seed, Some(777));
+    assert_eq!(meta.negative_prompt, "global negative");
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Steps,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+        ComfyMetadataField::PositivePrompt,
+    ] {
+        assert_source(&diagnostics, field, ComfyParseLayer::FlatParameters);
+    }
+    for field in [ComfyMetadataField::Seed, ComfyMetadataField::NegativePrompt] {
+        assert_source(&diagnostics, field, ComfyParseLayer::GlobalScan);
+    }
+}
+
+#[test]
+fn placeholder_flat_prompts_are_fillable_but_empty_graph_prompts_do_not_erase_text() {
+    let placeholder_chunks = mixed_chunks(
+        "unknown\nNegative prompt: unknown\nSteps: 20, Model: flat_model, Version: ComfyUI",
+        TRAVERSAL_PROMPT,
+    );
+    let (placeholder_meta, _) = extract_comfyui_metadata_with_diagnostics(&placeholder_chunks);
+    assert_eq!(placeholder_meta.positive_prompt, "graph positive");
+    assert_eq!(placeholder_meta.negative_prompt, "graph negative");
+
+    let zeroed_prompt = r#"{
+        "1": {
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": { "ckpt_name": "graph-model.safetensors" }
+        },
+        "2": {
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": "graph positive", "clip": ["1", 1] }
+        },
+        "3": {
+            "class_type": "ConditioningZeroOut",
+            "inputs": { "conditioning": ["2", 0] }
+        },
+        "4": {
+            "class_type": "KSampler",
+            "inputs": {
+                "model": ["1", 0],
+                "positive": ["2", 0],
+                "negative": ["3", 0],
+                "seed": 1,
+                "steps": 8,
+                "cfg": 1.0,
+                "sampler_name": "euler",
+                "scheduler": "simple"
+            }
+        },
+        "5": {
+            "class_type": "VAEDecode",
+            "inputs": { "samples": ["4", 0] }
+        },
+        "6": {
+            "class_type": "SaveImage",
+            "inputs": { "images": ["5", 0] }
+        }
+    }"#;
+    let chunks = mixed_chunks(FLAT_COMPLETE, zeroed_prompt);
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+    assert_eq!(meta.negative_prompt, "flat negative");
+    assert_source(
+        &diagnostics,
+        ComfyMetadataField::NegativePrompt,
+        ComfyParseLayer::FlatParameters,
+    );
+}
+
+#[test]
+fn model_hash_follows_the_selected_model() {
+    let matching_parameters = FLAT_COMPLETE.replace("flat_model", "Graph-Model.safetensors");
+    let matching_chunks = mixed_chunks(&matching_parameters, TRAVERSAL_PROMPT);
+    let (matching_meta, _) = extract_comfyui_metadata_with_diagnostics(&matching_chunks);
+    assert_eq!(matching_meta.model, "graph_model");
+    assert_eq!(
+        matching_meta.model_hash.as_deref(),
+        Some("flat_hash"),
+        "equivalent model names should retain the flat hash after graph normalization"
+    );
+
+    let weak_chunks = mixed_chunks(
+        FLAT_COMPLETE,
+        r#"{
+            "1": {
+                "class_type": "CheckpointLoaderSimple",
+                "inputs": { "ckpt_name": "weak-model.safetensors" }
+            }
+        }"#,
+    );
+    let (weak_meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&weak_chunks);
+    assert_eq!(weak_meta.model, "flat_model");
+    assert_eq!(weak_meta.model_hash.as_deref(), Some("flat_hash"));
+    assert_source(
+        &diagnostics,
+        ComfyMetadataField::Model,
+        ComfyParseLayer::FlatParameters,
+    );
+}
+
+#[test]
+fn scanner_reparse_and_diagnostics_share_the_same_final_metadata() {
+    let chunks = mixed_chunks(FLAT_COMPLETE, TRAVERSAL_PROMPT);
+
+    let mut scanner_meta = extract_a1111_metadata(FLAT_COMPLETE, None);
+    let scanner_diagnostics = merge_comfyui_metadata(&mut scanner_meta, &chunks);
+    let report = build_comfyui_diagnostics_report(&chunks);
+    let envelope = serde_json::json!({
+        "parameters": FLAT_COMPLETE,
+        "prompt": TRAVERSAL_PROMPT
+    })
+    .to_string();
+    let reparsed = reparse_from_json(&envelope, "ComfyUI")
+        .expect("mixed ComfyUI envelope should reparse")
+        .metadata;
+
+    assert_core_metadata_eq(&scanner_meta, &reparsed);
+    assert_eq!(report.metadata.model, scanner_meta.model);
+    assert_eq!(report.metadata.seed, scanner_meta.seed);
+    assert_eq!(report.metadata.steps, scanner_meta.steps);
+    assert_eq!(report.metadata.cfg, scanner_meta.cfg);
+    assert_eq!(report.metadata.sampler, scanner_meta.sampler);
+    assert_eq!(
+        report.metadata.positive_prompt,
+        scanner_meta.positive_prompt
+    );
+    assert_eq!(
+        report.metadata.negative_prompt,
+        scanner_meta.negative_prompt
+    );
+    assert_eq!(
+        report.field_sources.get("model").map(String::as_str),
+        Some("sampler_traversal")
+    );
+    assert_source(
+        &scanner_diagnostics,
+        ComfyMetadataField::Model,
+        ComfyParseLayer::SamplerTraversal,
+    );
+}
+
+fn assert_core_metadata_eq(left: &ImageMetadata, right: &ImageMetadata) {
+    assert_eq!(left.model, right.model);
+    assert_eq!(left.model_hash, right.model_hash);
+    assert_eq!(left.seed, right.seed);
+    assert_eq!(left.steps, right.steps);
+    assert_eq!(left.cfg, right.cfg);
+    assert_eq!(left.sampler, right.sampler);
+    assert_eq!(left.positive_prompt, right.positive_prompt);
+    assert_eq!(left.negative_prompt, right.negative_prompt);
+    assert_eq!(left.loras, right.loras);
+}

--- a/src-tauri/src/metadata/comfyui/tests/mod.rs
+++ b/src-tauri/src/metadata/comfyui/tests/mod.rs
@@ -6,6 +6,7 @@ pub mod merge_precedence;
 pub mod models;
 pub mod multi_stage;
 pub mod official_examples;
+pub mod output_selection;
 pub mod prompts;
 pub mod real_world;
 pub mod repro_dual_ip_adapter;

--- a/src-tauri/src/metadata/comfyui/tests/mod.rs
+++ b/src-tauri/src/metadata/comfyui/tests/mod.rs
@@ -17,3 +17,4 @@ pub mod strategies;
 pub mod subgraph_repro;
 pub mod test_workflow_repro;
 pub mod ui_format;
+pub mod workflow_subgraphs;

--- a/src-tauri/src/metadata/comfyui/tests/mod.rs
+++ b/src-tauri/src/metadata/comfyui/tests/mod.rs
@@ -2,6 +2,7 @@ pub mod complex_workflows;
 pub mod diagnostics;
 pub mod false_positive_models;
 pub mod general;
+pub mod merge_precedence;
 pub mod models;
 pub mod multi_stage;
 pub mod official_examples;

--- a/src-tauri/src/metadata/comfyui/tests/output_selection.rs
+++ b/src-tauri/src/metadata/comfyui/tests/output_selection.rs
@@ -1,0 +1,438 @@
+use super::super::diagnostics::{ComfyMetadataField, ComfyParseLayer};
+use crate::metadata::comfyui::extract_comfyui_metadata_with_diagnostics;
+use serde_json::{json, Map, Value};
+use std::collections::HashMap;
+
+fn add_sampler_branch(nodes: &mut Map<String, Value>, sampler_id: &str, label: &str) {
+    let base = sampler_id.parse::<u64>().expect("numeric sampler id");
+    let loader_id = format!("{}01", sampler_id);
+    let positive_id = format!("{}02", sampler_id);
+    let negative_id = format!("{}03", sampler_id);
+
+    nodes.insert(
+        loader_id.clone(),
+        json!({
+            "class_type": "CheckpointLoaderSimple",
+            "inputs": { "ckpt_name": format!("{label}.safetensors") }
+        }),
+    );
+    nodes.insert(
+        positive_id.clone(),
+        json!({
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": format!("{label} positive") }
+        }),
+    );
+    nodes.insert(
+        negative_id.clone(),
+        json!({
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": format!("{label} negative") }
+        }),
+    );
+    nodes.insert(
+        sampler_id.to_string(),
+        json!({
+            "class_type": "KSampler",
+            "inputs": {
+                "model": [loader_id, 0],
+                "positive": [positive_id, 0],
+                "negative": [negative_id, 0],
+                "seed": base * 100,
+                "steps": base as u32,
+                "cfg": base as f64 / 2.0,
+                "sampler_name": "euler",
+                "scheduler": "simple"
+            }
+        }),
+    );
+}
+
+fn add_output(
+    nodes: &mut Map<String, Value>,
+    output_id: &str,
+    node_type: &str,
+    sampler_id: Option<&str>,
+    mode: Option<i64>,
+) {
+    let mut node = json!({
+        "class_type": node_type,
+        "inputs": {}
+    });
+    if let Some(sampler_id) = sampler_id {
+        node["inputs"]["images"] = json!([sampler_id, 0]);
+    }
+    if let Some(mode) = mode {
+        node["mode"] = json!(mode);
+    }
+    nodes.insert(output_id.to_string(), node);
+}
+
+fn chunks(nodes: Map<String, Value>, parameters: Option<&str>) -> HashMap<String, String> {
+    let mut chunks = HashMap::from([(
+        "prompt".to_string(),
+        serde_json::to_string(&Value::Object(nodes)).expect("serialize prompt graph"),
+    )]);
+    if let Some(parameters) = parameters {
+        chunks.insert("parameters".to_string(), parameters.to_string());
+    }
+    chunks
+}
+
+fn assert_sampler_source(
+    diagnostics: &super::super::diagnostics::ComfyParseDiagnostics,
+    expected: ComfyParseLayer,
+) {
+    assert_eq!(
+        diagnostics.field_sources.get(&ComfyMetadataField::Model),
+        Some(&expected)
+    );
+    assert_eq!(
+        diagnostics.field_sources.get(&ComfyMetadataField::Steps),
+        Some(&expected)
+    );
+}
+
+#[test]
+fn persisted_save_beats_conflicting_preview_branch() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "preview-model");
+    add_sampler_branch(&mut nodes, "10", "saved-model");
+    add_output(&mut nodes, "20", "PreviewImage", Some("2"), None);
+    add_output(&mut nodes, "21", "SaveImage", Some("10"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "saved_model");
+    assert_eq!(meta.seed, Some(1_000));
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn disconnected_save_is_not_connected_by_an_unrelated_wireless_broadcaster() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "preview-model");
+    nodes.insert(
+        "15".to_string(),
+        json!({
+            "class_type": "Anything Everywhere",
+            "inputs": {}
+        }),
+    );
+    add_output(&mut nodes, "20", "SaveImage", None, None);
+    add_output(&mut nodes, "21", "PreviewImage", Some("2"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "preview_model");
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn multiple_persisted_saves_sharing_one_root_remain_trusted() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "shared-model");
+    add_output(&mut nodes, "20", "SaveImage", Some("2"), None);
+    add_output(&mut nodes, "21", "ImageSave", Some("2"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "shared_model");
+    assert_eq!(diagnostics.selected_output_candidate_count, 2);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn sampler_chain_through_latent_intermediate_resolves_to_one_root() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "base-model");
+    add_sampler_branch(&mut nodes, "10", "refiner-model");
+    nodes.insert(
+        "30".to_string(),
+        json!({
+            "class_type": "LatentUpscale",
+            "inputs": { "samples": ["2", 0] }
+        }),
+    );
+    nodes
+        .get_mut("10")
+        .expect("refiner sampler")
+        .get_mut("inputs")
+        .expect("sampler inputs")["latent_image"] = json!(["30", 0]);
+    add_output(&mut nodes, "20", "SaveImage", Some("2"), None);
+    add_output(&mut nodes, "21", "ImageSave", Some("10"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "base_model");
+    assert_eq!(meta.seed, Some(200));
+    assert_eq!(diagnostics.selected_output_candidate_count, 2);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn sampler_auxiliary_image_does_not_become_latent_ancestry() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "reference-model");
+    add_sampler_branch(&mut nodes, "10", "primary-model");
+    nodes.insert(
+        "30".to_string(),
+        json!({
+            "class_type": "VAEDecode",
+            "inputs": { "samples": ["2", 0] }
+        }),
+    );
+    nodes.insert(
+        "40".to_string(),
+        json!({
+            "class_type": "EmptyLatentImage",
+            "inputs": { "width": 512, "height": 512, "batch_size": 1 }
+        }),
+    );
+    let primary_inputs = nodes
+        .get_mut("10")
+        .expect("primary sampler")
+        .get_mut("inputs")
+        .expect("sampler inputs");
+    primary_inputs["image"] = json!(["30", 0]);
+    primary_inputs["latent_image"] = json!(["40", 0]);
+    add_output(&mut nodes, "20", "SaveImage", Some("10"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "primary_model");
+    assert_eq!(meta.seed, Some(1_000));
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn conflicting_saved_roots_preserve_flat_metadata_and_report_ambiguity() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "first-graph-model");
+    add_sampler_branch(&mut nodes, "10", "second-graph-model");
+    add_output(&mut nodes, "20", "SaveImage", Some("2"), None);
+    add_output(&mut nodes, "21", "ImageSave", Some("10"), None);
+    let parameters = "flat positive\nNegative prompt: flat negative\nSteps: 30, Sampler: dpmpp_2m, CFG scale: 7.0, Seed: 42, Model: flat-model, Version: ComfyUI";
+
+    let (meta, diagnostics) =
+        extract_comfyui_metadata_with_diagnostics(&chunks(nodes, Some(parameters)));
+
+    assert_eq!(meta.model, "flat-model");
+    assert_eq!(meta.seed, Some(42));
+    assert_eq!(meta.steps, 30);
+    assert_eq!(meta.cfg, 7.0);
+    assert_eq!(meta.sampler, "dpmpp_2m");
+    assert_eq!(meta.positive_prompt, "flat positive");
+    assert_eq!(diagnostics.selected_output_candidate_count, 2);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 2);
+    assert!(diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::FlatParameters);
+}
+
+#[test]
+fn ambiguous_outputs_without_flat_data_use_numeric_sampler_fallback() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "10", "later-model");
+    add_sampler_branch(&mut nodes, "2", "numeric-first-model");
+    add_output(&mut nodes, "20", "SaveImage", Some("10"), None);
+    add_output(&mut nodes, "21", "ImageSave", Some("2"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "numeric_first_model");
+    assert_eq!(meta.seed, Some(200));
+    assert_eq!(meta.steps, 2);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 2);
+    assert!(diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerFallback);
+}
+
+#[test]
+fn variadic_ui_save_collects_all_same_name_image_inputs() {
+    let workflow = json!({
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CheckpointLoaderSimple",
+                "widgets_values": ["numeric-first-model.safetensors"]
+            },
+            {
+                "id": 2,
+                "type": "KSampler",
+                "inputs": [
+                    { "name": "model", "type": "MODEL", "link": 1 }
+                ],
+                "widgets_values": [200, "fixed", 2, 1.0, "euler", "simple", 1.0]
+            },
+            {
+                "id": 4,
+                "type": "VAEDecode",
+                "inputs": [
+                    { "name": "samples", "type": "LATENT", "link": 2 }
+                ]
+            },
+            {
+                "id": 9,
+                "type": "CheckpointLoaderSimple",
+                "widgets_values": ["later-model.safetensors"]
+            },
+            {
+                "id": 10,
+                "type": "KSampler",
+                "inputs": [
+                    { "name": "model", "type": "MODEL", "link": 3 }
+                ],
+                "widgets_values": [1000, "fixed", 10, 5.0, "euler", "simple", 1.0]
+            },
+            {
+                "id": 11,
+                "type": "VAEDecode",
+                "inputs": [
+                    { "name": "samples", "type": "LATENT", "link": 4 }
+                ]
+            },
+            {
+                "id": 20,
+                "type": "Save Image Batch",
+                "inputs": [
+                    { "name": "images", "type": "IMAGE", "link": 5 },
+                    { "name": "images", "type": "IMAGE", "link": 6 }
+                ]
+            }
+        ],
+        "links": [
+            [1, 1, 0, 2, 0, "MODEL"],
+            [2, 2, 0, 4, 0, "LATENT"],
+            [3, 9, 0, 10, 0, "MODEL"],
+            [4, 10, 0, 11, 0, "LATENT"],
+            [5, 4, 0, 20, 0, "IMAGE"],
+            [6, 11, 0, 20, 1, "IMAGE"]
+        ]
+    });
+    let chunks = HashMap::from([("workflow".to_string(), workflow.to_string())]);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "numeric_first_model");
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 2);
+    assert!(diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerFallback);
+}
+
+#[test]
+fn disconnected_muted_and_bypassed_saves_are_not_candidates() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "active-model");
+    add_sampler_branch(&mut nodes, "10", "ignored-model");
+    add_output(&mut nodes, "20", "SaveImage", Some("2"), None);
+    add_output(&mut nodes, "21", "SaveImage", None, None);
+    add_output(&mut nodes, "22", "SaveImage", Some("10"), Some(2));
+    add_output(&mut nodes, "23", "SaveImage", Some("10"), Some(4));
+    nodes.insert(
+        "24".to_string(),
+        json!({
+            "class_type": "SaveImage",
+            "inputs": { "images": "not-a-node" }
+        }),
+    );
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "active_model");
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn preview_only_workflow_remains_supported() {
+    let mut nodes = Map::new();
+    add_sampler_branch(&mut nodes, "2", "preview-only-model");
+    add_output(&mut nodes, "20", "PreviewImage", Some("2"), None);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks(nodes, None));
+
+    assert_eq!(meta.model, "preview_only_model");
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}
+
+#[test]
+fn custom_spaced_save_uses_ui_image_and_latent_input_types() {
+    let workflow = json!({
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CheckpointLoaderSimple",
+                "widgets_values": ["ui-model.safetensors"]
+            },
+            {
+                "id": 2,
+                "type": "CLIPTextEncode",
+                "widgets_values": ["ui positive"]
+            },
+            {
+                "id": 3,
+                "type": "CLIPTextEncode",
+                "widgets_values": ["ui negative"]
+            },
+            {
+                "id": 4,
+                "type": "KSampler",
+                "inputs": [
+                    { "name": "model", "type": "MODEL", "link": 1 },
+                    { "name": "positive", "type": "CONDITIONING", "link": 2 },
+                    { "name": "negative", "type": "CONDITIONING", "link": 3 }
+                ],
+                "widgets_values": [400, "fixed", 12, 3.0, "euler", "simple", 1.0]
+            },
+            {
+                "id": 5,
+                "type": "CustomDecode",
+                "inputs": [
+                    { "name": "latent_result", "type": "LATENT", "link": 4 }
+                ]
+            },
+            {
+                "id": 6,
+                "type": "Save Rendered Image",
+                "mode": 0,
+                "inputs": [
+                    { "name": "render", "type": "IMAGE", "link": 5 }
+                ]
+            }
+        ],
+        "links": [
+            [1, 1, 0, 4, 0, "MODEL"],
+            [2, 2, 0, 4, 1, "CONDITIONING"],
+            [3, 3, 0, 4, 2, "CONDITIONING"],
+            [4, 4, 0, 5, 0, "LATENT"],
+            [5, 5, 0, 6, 0, "IMAGE"]
+        ]
+    });
+    let chunks = HashMap::from([("workflow".to_string(), workflow.to_string())]);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "ui_model");
+    assert_eq!(meta.seed, Some(400));
+    assert_eq!(meta.steps, 12);
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert_sampler_source(&diagnostics, ComfyParseLayer::SamplerTraversal);
+}

--- a/src-tauri/src/metadata/comfyui/tests/real_world.rs
+++ b/src-tauri/src/metadata/comfyui/tests/real_world.rs
@@ -399,6 +399,7 @@ fn test_trusted_graph_model_preserves_flat_hash_when_model_matches() {
         }
     }"#;
     let mut chunks = HashMap::new();
+    chunks.insert("parameters".to_string(), parameters.to_string());
     chunks.insert("prompt".to_string(), prompt.to_string());
 
     let mut merged = extract_a1111_metadata(parameters, None);
@@ -430,6 +431,7 @@ fn test_global_scan_model_does_not_override_known_flat_model() {
         }
     }"#;
     let mut chunks = HashMap::new();
+    chunks.insert("parameters".to_string(), parameters.to_string());
     chunks.insert("prompt".to_string(), prompt.to_string());
 
     let mut merged = extract_a1111_metadata(parameters, None);
@@ -437,8 +439,8 @@ fn test_global_scan_model_does_not_override_known_flat_model() {
 
     assert_eq!(
         diagnostics.field_sources.get(&ComfyMetadataField::Model),
-        Some(&ComfyParseLayer::GlobalScan),
-        "synthetic graph should only provide model through weak global scan"
+        Some(&ComfyParseLayer::FlatParameters),
+        "the retained flat model should report its selected provenance"
     );
     assert_eq!(
         merged.model, "trusted_flat_model",

--- a/src-tauri/src/metadata/comfyui/tests/real_world.rs
+++ b/src-tauri/src/metadata/comfyui/tests/real_world.rs
@@ -214,19 +214,19 @@ fn test_real_world_fixtures_extract_expected_metadata() {
             ip_adapters: &[],
         },
         &[
-            (ComfyMetadataField::Model, ComfyParseLayer::SamplerFallback),
-            (ComfyMetadataField::Seed, ComfyParseLayer::SamplerFallback),
-            (ComfyMetadataField::Steps, ComfyParseLayer::SamplerFallback),
-            (ComfyMetadataField::Cfg, ComfyParseLayer::SamplerFallback),
+            (ComfyMetadataField::Model, ComfyParseLayer::SamplerTraversal),
+            (ComfyMetadataField::Seed, ComfyParseLayer::SamplerTraversal),
+            (ComfyMetadataField::Steps, ComfyParseLayer::SamplerTraversal),
+            (ComfyMetadataField::Cfg, ComfyParseLayer::SamplerTraversal),
             (
                 ComfyMetadataField::Sampler,
-                ComfyParseLayer::SamplerFallback,
+                ComfyParseLayer::SamplerTraversal,
             ),
             (
                 ComfyMetadataField::PositivePrompt,
-                ComfyParseLayer::SamplerFallback,
+                ComfyParseLayer::SamplerTraversal,
             ),
-            (ComfyMetadataField::Loras, ComfyParseLayer::SamplerFallback),
+            (ComfyMetadataField::Loras, ComfyParseLayer::SamplerTraversal),
         ],
     );
 }

--- a/src-tauri/src/metadata/comfyui/tests/workflow_subgraphs.rs
+++ b/src-tauri/src/metadata/comfyui/tests/workflow_subgraphs.rs
@@ -1,0 +1,613 @@
+use super::super::diagnostics::{ComfyMetadataField, ComfyParseLayer};
+use super::super::workflow_normalizer::{normalize_workflow_with_test_limits, normalized_node_ids};
+use crate::metadata::comfyui::extract_comfyui_metadata_with_diagnostics;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+const KREA_FIXTURE: &str =
+    include_str!("fixtures/real_world/krea2_turbo_official_template.chunks.json");
+
+fn chunks_from_workflow(workflow: Value) -> HashMap<String, String> {
+    HashMap::from([("workflow".to_string(), workflow.to_string())])
+}
+
+fn basic_definition(id: &str, model: &str, seed: i64) -> Value {
+    json!({
+        "id": id,
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [{ "name": "seed", "type": "INT" }],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [
+            {
+                "id": 1,
+                "type": "CheckpointLoaderSimple",
+                "inputs": [],
+                "widgets_values": [format!("{model}.safetensors")]
+            },
+            {
+                "id": 2,
+                "type": "CLIPTextEncode",
+                "inputs": [],
+                "widgets_values": ["subgraph positive"]
+            },
+            {
+                "id": 3,
+                "type": "CLIPTextEncode",
+                "inputs": [],
+                "widgets_values": ["subgraph negative"]
+            },
+            {
+                "id": 4,
+                "type": "KSampler",
+                "inputs": [
+                    { "name": "model", "type": "MODEL", "link": 1 },
+                    { "name": "positive", "type": "CONDITIONING", "link": 2 },
+                    { "name": "negative", "type": "CONDITIONING", "link": 3 },
+                    { "name": "latent_image", "type": "LATENT", "link": null },
+                    { "name": "seed", "type": "INT", "widget": { "name": "seed" }, "link": 4 }
+                ],
+                "widgets_values": [seed, "fixed", 8, 1.0, "euler", "simple", 1.0]
+            },
+            {
+                "id": 5,
+                "type": "VAEDecode",
+                "inputs": [{ "name": "samples", "type": "LATENT", "link": 5 }],
+                "widgets_values": []
+            }
+        ],
+        "links": [
+            { "id": 1, "origin_id": 1, "origin_slot": 0, "target_id": 4, "target_slot": 0, "type": "MODEL" },
+            { "id": 2, "origin_id": 2, "origin_slot": 0, "target_id": 4, "target_slot": 1, "type": "CONDITIONING" },
+            { "id": 3, "origin_id": 3, "origin_slot": 0, "target_id": 4, "target_slot": 2, "type": "CONDITIONING" },
+            { "id": 4, "origin_id": -10, "origin_slot": 0, "target_id": 4, "target_slot": 4, "type": "INT" },
+            { "id": 5, "origin_id": 4, "origin_slot": 0, "target_id": 5, "target_slot": 0, "type": "LATENT" },
+            { "id": 6, "origin_id": 5, "origin_slot": 0, "target_id": -20, "target_slot": 0, "type": "IMAGE" }
+        ]
+    })
+}
+
+fn instance(id: i64, definition: &str, seed_override: Option<i64>, mode: i64) -> Value {
+    json!({
+        "id": id,
+        "type": definition,
+        "mode": mode,
+        "inputs": [
+            { "name": "seed", "type": "INT", "widget": { "name": "seed" }, "link": null }
+        ],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [] }],
+        "properties": { "proxyWidgets": [["4", "seed"]] },
+        "widgets_values": seed_override.into_iter().collect::<Vec<_>>()
+    })
+}
+
+fn save_node(id: i64, link: i64) -> Value {
+    json!({
+        "id": id,
+        "type": "SaveImage",
+        "mode": 0,
+        "inputs": [{ "name": "images", "type": "IMAGE", "link": link }],
+        "outputs": [],
+        "widgets_values": ["subgraph"]
+    })
+}
+
+fn single_instance_workflow(seed_override: Option<i64>, external_seed: Option<i64>) -> Value {
+    let mut nodes = vec![instance(30, "basic", seed_override, 0), save_node(40, 1)];
+    let mut links = vec![json!([1, 30, 0, 40, 0, "IMAGE"])];
+    if let Some(seed) = external_seed {
+        nodes.push(json!({
+            "id": 20,
+            "type": "PrimitiveInt",
+            "inputs": [],
+            "outputs": [{ "name": "INT", "type": "INT", "links": [2] }],
+            "widgets_values": [seed]
+        }));
+        nodes[0]["inputs"][0]["link"] = json!(2);
+        links.push(json!([2, 20, 0, 30, 0, "INT"]));
+    }
+
+    json!({
+        "nodes": nodes,
+        "links": links,
+        "definitions": { "subgraphs": [basic_definition("basic", "subgraph-model", 11)] },
+        "version": 0.4
+    })
+}
+
+fn assert_traversal_source(
+    diagnostics: &super::super::diagnostics::ComfyParseDiagnostics,
+    field: ComfyMetadataField,
+) {
+    assert_eq!(
+        diagnostics.field_sources.get(&field),
+        Some(&ComfyParseLayer::SamplerTraversal)
+    );
+}
+
+#[test]
+fn krea_workflow_only_expands_official_subgraph_metadata() {
+    let raw: HashMap<String, Value> =
+        serde_json::from_str(KREA_FIXTURE).expect("Krea chunk fixture");
+    let workflow = raw
+        .get("workflow")
+        .and_then(Value::as_str)
+        .expect("Krea workflow chunk");
+    let workflow_json: Value = serde_json::from_str(workflow).expect("Krea workflow JSON");
+    let expected_prompt = workflow_json["definitions"]["subgraphs"][0]["nodes"]
+        .as_array()
+        .and_then(|nodes| nodes.iter().find(|node| node["id"] == 19))
+        .and_then(|node| node["widgets_values"][0].as_str())
+        .expect("Krea user prompt")
+        .to_string();
+    let chunks = HashMap::from([("workflow".to_string(), workflow.to_string())]);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+    let normalized_ids = normalized_node_ids(&workflow_json);
+
+    assert_eq!(meta.model, "krea2_turbo_fp8_scaled");
+    assert_eq!(meta.seed, Some(552_211_234_818_773));
+    assert_eq!(meta.steps, 8);
+    assert_eq!(meta.cfg, 1.0);
+    assert_eq!(meta.sampler, "euler (simple)");
+    assert_eq!(meta.positive_prompt, expected_prompt);
+    assert_eq!(meta.negative_prompt, "");
+    assert_eq!(meta.workflow_json.as_deref(), Some(workflow));
+    assert!(meta.has_workflow_hint);
+    assert!(normalized_ids.len() > 5);
+    assert!(normalized_ids.contains("30:3"));
+    assert!(normalized_ids.contains("30:19"));
+    assert!(normalized_ids.contains("29"));
+    assert!(!normalized_ids.contains("30"));
+    assert_eq!(diagnostics.graph_node_count, normalized_ids.len());
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Seed,
+        ComfyMetadataField::Steps,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+        ComfyMetadataField::PositivePrompt,
+    ] {
+        assert_traversal_source(&diagnostics, field);
+    }
+    assert_eq!(
+        diagnostics
+            .field_sources
+            .get(&ComfyMetadataField::WorkflowJson),
+        Some(&ComfyParseLayer::WorkflowChunk)
+    );
+}
+
+#[test]
+fn subgraph_inputs_use_defaults_then_proxy_then_external_link() {
+    for (workflow, expected_seed) in [
+        (single_instance_workflow(None, None), 11),
+        (single_instance_workflow(Some(77), None), 77),
+        (single_instance_workflow(Some(77), Some(99)), 99),
+    ] {
+        let (meta, diagnostics) =
+            extract_comfyui_metadata_with_diagnostics(&chunks_from_workflow(workflow));
+        assert_eq!(meta.model, "subgraph_model");
+        assert_eq!(meta.seed, Some(expected_seed));
+        assert_traversal_source(&diagnostics, ComfyMetadataField::Seed);
+    }
+}
+
+#[test]
+fn repeated_subgraph_instances_keep_namespaced_nodes_distinct() {
+    let workflow = json!({
+        "nodes": [
+            instance(30, "basic", Some(30), 0),
+            instance(31, "basic", Some(31), 0),
+            save_node(40, 1),
+            save_node(41, 2)
+        ],
+        "links": [
+            [1, 30, 0, 40, 0, "IMAGE"],
+            [2, 31, 0, 41, 0, "IMAGE"]
+        ],
+        "definitions": { "subgraphs": [basic_definition("basic", "subgraph-model", 11)] }
+    });
+    let ids = normalized_node_ids(&workflow);
+    assert!(ids.contains("30:4"));
+    assert!(ids.contains("31:4"));
+
+    let (meta, diagnostics) =
+        extract_comfyui_metadata_with_diagnostics(&chunks_from_workflow(workflow));
+    assert!(diagnostics.output_ambiguous);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 2);
+    assert_eq!(meta.seed, Some(30));
+    assert_eq!(
+        diagnostics.field_sources.get(&ComfyMetadataField::Seed),
+        Some(&ComfyParseLayer::SamplerFallback)
+    );
+}
+
+#[test]
+fn nested_subgraph_output_reaches_root_sampler() {
+    let outer = json!({
+        "id": "outer",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [{
+            "id": 7,
+            "type": "basic",
+            "mode": 0,
+            "inputs": [{ "name": "seed", "type": "INT", "widget": { "name": "seed" }, "link": null }],
+            "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [1] }],
+            "properties": { "proxyWidgets": [["4", "seed"]] },
+            "widgets_values": [71]
+        }],
+        "links": [
+            { "id": 1, "origin_id": 7, "origin_slot": 0, "target_id": -20, "target_slot": 0, "type": "IMAGE" }
+        ]
+    });
+    let workflow = json!({
+        "nodes": [
+            { "id": 30, "type": "outer", "mode": 0, "inputs": [], "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [1] }] },
+            save_node(40, 1)
+        ],
+        "links": [[1, 30, 0, 40, 0, "IMAGE"]],
+        "definitions": { "subgraphs": [basic_definition("basic", "nested-model", 11), outer] }
+    });
+
+    let ids = normalized_node_ids(&workflow);
+    assert!(ids.contains("30:7:4"));
+    let (meta, diagnostics) =
+        extract_comfyui_metadata_with_diagnostics(&chunks_from_workflow(workflow));
+    assert_eq!(meta.model, "nested_model");
+    assert_eq!(meta.seed, Some(71));
+    assert_traversal_source(&diagnostics, ComfyMetadataField::Model);
+}
+
+#[test]
+fn inactive_cyclic_and_malformed_subgraphs_do_not_gain_traversal_authority() {
+    let cyclic = json!({
+        "id": "cycle",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [{ "id": 7, "type": "cycle", "mode": 0, "inputs": [], "outputs": [{ "name": "IMAGE", "type": "IMAGE" }] }],
+        "links": [{ "origin_id": 7, "origin_slot": 0, "target_id": -20, "target_slot": 0, "type": "IMAGE" }]
+    });
+    let malformed = json!({
+        "id": "malformed",
+        "inputNode": { "id": -10 },
+        "inputs": [],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [],
+        "links": []
+    });
+
+    for (definition, node) in [
+        (
+            basic_definition("basic", "muted-model", 11),
+            instance(30, "basic", None, 2),
+        ),
+        (
+            basic_definition("basic", "bypassed-model", 11),
+            instance(30, "basic", None, 4),
+        ),
+        (cyclic, instance(30, "cycle", None, 0)),
+        (malformed, instance(30, "malformed", None, 0)),
+    ] {
+        let workflow = json!({
+            "nodes": [node, save_node(40, 1)],
+            "links": [[1, 30, 0, 40, 0, "IMAGE"]],
+            "definitions": { "subgraphs": [definition] }
+        });
+        let (meta, diagnostics) =
+            extract_comfyui_metadata_with_diagnostics(&chunks_from_workflow(workflow));
+        assert_eq!(meta.model, "Unknown");
+        assert_eq!(diagnostics.unique_output_root_sampler_count, 0);
+        assert_ne!(
+            diagnostics.field_sources.get(&ComfyMetadataField::Model),
+            Some(&ComfyParseLayer::SamplerTraversal)
+        );
+    }
+}
+
+#[test]
+fn inactive_subgraph_cannot_pass_an_image_source_to_saved_output_traversal() {
+    let passthrough = json!({
+        "id": "passthrough",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [{ "name": "image", "type": "IMAGE" }],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [],
+        "links": [{ "origin_id": -10, "origin_slot": 0, "target_id": -20, "target_slot": 0, "type": "IMAGE" }]
+    });
+    let workflow = json!({
+        "nodes": [
+            { "id": 1, "type": "CheckpointLoaderSimple", "inputs": [], "widgets_values": ["weak-model.safetensors"] },
+            {
+                "id": 2,
+                "type": "KSampler",
+                "inputs": [{ "name": "model", "type": "MODEL", "link": 1 }],
+                "widgets_values": [22, "fixed", 4, 1.0, "euler", "simple", 1.0]
+            },
+            {
+                "id": 30,
+                "type": "passthrough",
+                "mode": 2,
+                "inputs": [{ "name": "image", "type": "IMAGE", "link": 2 }],
+                "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [3] }]
+            },
+            save_node(40, 3)
+        ],
+        "links": [
+            [1, 1, 0, 2, 0, "MODEL"],
+            [2, 2, 0, 30, 0, "IMAGE"],
+            [3, 30, 0, 40, 0, "IMAGE"]
+        ],
+        "definitions": { "subgraphs": [passthrough] }
+    });
+
+    let (_, diagnostics) =
+        extract_comfyui_metadata_with_diagnostics(&chunks_from_workflow(workflow));
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 0);
+    assert_ne!(
+        diagnostics.field_sources.get(&ComfyMetadataField::Model),
+        Some(&ComfyParseLayer::SamplerTraversal)
+    );
+}
+
+#[test]
+fn branching_subgraphs_stop_at_the_shared_node_budget() {
+    fn branch_definition(id: &str, child: Option<&str>) -> Value {
+        let nodes = child.map_or_else(Vec::new, |child| {
+            (1..=4)
+                .map(|node_id| {
+                    json!({
+                        "id": node_id,
+                        "type": child,
+                        "mode": 0,
+                        "inputs": [],
+                        "outputs": []
+                    })
+                })
+                .collect()
+        });
+        json!({
+            "id": id,
+            "inputNode": { "id": -10 },
+            "outputNode": { "id": -20 },
+            "inputs": [],
+            "outputs": [],
+            "nodes": nodes,
+            "links": []
+        })
+    }
+
+    let workflow = json!({
+        "nodes": [{ "id": 30, "type": "branch-a", "mode": 0, "inputs": [], "outputs": [] }],
+        "links": [],
+        "definitions": { "subgraphs": [
+            branch_definition("branch-a", Some("branch-b")),
+            branch_definition("branch-b", Some("branch-c")),
+            branch_definition("branch-c", Some("branch-leaf")),
+            branch_definition("branch-leaf", None)
+        ] }
+    });
+
+    let normalized = normalize_workflow_with_test_limits(&workflow, 20, 1_000, 1_000_000)
+        .expect("the top-level workflow should remain available");
+    assert!(normalized.nodes.len() <= 20);
+    assert!(normalized.nodes.iter().any(|node| {
+        node.get("type")
+            .and_then(Value::as_str)
+            .is_some_and(|node_type| node_type.starts_with("branch-"))
+    }));
+}
+
+#[test]
+fn constrained_expansion_uses_deterministic_numeric_instance_order() {
+    let definition = json!({
+        "id": "limited",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [],
+        "outputs": [],
+        "nodes": [
+            { "id": 1, "type": "PrimitiveInt", "inputs": [], "widgets_values": [1] },
+            { "id": 2, "type": "PreviewAny", "inputs": [], "widgets_values": [] }
+        ],
+        "links": [[1, 1, 0, 2, 0, "*"]]
+    });
+    let workflow = json!({
+        "nodes": [
+            { "id": 10, "type": "limited", "mode": 0, "inputs": [], "outputs": [] },
+            { "id": 2, "type": "limited", "mode": 0, "inputs": [], "outputs": [] }
+        ],
+        "links": [],
+        "definitions": { "subgraphs": [definition] }
+    });
+
+    let normalize = || {
+        let normalized = normalize_workflow_with_test_limits(&workflow, 4, 100, 1_000_000)
+            .expect("the top-level workflow should remain available");
+        let mut node_ids = normalized
+            .nodes
+            .iter()
+            .filter_map(|node| node.get("id").and_then(Value::as_str).map(str::to_string))
+            .collect::<Vec<_>>();
+        node_ids.sort();
+        let mut edges = normalized
+            .edges
+            .iter()
+            .map(|edge| {
+                format!(
+                    "{}:{}>{}:{}:{}",
+                    edge.source_id,
+                    edge.source_slot,
+                    edge.target_id,
+                    edge.target_slot,
+                    edge.link_type
+                )
+            })
+            .collect::<Vec<_>>();
+        edges.sort();
+        (node_ids, edges)
+    };
+
+    let first = normalize();
+    let second = normalize();
+    assert_eq!(first, second);
+    assert_eq!(first.0, vec!["10", "2:1", "2:2"]);
+    assert_eq!(first.1, vec!["2:1:0>2:2:0:*"]);
+}
+
+#[test]
+fn subgraph_edge_fanout_stops_at_the_shared_edge_budget() {
+    let definition = json!({
+        "id": "fanout",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [{ "id": 1, "type": "PreviewImage", "inputs": [], "outputs": [] }],
+        "links": (1..=20)
+            .map(|link_id| json!([link_id, 1, 0, -20, 0, "IMAGE"]))
+            .collect::<Vec<_>>()
+    });
+    let workflow = json!({
+        "nodes": [
+            { "id": 30, "type": "fanout", "mode": 0, "inputs": [], "outputs": [{ "name": "IMAGE", "type": "IMAGE" }] },
+            save_node(40, 1)
+        ],
+        "links": [[1, 30, 0, 40, 0, "IMAGE"]],
+        "definitions": { "subgraphs": [definition] }
+    });
+
+    let normalized = normalize_workflow_with_test_limits(&workflow, 100, 10, 1_000_000)
+        .expect("the rejected subgraph should remain opaque");
+    assert!(normalized
+        .nodes
+        .iter()
+        .any(|node| node.get("id") == Some(&json!("30"))));
+    assert!(!normalized
+        .nodes
+        .iter()
+        .any(|node| node.get("id") == Some(&json!("30:1"))));
+}
+
+#[test]
+fn oversized_subgraph_payload_is_rejected_and_blocks_incoming_traversal() {
+    let definition = json!({
+        "id": "oversized",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [{ "name": "image", "type": "IMAGE" }],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [{
+            "id": 1,
+            "type": "PreviewAny",
+            "inputs": [],
+            "widgets_values": ["x".repeat(8_192)]
+        }],
+        "links": [
+            [1, -10, 0, 1, 0, "IMAGE"],
+            [2, 1, 0, -20, 0, "IMAGE"]
+        ]
+    });
+    let workflow = json!({
+        "nodes": [
+            { "id": 2, "type": "KSampler", "inputs": [], "widgets_values": [22, "fixed", 4, 1.0, "euler", "simple", 1.0] },
+            {
+                "id": 30,
+                "type": "oversized",
+                "mode": 0,
+                "inputs": [{ "name": "image", "type": "IMAGE", "link": 2 }],
+                "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [3] }]
+            },
+            save_node(40, 3)
+        ],
+        "links": [
+            [2, 2, 0, 30, 0, "IMAGE"],
+            [3, 30, 0, 40, 0, "IMAGE"]
+        ],
+        "definitions": { "subgraphs": [definition] }
+    });
+
+    let normalized = normalize_workflow_with_test_limits(&workflow, 100, 100, 4_096)
+        .expect("the rejected subgraph should leave the outer graph usable");
+    assert!(normalized
+        .nodes
+        .iter()
+        .any(|node| node.get("id") == Some(&json!("30"))));
+    assert!(!normalized
+        .nodes
+        .iter()
+        .any(|node| node.get("id") == Some(&json!("30:1"))));
+    assert!(!normalized.edges.iter().any(|edge| edge.target_id == "30"));
+}
+
+#[test]
+fn oversized_subgraph_edge_is_rejected_and_blocks_incoming_traversal() {
+    let definition = json!({
+        "id": "oversized-edge",
+        "inputNode": { "id": -10 },
+        "outputNode": { "id": -20 },
+        "inputs": [{ "name": "image", "type": "IMAGE" }],
+        "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+        "nodes": [{ "id": 1, "type": "PreviewAny", "inputs": [], "widgets_values": [] }],
+        "links": [
+            [1, -10, 0, 1, 0, "x".repeat(8_192)],
+            [2, 1, 0, -20, 0, "IMAGE"]
+        ]
+    });
+    let workflow = json!({
+        "nodes": [
+            { "id": 2, "type": "KSampler", "inputs": [], "widgets_values": [22, "fixed", 4, 1.0, "euler", "simple", 1.0] },
+            {
+                "id": 30,
+                "type": "oversized-edge",
+                "mode": 0,
+                "inputs": [{ "name": "image", "type": "IMAGE", "link": 2 }],
+                "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [3] }]
+            },
+            save_node(40, 3)
+        ],
+        "links": [
+            [2, 2, 0, 30, 0, "IMAGE"],
+            [3, 30, 0, 40, 0, "IMAGE"]
+        ],
+        "definitions": { "subgraphs": [definition] }
+    });
+
+    let normalized = normalize_workflow_with_test_limits(&workflow, 100, 100, 4_096)
+        .expect("the rejected subgraph should leave the outer graph usable");
+    assert!(normalized
+        .nodes
+        .iter()
+        .any(|node| node.get("id") == Some(&json!("30"))));
+    assert!(!normalized
+        .nodes
+        .iter()
+        .any(|node| node.get("id") == Some(&json!("30:1"))));
+    assert!(!normalized.edges.iter().any(|edge| edge.target_id == "30"));
+}
+
+#[test]
+fn api_prompt_graph_remains_authoritative() {
+    let workflow = single_instance_workflow(Some(77), None);
+    let prompt = json!({
+        "1": { "class_type": "CheckpointLoaderSimple", "inputs": { "ckpt_name": "prompt-model.safetensors" } },
+        "2": { "class_type": "KSampler", "inputs": { "model": ["1", 0], "seed": 22, "steps": 4, "cfg": 2.0, "sampler_name": "euler", "scheduler": "simple" } },
+        "3": { "class_type": "SaveImage", "inputs": { "images": ["2", 0] } }
+    });
+    let chunks = HashMap::from([
+        ("workflow".to_string(), workflow.to_string()),
+        ("prompt".to_string(), prompt.to_string()),
+    ]);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+    assert_eq!(meta.model, "prompt_model");
+    assert_eq!(meta.seed, Some(22));
+    assert_eq!(diagnostics.graph_node_count, 3);
+    assert_traversal_source(&diagnostics, ComfyMetadataField::Model);
+}

--- a/src-tauri/src/metadata/comfyui/workflow_normalizer.rs
+++ b/src-tauri/src/metadata/comfyui/workflow_normalizer.rs
@@ -1,0 +1,777 @@
+use serde_json::Value;
+use std::collections::HashMap;
+
+use super::graph::compare_node_ids;
+
+const MAX_SUBGRAPH_DEPTH: usize = 16;
+const MAX_EXPANDED_NODES: usize = 10_000;
+const MAX_EXPANDED_EDGES: usize = 50_000;
+const MAX_EXPANDED_CLONED_BYTES: usize = 32 * 1024 * 1024;
+const INPUT_BOUNDARY: &str = "\u{0}subgraph_input";
+const OUTPUT_BOUNDARY: &str = "\u{0}subgraph_output";
+
+#[derive(Clone, Copy)]
+struct ExpansionLimits {
+    nodes: usize,
+    edges: usize,
+    cloned_bytes: usize,
+}
+
+impl Default for ExpansionLimits {
+    fn default() -> Self {
+        Self {
+            nodes: MAX_EXPANDED_NODES,
+            edges: MAX_EXPANDED_EDGES,
+            cloned_bytes: MAX_EXPANDED_CLONED_BYTES,
+        }
+    }
+}
+
+struct ExpansionBudget {
+    limits: ExpansionLimits,
+    nodes: usize,
+    edges: usize,
+    cloned_bytes: usize,
+    exhausted: bool,
+}
+
+impl ExpansionBudget {
+    fn new(limits: ExpansionLimits) -> Self {
+        Self {
+            limits,
+            nodes: 0,
+            edges: 0,
+            cloned_bytes: 0,
+            exhausted: false,
+        }
+    }
+
+    fn reserve_node(&mut self, node: &Value, extra_bytes: usize) -> bool {
+        let Some(bytes) = self.value_clone_bytes(node, extra_bytes) else {
+            return false;
+        };
+        self.reserve(1, 0, bytes)
+    }
+
+    fn reserve_edge(&mut self, edge: &WorkflowEdge) -> bool {
+        let bytes = edge.link_id.as_ref().map_or(0, String::len)
+            + edge.source_id.len()
+            + edge.target_id.len()
+            + edge.link_type.len();
+        self.reserve(0, 1, bytes)
+    }
+
+    fn reserve_raw_edge(&mut self, edge: &BorrowedWorkflowEdge<'_>) -> bool {
+        let bytes = edge.link_id.as_ref().map_or(0, BorrowedId::owned_len)
+            + edge.source_id.owned_len()
+            + edge.target_id.owned_len()
+            + edge.link_type.len();
+        self.reserve(0, 1, bytes)
+    }
+
+    fn reserve_value_clone(&mut self, value: &Value, extra_bytes: usize) -> bool {
+        let Some(bytes) = self.value_clone_bytes(value, extra_bytes) else {
+            return false;
+        };
+        self.reserve(0, 0, bytes)
+    }
+
+    fn reserve_auxiliary_clone(&mut self, bytes: usize) -> bool {
+        self.reserve(0, 0, bytes)
+    }
+
+    fn value_clone_bytes(&mut self, value: &Value, extra_bytes: usize) -> Option<usize> {
+        if self.exhausted {
+            return None;
+        }
+        let remaining = self.limits.cloned_bytes.saturating_sub(self.cloned_bytes);
+        let Some(available) = remaining.checked_sub(extra_bytes) else {
+            self.exhausted = true;
+            return None;
+        };
+        let Some(bytes) = estimate_clone_bytes(value, available) else {
+            self.exhausted = true;
+            return None;
+        };
+        match bytes.checked_add(extra_bytes) {
+            Some(total) => Some(total),
+            None => {
+                self.exhausted = true;
+                None
+            }
+        }
+    }
+
+    fn reserve(&mut self, nodes: usize, edges: usize, cloned_bytes: usize) -> bool {
+        if self.exhausted {
+            return false;
+        }
+        let Some(next_nodes) = self.nodes.checked_add(nodes) else {
+            self.exhausted = true;
+            return false;
+        };
+        let Some(next_edges) = self.edges.checked_add(edges) else {
+            self.exhausted = true;
+            return false;
+        };
+        let Some(next_bytes) = self.cloned_bytes.checked_add(cloned_bytes) else {
+            self.exhausted = true;
+            return false;
+        };
+        if next_nodes > self.limits.nodes
+            || next_edges > self.limits.edges
+            || next_bytes > self.limits.cloned_bytes
+        {
+            self.exhausted = true;
+            return false;
+        }
+        self.nodes = next_nodes;
+        self.edges = next_edges;
+        self.cloned_bytes = next_bytes;
+        true
+    }
+}
+
+fn estimate_clone_bytes(value: &Value, available: usize) -> Option<usize> {
+    fn add(total: &mut usize, amount: usize, available: usize) -> Option<()> {
+        *total = total.checked_add(amount)?;
+        (*total <= available).then_some(())
+    }
+
+    fn visit(value: &Value, total: &mut usize, available: usize) -> Option<()> {
+        match value {
+            Value::Null => add(total, 1, available),
+            Value::Bool(_) => add(total, std::mem::size_of::<bool>(), available),
+            Value::Number(_) => add(total, std::mem::size_of::<serde_json::Number>(), available),
+            Value::String(value) => add(total, value.len(), available),
+            Value::Array(values) => {
+                add(
+                    total,
+                    values.len().saturating_mul(std::mem::size_of::<Value>()),
+                    available,
+                )?;
+                for value in values {
+                    visit(value, total, available)?;
+                }
+                Some(())
+            }
+            Value::Object(values) => {
+                add(
+                    total,
+                    values.len().saturating_mul(
+                        std::mem::size_of::<String>() + std::mem::size_of::<Value>(),
+                    ),
+                    available,
+                )?;
+                for (key, value) in values {
+                    add(total, key.len(), available)?;
+                    visit(value, total, available)?;
+                }
+                Some(())
+            }
+        }
+    }
+
+    let mut total = 0;
+    visit(value, &mut total, available)?;
+    Some(total)
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct WorkflowEdge {
+    pub link_id: Option<String>,
+    pub source_id: String,
+    pub source_slot: usize,
+    pub target_id: String,
+    pub target_slot: usize,
+    pub link_type: String,
+}
+
+#[derive(Clone, Copy)]
+enum BorrowedId<'a> {
+    String(&'a str),
+    Signed(i64),
+    Unsigned(u64),
+}
+
+impl BorrowedId<'_> {
+    fn owned_len(&self) -> usize {
+        match self {
+            Self::String(value) => value.len(),
+            Self::Signed(value) => {
+                usize::from(value.is_negative()) + decimal_len(value.unsigned_abs())
+            }
+            Self::Unsigned(value) => decimal_len(*value),
+        }
+    }
+
+    fn into_owned(self) -> String {
+        match self {
+            Self::String(value) => value.to_string(),
+            Self::Signed(value) => value.to_string(),
+            Self::Unsigned(value) => value.to_string(),
+        }
+    }
+}
+
+struct BorrowedWorkflowEdge<'a> {
+    link_id: Option<BorrowedId<'a>>,
+    source_id: BorrowedId<'a>,
+    source_slot: usize,
+    target_id: BorrowedId<'a>,
+    target_slot: usize,
+    link_type: &'a str,
+}
+
+impl BorrowedWorkflowEdge<'_> {
+    fn into_owned(self) -> WorkflowEdge {
+        WorkflowEdge {
+            link_id: self.link_id.map(BorrowedId::into_owned),
+            source_id: self.source_id.into_owned(),
+            source_slot: self.source_slot,
+            target_id: self.target_id.into_owned(),
+            target_slot: self.target_slot,
+            link_type: self.link_type.to_string(),
+        }
+    }
+}
+
+pub(crate) struct NormalizedWorkflow {
+    pub nodes: Vec<Value>,
+    pub edges: Vec<WorkflowEdge>,
+}
+
+#[derive(Clone)]
+struct BoundaryTarget {
+    link_id: Option<String>,
+    node_id: String,
+    slot: usize,
+    link_type: String,
+}
+
+#[derive(Clone)]
+struct BoundarySource {
+    node_id: String,
+    slot: usize,
+    link_type: String,
+}
+
+struct WorkflowFragment {
+    nodes: HashMap<String, Value>,
+    edges: Vec<WorkflowEdge>,
+    input_targets: HashMap<usize, Vec<BoundaryTarget>>,
+    output_sources: HashMap<usize, Vec<BoundarySource>>,
+}
+
+pub(crate) fn normalize_workflow(workflow: &Value) -> Option<NormalizedWorkflow> {
+    normalize_workflow_with_limits(workflow, ExpansionLimits::default())
+}
+
+fn normalize_workflow_with_limits(
+    workflow: &Value,
+    limits: ExpansionLimits,
+) -> Option<NormalizedWorkflow> {
+    let definitions = workflow
+        .get("definitions")
+        .and_then(|value| value.get("subgraphs"))
+        .and_then(Value::as_array)
+        .map(|subgraphs| {
+            subgraphs
+                .iter()
+                .filter_map(|definition| value_id(definition.get("id")?).map(|id| (id, definition)))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    let mut stack = Vec::new();
+    let mut budget = ExpansionBudget::new(limits);
+    let fragment = flatten_container(workflow, &definitions, "", None, &mut stack, 0, &mut budget)?;
+    Some(NormalizedWorkflow {
+        nodes: fragment.nodes.into_values().collect(),
+        edges: fragment.edges,
+    })
+}
+
+fn flatten_container<'a>(
+    container: &Value,
+    definitions: &HashMap<String, &'a Value>,
+    prefix: &str,
+    boundary_ids: Option<(String, String)>,
+    stack: &mut Vec<String>,
+    depth: usize,
+    budget: &mut ExpansionBudget,
+) -> Option<WorkflowFragment> {
+    let source_nodes = container.get("nodes")?.as_array()?;
+    let mut local_ids = HashMap::new();
+    let mut nodes = HashMap::new();
+
+    for source_node in source_nodes {
+        let Some(local_id) = source_node.get("id").and_then(value_id) else {
+            continue;
+        };
+        let namespaced_id = namespace_id(prefix, &local_id);
+        if !budget.reserve_node(source_node, namespaced_id.len()) {
+            return None;
+        }
+        let mut node = source_node.clone();
+        let Some(object) = node.as_object_mut() else {
+            continue;
+        };
+        object.insert("id".to_string(), Value::String(namespaced_id.clone()));
+        local_ids.insert(local_id, namespaced_id.clone());
+        nodes.insert(namespaced_id, node);
+    }
+
+    let (input_id, output_id) = boundary_ids
+        .map(|(input, output)| (Some(input), Some(output)))
+        .unwrap_or((None, None));
+    let mut edges = Vec::new();
+    if let Some(raw_edges) = container.get("links").and_then(Value::as_array) {
+        for raw_edge in raw_edges {
+            let Some(raw_edge) = parse_borrowed_edge(raw_edge) else {
+                continue;
+            };
+            if !budget.reserve_raw_edge(&raw_edge) {
+                return None;
+            }
+            let mut edge = raw_edge.into_owned();
+            let mapped_source = map_endpoint(
+                &edge.source_id,
+                &local_ids,
+                input_id.as_deref(),
+                output_id.as_deref(),
+            );
+            let mapped_target = map_endpoint(
+                &edge.target_id,
+                &local_ids,
+                input_id.as_deref(),
+                output_id.as_deref(),
+            );
+            let source_changed = mapped_source != edge.source_id;
+            let target_changed = mapped_target != edge.target_id;
+            let replacement_bytes = usize::from(source_changed) * mapped_source.len()
+                + usize::from(target_changed) * mapped_target.len();
+            if !budget.reserve_auxiliary_clone(replacement_bytes) {
+                return None;
+            }
+            let source_replacement = source_changed.then(|| mapped_source.to_string());
+            let target_replacement = target_changed.then(|| mapped_target.to_string());
+            if let Some(source) = source_replacement {
+                edge.source_id = source;
+            }
+            if let Some(target) = target_replacement {
+                edge.target_id = target;
+            }
+            edges.push(edge);
+        }
+    }
+
+    let mut instance_ids = nodes
+        .iter()
+        .filter_map(|(id, node)| {
+            let definition_id = node.get("type")?.as_str()?;
+            definitions.contains_key(definition_id).then(|| id.clone())
+        })
+        .collect::<Vec<_>>();
+    instance_ids.sort_by(|left, right| compare_node_ids(left, right));
+
+    for instance_id in instance_ids {
+        let Some(instance) = nodes.get(&instance_id) else {
+            continue;
+        };
+        if is_inactive(&instance) || depth >= MAX_SUBGRAPH_DEPTH {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        }
+
+        let Some(definition_id) = instance.get("type").and_then(Value::as_str) else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+        if stack.iter().any(|id| id == definition_id) {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        }
+        let Some(definition) = definitions.get(definition_id) else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+        let Some(definition_input_id) = definition
+            .get("inputNode")
+            .and_then(|value| value.get("id"))
+            .and_then(value_id)
+        else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+        let Some(definition_output_id) = definition
+            .get("outputNode")
+            .and_then(|value| value.get("id"))
+            .and_then(value_id)
+        else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+
+        stack.push(definition_id.to_string());
+        let child = flatten_container(
+            definition,
+            definitions,
+            &instance_id,
+            Some((definition_input_id, definition_output_id)),
+            stack,
+            depth + 1,
+            budget,
+        );
+        stack.pop();
+        let Some(mut child) = child else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+
+        if !apply_proxy_widget_overrides(instance, &instance_id, &mut child.nodes, budget) {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        }
+
+        let incoming = edges
+            .iter()
+            .filter(|edge| edge.target_id == instance_id)
+            .collect::<Vec<_>>();
+        let outgoing = edges
+            .iter()
+            .filter(|edge| edge.source_id == instance_id)
+            .collect::<Vec<_>>();
+
+        let Some(input_bindings) =
+            bind_instance_inputs(instance, definition, &incoming, &child, budget)
+        else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+        let Some(output_bindings) =
+            bind_instance_outputs(instance, definition, &outgoing, &child, budget)
+        else {
+            block_instance_inputs(&mut edges, &instance_id);
+            continue;
+        };
+
+        edges.retain(|edge| edge.source_id != instance_id && edge.target_id != instance_id);
+        edges.extend(child.edges);
+        edges.extend(input_bindings);
+        edges.extend(output_bindings);
+        nodes.remove(&instance_id);
+        nodes.extend(child.nodes);
+    }
+
+    let mut input_targets: HashMap<usize, Vec<BoundaryTarget>> = HashMap::new();
+    let mut output_sources: HashMap<usize, Vec<BoundarySource>> = HashMap::new();
+    let mut retained_edges = Vec::with_capacity(edges.len());
+    for edge in edges {
+        if edge.source_id == INPUT_BOUNDARY {
+            let cloned_bytes = edge.link_id.as_ref().map_or(0, String::len)
+                + edge.target_id.len()
+                + edge.link_type.len();
+            if !budget.reserve_auxiliary_clone(cloned_bytes) {
+                return None;
+            }
+            input_targets
+                .entry(edge.source_slot)
+                .or_default()
+                .push(BoundaryTarget {
+                    link_id: edge.link_id.clone(),
+                    node_id: edge.target_id.clone(),
+                    slot: edge.target_slot,
+                    link_type: edge.link_type.clone(),
+                });
+            continue;
+        }
+        if edge.target_id == OUTPUT_BOUNDARY {
+            let cloned_bytes = edge.source_id.len() + edge.link_type.len();
+            if !budget.reserve_auxiliary_clone(cloned_bytes) {
+                return None;
+            }
+            output_sources
+                .entry(edge.target_slot)
+                .or_default()
+                .push(BoundarySource {
+                    node_id: edge.source_id.clone(),
+                    slot: edge.source_slot,
+                    link_type: edge.link_type.clone(),
+                });
+            continue;
+        }
+        if edge.source_id != OUTPUT_BOUNDARY && edge.target_id != INPUT_BOUNDARY {
+            retained_edges.push(edge);
+        }
+    }
+
+    Some(WorkflowFragment {
+        nodes,
+        edges: retained_edges,
+        input_targets,
+        output_sources,
+    })
+}
+
+fn block_instance_inputs(edges: &mut Vec<WorkflowEdge>, instance_id: &str) {
+    edges.retain(|edge| edge.target_id != instance_id);
+}
+
+fn bind_instance_inputs(
+    instance: &Value,
+    definition: &Value,
+    incoming: &[&WorkflowEdge],
+    child: &WorkflowFragment,
+    budget: &mut ExpansionBudget,
+) -> Option<Vec<WorkflowEdge>> {
+    let instance_inputs = instance.get("inputs").and_then(Value::as_array);
+    let definition_inputs = definition.get("inputs").and_then(Value::as_array)?;
+    let mut bindings = Vec::new();
+
+    for edge in incoming {
+        let input_name = instance_inputs
+            .and_then(|inputs| inputs.get(edge.target_slot))
+            .and_then(|input| input.get("name"))
+            .and_then(Value::as_str)?;
+        let definition_slot = definition_inputs
+            .iter()
+            .position(|input| input.get("name").and_then(Value::as_str) == Some(input_name))?;
+        let targets = child.input_targets.get(&definition_slot)?;
+        if targets.is_empty() {
+            return None;
+        }
+        for target in targets {
+            let binding = WorkflowEdge {
+                link_id: target.link_id.clone(),
+                source_id: edge.source_id.clone(),
+                source_slot: edge.source_slot,
+                target_id: target.node_id.clone(),
+                target_slot: target.slot,
+                link_type: stronger_link_type(&edge.link_type, &target.link_type),
+            };
+            if !budget.reserve_edge(&binding) {
+                return None;
+            }
+            bindings.push(binding);
+        }
+    }
+
+    Some(bindings)
+}
+
+fn bind_instance_outputs(
+    instance: &Value,
+    definition: &Value,
+    outgoing: &[&WorkflowEdge],
+    child: &WorkflowFragment,
+    budget: &mut ExpansionBudget,
+) -> Option<Vec<WorkflowEdge>> {
+    let instance_outputs = instance.get("outputs").and_then(Value::as_array);
+    let definition_outputs = definition.get("outputs").and_then(Value::as_array)?;
+    let mut bindings = Vec::new();
+
+    for edge in outgoing {
+        let output_name = instance_outputs
+            .and_then(|outputs| outputs.get(edge.source_slot))
+            .and_then(|output| output.get("name"))
+            .and_then(Value::as_str);
+        let definition_slot = output_name
+            .and_then(|name| {
+                definition_outputs
+                    .iter()
+                    .position(|output| output.get("name").and_then(Value::as_str) == Some(name))
+            })
+            .unwrap_or(edge.source_slot);
+        if definition_slot >= definition_outputs.len() {
+            return None;
+        }
+        let sources = child.output_sources.get(&definition_slot)?;
+        if sources.is_empty() {
+            return None;
+        }
+        for source in sources {
+            let binding = WorkflowEdge {
+                link_id: edge.link_id.clone(),
+                source_id: source.node_id.clone(),
+                source_slot: source.slot,
+                target_id: edge.target_id.clone(),
+                target_slot: edge.target_slot,
+                link_type: stronger_link_type(&edge.link_type, &source.link_type),
+            };
+            if !budget.reserve_edge(&binding) {
+                return None;
+            }
+            bindings.push(binding);
+        }
+    }
+
+    Some(bindings)
+}
+
+fn apply_proxy_widget_overrides(
+    instance: &Value,
+    instance_id: &str,
+    nodes: &mut HashMap<String, Value>,
+    budget: &mut ExpansionBudget,
+) -> bool {
+    let Some(proxy_widgets) = instance
+        .get("properties")
+        .and_then(|value| value.get("proxyWidgets"))
+        .and_then(Value::as_array)
+    else {
+        return true;
+    };
+    let Some(values) = instance.get("widgets_values").and_then(Value::as_array) else {
+        return true;
+    };
+
+    for (proxy, value) in proxy_widgets.iter().zip(values) {
+        let Some(proxy) = proxy.as_array() else {
+            continue;
+        };
+        let (Some(node_id), Some(widget_name)) = (
+            proxy.first().and_then(value_id),
+            proxy.get(1).and_then(Value::as_str),
+        ) else {
+            continue;
+        };
+        let target_id = namespace_id(instance_id, &node_id);
+        if !nodes.contains_key(&target_id) {
+            continue;
+        }
+        if !budget.reserve_value_clone(value, widget_name.len()) {
+            return false;
+        }
+        let target = nodes
+            .get_mut(&target_id)
+            .and_then(Value::as_object_mut)
+            .expect("checked subgraph proxy target should remain an object");
+        let overrides = target
+            .entry("_widget_overrides".to_string())
+            .or_insert_with(|| Value::Object(serde_json::Map::new()));
+        if let Some(overrides) = overrides.as_object_mut() {
+            overrides.insert(widget_name.to_string(), value.clone());
+        }
+    }
+    true
+}
+
+fn parse_borrowed_edge(value: &Value) -> Option<BorrowedWorkflowEdge<'_>> {
+    if let Some(edge) = value.as_array() {
+        return Some(BorrowedWorkflowEdge {
+            link_id: edge.first().and_then(borrowed_id),
+            source_id: borrowed_id(edge.get(1)?)?,
+            source_slot: value_usize(edge.get(2)?)?,
+            target_id: borrowed_id(edge.get(3)?)?,
+            target_slot: value_usize(edge.get(4)?)?,
+            link_type: edge.get(5).and_then(Value::as_str).unwrap_or("*"),
+        });
+    }
+
+    Some(BorrowedWorkflowEdge {
+        link_id: value.get("id").and_then(borrowed_id),
+        source_id: borrowed_id(value.get("origin_id")?)?,
+        source_slot: value_usize(value.get("origin_slot")?)?,
+        target_id: borrowed_id(value.get("target_id")?)?,
+        target_slot: value_usize(value.get("target_slot")?)?,
+        link_type: value.get("type").and_then(Value::as_str).unwrap_or("*"),
+    })
+}
+
+fn map_endpoint<'a>(
+    id: &'a str,
+    local_ids: &'a HashMap<String, String>,
+    input_id: Option<&'a str>,
+    output_id: Option<&'a str>,
+) -> &'a str {
+    if input_id == Some(id) {
+        return INPUT_BOUNDARY;
+    }
+    if output_id == Some(id) {
+        return OUTPUT_BOUNDARY;
+    }
+    local_ids.get(id).map(String::as_str).unwrap_or(id)
+}
+
+fn namespace_id(prefix: &str, id: &str) -> String {
+    if prefix.is_empty() {
+        id.to_string()
+    } else {
+        format!("{prefix}:{id}")
+    }
+}
+
+fn value_id(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| value.as_i64().map(|id| id.to_string()))
+        .or_else(|| value.as_u64().map(|id| id.to_string()))
+}
+
+fn borrowed_id(value: &Value) -> Option<BorrowedId<'_>> {
+    value
+        .as_str()
+        .map(BorrowedId::String)
+        .or_else(|| value.as_i64().map(BorrowedId::Signed))
+        .or_else(|| value.as_u64().map(BorrowedId::Unsigned))
+}
+
+fn decimal_len(mut value: u64) -> usize {
+    let mut len = 1;
+    while value >= 10 {
+        value /= 10;
+        len += 1;
+    }
+    len
+}
+
+fn value_usize(value: &Value) -> Option<usize> {
+    value
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())
+        .or_else(|| value.as_i64().and_then(|value| usize::try_from(value).ok()))
+}
+
+fn is_inactive(node: &Value) -> bool {
+    matches!(node.get("mode").and_then(Value::as_i64), Some(2 | 4))
+}
+
+fn stronger_link_type<'a>(left: &'a str, right: &'a str) -> String {
+    if left.is_empty() || left == "*" {
+        right.to_string()
+    } else {
+        left.to_string()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn normalized_node_ids(workflow: &Value) -> std::collections::HashSet<String> {
+    normalize_workflow(workflow)
+        .map(|normalized| {
+            normalized
+                .nodes
+                .iter()
+                .filter_map(|node| node.get("id").and_then(value_id))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+pub(crate) fn normalize_workflow_with_test_limits(
+    workflow: &Value,
+    nodes: usize,
+    edges: usize,
+    cloned_bytes: usize,
+) -> Option<NormalizedWorkflow> {
+    normalize_workflow_with_limits(
+        workflow,
+        ExpansionLimits {
+            nodes,
+            edges,
+            cloned_bytes,
+        },
+    )
+}

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -18,7 +18,7 @@ pub use parsers::{extract_png_chunks, scan_jpeg_metadata, scan_webp_metadata};
 /// Current parser version. Increment when any parser logic changes.
 /// Images with parser_version < CURRENT_PARSER_VERSION will be queued
 /// for background re-parsing from their stored original_metadata_json.
-pub const CURRENT_PARSER_VERSION: u32 = 13;
+pub const CURRENT_PARSER_VERSION: u32 = 14;
 
 pub(crate) fn is_missing_prompt_value(value: &str) -> bool {
     value.trim().is_empty() || is_placeholder_prompt_value(value)
@@ -26,11 +26,19 @@ pub(crate) fn is_missing_prompt_value(value: &str) -> bool {
 
 pub(crate) fn is_placeholder_prompt_value(value: &str) -> bool {
     let trimmed = value.trim();
-    trimmed.eq_ignore_ascii_case("undefined")
-        || trimmed.eq_ignore_ascii_case("null")
-        || trimmed.eq_ignore_ascii_case("none")
-        || trimmed.eq_ignore_ascii_case("unknown")
-        || trimmed.eq_ignore_ascii_case("negative prompt:")
+    const POSITIVE_PROMPT_PREFIX: &str = "positive prompt:";
+    let candidate = trimmed
+        .get(..POSITIVE_PROMPT_PREFIX.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(POSITIVE_PROMPT_PREFIX))
+        .map(|_| &trimmed[POSITIVE_PROMPT_PREFIX.len()..])
+        .unwrap_or(trimmed)
+        .trim_matches(|c: char| c.is_whitespace() || c == ',' || c == ';');
+
+    candidate.eq_ignore_ascii_case("undefined")
+        || candidate.eq_ignore_ascii_case("null")
+        || candidate.eq_ignore_ascii_case("none")
+        || candidate.eq_ignore_ascii_case("unknown")
+        || candidate.eq_ignore_ascii_case("negative prompt:")
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, specta::Type, PartialEq)]

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -18,7 +18,7 @@ pub use parsers::{extract_png_chunks, scan_jpeg_metadata, scan_webp_metadata};
 /// Current parser version. Increment when any parser logic changes.
 /// Images with parser_version < CURRENT_PARSER_VERSION will be queued
 /// for background re-parsing from their stored original_metadata_json.
-pub const CURRENT_PARSER_VERSION: u32 = 15;
+pub const CURRENT_PARSER_VERSION: u32 = 16;
 
 pub(crate) fn is_missing_prompt_value(value: &str) -> bool {
     value.trim().is_empty() || is_placeholder_prompt_value(value)

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -18,7 +18,7 @@ pub use parsers::{extract_png_chunks, scan_jpeg_metadata, scan_webp_metadata};
 /// Current parser version. Increment when any parser logic changes.
 /// Images with parser_version < CURRENT_PARSER_VERSION will be queued
 /// for background re-parsing from their stored original_metadata_json.
-pub const CURRENT_PARSER_VERSION: u32 = 14;
+pub const CURRENT_PARSER_VERSION: u32 = 15;
 
 pub(crate) fn is_missing_prompt_value(value: &str) -> bool {
     value.trim().is_empty() || is_placeholder_prompt_value(value)

--- a/src/features/viewer/components/WorkflowInspector.tsx
+++ b/src/features/viewer/components/WorkflowInspector.tsx
@@ -35,6 +35,8 @@ const getDiagnosticLayerBadgeClass = (layer: string | null | undefined) => {
             return 'border-rose-300/70 dark:border-rose-400/30 bg-rose-50/80 dark:bg-rose-500/10 text-rose-900 dark:text-rose-100';
         case 'explicit_node':
             return 'border-sky-300/70 dark:border-sky-400/30 bg-sky-50/80 dark:bg-sky-500/10 text-sky-900 dark:text-sky-100';
+        case 'flat_parameters':
+            return 'border-violet-300/70 dark:border-violet-400/30 bg-violet-50/80 dark:bg-violet-500/10 text-violet-900 dark:text-violet-100';
         default:
             return 'border-amber-300/70 dark:border-amber-400/20 bg-white/70 dark:bg-black/20 text-amber-950 dark:text-amber-100';
     }
@@ -46,6 +48,9 @@ const getDiagnosticLayerTitle = (layer: string | null | undefined) => {
     }
     if (layer === 'sampler_traversal') {
         return 'Sampler traversal: found by following the saved image output path.';
+    }
+    if (layer === 'flat_parameters') {
+        return 'Flat parameters: embedded saver metadata, stronger than fallback scans but weaker than saved-output traversal.';
     }
     return formatDiagnosticLabel(layer ?? '');
 };

--- a/src/features/viewer/components/__tests__/WorkflowInspector.test.tsx
+++ b/src/features/viewer/components/__tests__/WorkflowInspector.test.tsx
@@ -189,6 +189,25 @@ describe('WorkflowInspector ComfyUI parser diagnostics', () => {
         ).toBeTruthy();
     });
 
+    it('identifies retained flat parameters as medium-confidence evidence', async () => {
+        mockInspectComfyuiMetadataChunks.mockResolvedValue({
+            status: 'ok',
+            data: {
+                ...diagnosticsReport,
+                fieldSources: {
+                    ...diagnosticsReport.fieldSources,
+                    seed: 'flat_parameters'
+                }
+            }
+        });
+
+        render(<WorkflowInspector image={makeImage()} />);
+
+        expect(
+            await screen.findByTitle('Flat parameters: embedded saver metadata, stronger than fallback scans but weaker than saved-output traversal.')
+        ).toBeTruthy();
+    });
+
     it('hides parser diagnostics outside developer mode', () => {
         mockSettings.devMode = false;
 


### PR DESCRIPTION
## Summary

- unify ComfyUI flat-parameter and graph metadata precedence with field-level provenance
- harden saved-output discovery, root selection, and conservative handling of ambiguous output branches
- expand modern workflow-only ComfyUI subgraphs for parser traversal, including nested definitions and bounded deterministic normalization
- increment the metadata parser version to 16 so affected records are reparsed automatically

## Why

These changes make scanner imports, background reparsing, and developer diagnostics agree on the same metadata. Strong saved-output evidence can correct stale saver defaults, weak fallback evidence cannot overwrite known values, multiple conflicting saved outputs no longer receive strong traversal authority, and workflow-only modern subgraphs can be parsed without a flattened API prompt.

## Compatibility

No public API, database schema, Tauri command, Specta binding, `ImageMetadata` shape, or frontend changes.

## Verification

- `cargo test metadata::comfyui::tests::merge_precedence`: 7 passed
- `cargo test metadata::comfyui::tests::output_selection`: 11 passed
- `cargo test metadata::comfyui::tests::workflow_subgraphs`: 12 passed
- `cargo test metadata::comfyui`: 103 passed, 1 ignored
- `cargo test metadata::reparse`: 10 passed
- `git diff --check origin/main...HEAD`: passed
- scoped `rustfmt --edition 2021 --check --config skip_children=true` on all touched Rust files: passed

A recursive rustfmt check still reports pre-existing formatting drift in untouched ComfyUI test files; this PR does not modify that unrelated formatting.