### PR TITLE
fix: preserve native copy shortcut

### DIFF
--- a/src/hooks/__tests__/useGlobalShortcuts.test.ts
+++ b/src/hooks/__tests__/useGlobalShortcuts.test.ts
@@ -137,6 +137,19 @@ describe('useGlobalShortcuts', () => {
         expect(mockActions.openCollection).toHaveBeenCalledTimes(1);
     });
 
+    it('preserves copy shortcuts instead of opening the collection modal', () => {
+        renderHook(() => useGlobalShortcuts(defaultProps));
+        const ctrlCopy = new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, cancelable: true });
+        const metaCopy = new KeyboardEvent('keydown', { key: 'c', metaKey: true, cancelable: true });
+
+        window.dispatchEvent(ctrlCopy);
+        window.dispatchEvent(metaCopy);
+
+        expect(mockActions.openCollection).not.toHaveBeenCalled();
+        expect(ctrlCopy.defaultPrevented).toBe(false);
+        expect(metaCopy.defaultPrevented).toBe(false);
+    });
+
     it('closes modals with Escape and blocks modal navigation and actions', () => {
         renderHook(() => useGlobalShortcuts({ ...defaultProps, isModalOpen: true }));
         window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));

--- a/src/hooks/useGlobalShortcuts.ts
+++ b/src/hooks/useGlobalShortcuts.ts
@@ -161,7 +161,7 @@ export const useGlobalShortcuts = ({
                 return;
             }
 
-            if (e.key === 'c' || e.key === 'C') {
+            if (!e.ctrlKey && !e.metaKey && !e.altKey && (e.key === 'c' || e.key === 'C')) {
                 e.preventDefault();
                 openCollection();
                 return;


### PR DESCRIPTION
## Summary

- preserve native copy behavior for `Ctrl+C` and `Cmd+C`
- keep plain `C` as the Add to Collection shortcut
- add regression coverage that verifies copy is not prevented or routed to the collection modal

## Root cause

The global `C` shortcut matched keyboard events regardless of modifier state, so copy shortcuts called `preventDefault()` and opened Add to Collection.

## Impact

Users can copy normally throughout the app without triggering the collection modal, while the documented plain-`C` action remains unchanged.

## Validation

- `node_modules\.bin\vitest.cmd run src\hooks\__tests__\useGlobalShortcuts.test.ts` — 22/22 passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- live browser QA — `Ctrl+C` kept the modal closed; plain `C` opened Add to Collection
- `git diff --check` — passed