### PR TITLE
feat(release): add metadata refresh notice

### DIFF
--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -111,7 +111,7 @@ Use **Actions > updater-signing-preflight > Run workflow** before publishing. Th
 6. Merge the release PR only when a release should be published.
 7. Confirm the generated `vX.Y.Z` tag starts `release.yml`.
 
-The release workflow currently publishes Windows NSIS and MSI artifacts, updater signatures, and `latest.json`. It copies the matching version section from `CHANGELOG.md` into the updater metadata so installed apps can show the same release notes. Release tags must use the exact `vX.Y.Z` format, match `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/tauri.dev.json`, and `src-tauri/Cargo.toml`, and point to a commit reachable from `main`.
+The release workflow currently publishes Windows NSIS and MSI artifacts, updater signatures, and `latest.json`. It copies the matching version section from `CHANGELOG.md` into the updater metadata so installed apps can show the same release notes. When `CURRENT_PARSER_VERSION` increases from the previous stable release, the extraction step prepends a metadata-refresh notice to the published GitHub and updater notes without modifying `CHANGELOG.md`. Release tags must use the exact `vX.Y.Z` format, match `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/tauri.dev.json`, and `src-tauri/Cargo.toml`, and point to a commit reachable from `main`.
 
 Release Please remains the normal and preferred tag creator. Do not create manual release tags except for recovery work after confirming the tag target is already on `main` and all version files match.
 

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,13 +1,20 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const VERSION_RE = /^v?(\d+\.\d+\.\d+)$/;
+const PARSER_SOURCE_PATH = 'src-tauri/src/metadata/mod.rs';
+const PARSER_VERSION_RE = /^\s*pub const CURRENT_PARSER_VERSION:\s*u32\s*=\s*(\d+);\s*$/m;
+
+export const METADATA_REFRESH_NOTICE = `### Before you update
+
+**Metadata refresh:** When Ambit starts after the update, it will re-analyze metadata for affected existing images in the background. Large libraries may take some time; you can keep browsing while the refresh runs.`;
 
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-export const extractReleaseNotes = (changelog, versionOrTag) => {
+const findRelease = (changelog, versionOrTag) => {
   const versionMatch = versionOrTag.match(VERSION_RE);
 
   if (!versionMatch) {
@@ -25,6 +32,12 @@ export const extractReleaseNotes = (changelog, versionOrTag) => {
     throw new Error(`Could not find release ${version} in CHANGELOG.md.`);
   }
 
+  return { version, headingMatch };
+};
+
+export const extractReleaseNotes = (changelog, versionOrTag) => {
+  const { headingMatch } = findRelease(changelog, versionOrTag);
+
   const afterHeading = changelog.slice(headingMatch.index + headingMatch[0].length);
   const nextReleaseIndex = afterHeading.search(/^## \[/m);
   const notes = afterHeading.slice(0, nextReleaseIndex === -1 ? undefined : nextReleaseIndex).trim();
@@ -34,6 +47,72 @@ export const extractReleaseNotes = (changelog, versionOrTag) => {
   }
 
   return notes;
+};
+
+export const extractPreviousReleaseTag = (changelog, versionOrTag) => {
+  const { version, headingMatch } = findRelease(changelog, versionOrTag);
+  const compareMatch = headingMatch[0].match(/\/compare\/(v\d+\.\d+\.\d+)\.\.\.(v\d+\.\d+\.\d+)\)/);
+
+  if (!compareMatch) {
+    throw new Error(`Release ${version} must include a stable GitHub comparison link.`);
+  }
+
+  const [, previousTag, targetTag] = compareMatch;
+  const expectedTargetTag = `v${version}`;
+
+  if (targetTag !== expectedTargetTag) {
+    throw new Error(`Release ${version} comparison link targets ${targetTag}, expected ${expectedTargetTag}.`);
+  }
+
+  return previousTag;
+};
+
+export const parseParserVersion = (source, label) => {
+  const versionMatch = source.match(PARSER_VERSION_RE);
+
+  if (!versionMatch) {
+    throw new Error(`Could not find CURRENT_PARSER_VERSION in ${label}.`);
+  }
+
+  return Number(versionMatch[1]);
+};
+
+export const addMetadataRefreshNotice = ({ notes, previousParserSource, currentParserSource }) => {
+  const previousVersion = parseParserVersion(previousParserSource, 'previous release parser source');
+  const currentVersion = parseParserVersion(currentParserSource, 'current release parser source');
+
+  if (currentVersion < previousVersion) {
+    throw new Error(`CURRENT_PARSER_VERSION decreased from ${previousVersion} to ${currentVersion}.`);
+  }
+
+  if (currentVersion === previousVersion || notes.includes(METADATA_REFRESH_NOTICE)) {
+    return notes;
+  }
+
+  return `${METADATA_REFRESH_NOTICE}\n\n${notes}`;
+};
+
+export const buildUpdaterReleaseNotes = ({
+  changelog,
+  versionOrTag,
+  previousParserSource,
+  currentParserSource,
+}) => addMetadataRefreshNotice({
+  notes: extractReleaseNotes(changelog, versionOrTag),
+  previousParserSource,
+  currentParserSource,
+});
+
+const readPreviousParserSource = (rootDir, previousTag) => {
+  try {
+    return execFileSync('git', ['show', `${previousTag}:${PARSER_SOURCE_PATH}`], {
+      cwd: rootDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch {
+    throw new Error(`Could not read ${PARSER_SOURCE_PATH} from ${previousTag}.`);
+  }
 };
 
 const isCli = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
@@ -47,7 +126,16 @@ if (isCli) {
     }
 
     const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
-    const notes = extractReleaseNotes(fs.readFileSync(changelogPath, 'utf8'), versionOrTag);
+    const changelog = fs.readFileSync(changelogPath, 'utf8');
+    const previousTag = extractPreviousReleaseTag(changelog, versionOrTag);
+    const currentParserSource = fs.readFileSync(path.join(process.cwd(), PARSER_SOURCE_PATH), 'utf8');
+    const previousParserSource = readPreviousParserSource(process.cwd(), previousTag);
+    const notes = buildUpdaterReleaseNotes({
+      changelog,
+      versionOrTag,
+      previousParserSource,
+      currentParserSource,
+    });
     console.log(notes);
   } catch (error) {
     console.error(error instanceof Error ? error.message : error);

--- a/scripts/extract-release-notes.node-test.mjs
+++ b/scripts/extract-release-notes.node-test.mjs
@@ -1,7 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { extractReleaseNotes } from './extract-release-notes.mjs';
+import {
+  METADATA_REFRESH_NOTICE,
+  addMetadataRefreshNotice,
+  buildUpdaterReleaseNotes,
+  extractPreviousReleaseTag,
+  extractReleaseNotes,
+  parseParserVersion,
+} from './extract-release-notes.mjs';
 
 const changelog = `# Changelog
 
@@ -37,6 +44,67 @@ test('extracts only the requested release section for updater metadata', () => {
 
 test('accepts a version without the tag prefix', () => {
   assert.match(extractReleaseNotes(changelog, '0.7.0'), /older change/);
+});
+
+test('extracts the previous stable release from the comparison link', () => {
+  assert.equal(extractPreviousReleaseTag(changelog, 'v0.8.0'), 'v0.7.0');
+});
+
+test('prepends the metadata refresh notice exactly once when the parser version increases', () => {
+  const notesWithNotice = buildUpdaterReleaseNotes({
+    changelog,
+    versionOrTag: 'v0.8.0',
+    previousParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 13;',
+    currentParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 17;',
+  });
+
+  assert.ok(notesWithNotice.startsWith(`${METADATA_REFRESH_NOTICE}\n\n### Features`));
+  assert.equal(notesWithNotice.match(/### Before you update/g)?.length, 1);
+  assert.doesNotMatch(notesWithNotice, /older change/);
+
+  assert.equal(
+    addMetadataRefreshNotice({
+      notes: notesWithNotice,
+      previousParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 13;',
+      currentParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 17;',
+    }),
+    notesWithNotice,
+  );
+});
+
+test('preserves release notes when the parser version is unchanged', () => {
+  const notes = extractReleaseNotes(changelog, 'v0.8.0');
+
+  assert.equal(
+    addMetadataRefreshNotice({
+      notes,
+      previousParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 17;',
+      currentParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 17;',
+    }),
+    notes,
+  );
+});
+
+test('rejects missing or malformed parser version constants', () => {
+  assert.throws(
+    () => parseParserVersion('pub const SOMETHING_ELSE: u32 = 17;', 'test parser source'),
+    /Could not find CURRENT_PARSER_VERSION in test parser source/,
+  );
+  assert.throws(
+    () => parseParserVersion('pub const CURRENT_PARSER_VERSION: usize = 17;', 'test parser source'),
+    /Could not find CURRENT_PARSER_VERSION in test parser source/,
+  );
+});
+
+test('rejects parser version regressions', () => {
+  assert.throws(
+    () => addMetadataRefreshNotice({
+      notes: 'Existing notes',
+      previousParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 17;',
+      currentParserSource: 'pub const CURRENT_PARSER_VERSION: u32 = 16;',
+    }),
+    /CURRENT_PARSER_VERSION decreased from 17 to 16/,
+  );
 });
 
 test('rejects missing and malformed release versions', () => {


### PR DESCRIPTION
## Summary

- detect `CURRENT_PARSER_VERSION` increases during release-note extraction
- prepend a metadata-refresh warning to GitHub and updater release notes
- preserve unchanged notes and fail clearly for malformed or decreasing parser versions
- document the release behavior without modifying `CHANGELOG.md`

## Why

Parser upgrades already trigger a background metadata refresh after installation, but users are not warned before updating. This makes that operational impact visible automatically whenever the parser version increases.

## Validation

- `node --test scripts/check-release-tag.node-test.mjs scripts/extract-release-notes.node-test.mjs` (14 passed)
- `node_modules\.bin\vitest.cmd run src/components/ui/__tests__/UpdateDialog.test.tsx --maxWorkers=1` (3 passed)
- `pnpm run lint`
- end-to-end extraction against `v0.7.0 → v0.8.0`
- `git diff --check`