### PR TITLE
fix(ui): use neutral search examples

### DIFF
--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -26,7 +26,7 @@ Examples:
 ```text
 sunset portrait
 "dark forest"
-orc OR elf
+forest OR ocean
 dragon -blurry
 model:sdxl lora:detail
 date:2026-04 after:2026-03
@@ -37,7 +37,7 @@ Open Help, then Search Syntax, for the in-app operator list.
 
 ## Search Syntax
 
-Plain terms search positive prompts. Multiple plain terms narrow results. `OR` only groups adjacent positive-prompt terms, such as `orc OR elf`; resource, date, numeric, and other operator filters still combine with the rest of the query.
+Plain terms search positive prompts. Multiple plain terms narrow results. `OR` only groups adjacent positive-prompt terms, such as `forest OR ocean`; resource, date, numeric, and other operator filters still combine with the rest of the query.
 
 Supported operators include:
 

--- a/src/components/ui/ShortcutsModal.tsx
+++ b/src/components/ui/ShortcutsModal.tsx
@@ -111,7 +111,7 @@ export const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose,
     const searchOperators = [
         // Content Search
         { op: 'sunset', desc: 'Search positive prompt (default)', icon: <Search className="w-3 h-3" /> },
-        { op: 'orc OR elf', desc: 'Match either prompt term', icon: <Search className="w-3 h-3" /> },
+        { op: 'forest OR ocean', desc: 'Match either prompt term', icon: <Search className="w-3 h-3" /> },
         { op: 'neg:blur', desc: 'Search negative prompt', icon: <Hash className="w-3 h-3" /> },
         { op: 'file:portrait', desc: 'Search filename/path', icon: <Hash className="w-3 h-3" /> },
         { op: 'all:anime', desc: 'Search all metadata (legacy)', icon: <Hash className="w-3 h-3" /> },
@@ -299,10 +299,10 @@ export const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose,
                             <div className="p-4 rounded-lg bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-white/10">
                                 <h4 className="text-xs font-bold text-gray-800 dark:text-gray-300 mb-1">Example Query</h4>
                                 <div className="font-mono text-xs bg-white dark:bg-black/40 p-2 rounded border border-gray-200 dark:border-white/10 text-gray-700 dark:text-gray-300 mb-2">
-                                    orc OR "dark elf" model:pony
+                                    forest OR "city skyline" model:flux
                                 </div>
                                 <p className="text-[10px] text-gray-600 dark:text-gray-400 uppercase tracking-tight">
-                                    Finds Pony images whose positive prompt mentions orc or dark elf.
+                                    Finds Flux images whose positive prompt mentions forest or city skyline.
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary

- replace the fantasy-themed `OR` example with `forest OR ocean`
- use Flux and neutral prompt terms in the combined search example
- keep the in-app Search Syntax help and user manual aligned

## Why

The previous Orc, Elf, and Pony examples carried associations that were unnecessary for explaining search syntax. Neutral terms demonstrate the same behavior without that baggage.

## User impact

Search behavior is unchanged. Only the examples shown in Help and the corresponding manual text are updated.

## Validation

- `node_modules\.bin\vitest.cmd run src/components/ui/__tests__/ShortcutsModal.test.tsx` — 4 tests passed
- `node_modules\.bin\vitest.cmd run src/utils/__tests__/sqlHelpers.test.ts -t "explicit OR prompt terms"` — 1 test passed
- `git diff --check`