### PR TITLE
fix: preserve smart collection thumbnails

### DIFF
--- a/src/services/db/__tests__/collectionRepo.test.ts
+++ b/src/services/db/__tests__/collectionRepo.test.ts
@@ -809,6 +809,17 @@ describe('collectionRepo membership helpers', () => {
         expect(dbMocks.getDb).not.toHaveBeenCalled();
     });
 
+    it('limits full Invoke reconciliation cache clearing to non-smart Invoke boards', async () => {
+        const { clearInvokeBoardThumbnailCaches } = await import('../collectionRepo');
+
+        await clearInvokeBoardThumbnailCaches();
+
+        const sql = dbMocks.execute.mock.calls[0]?.[0] as string;
+        expect(sql).toContain("source = 'invoke'");
+        expect(sql).toContain('filter_state IS NULL');
+        expect(sql).toContain("custom_thumbnail IS NULL OR custom_thumbnail = ''");
+    });
+
     it('clears selected and all native collection thumbnail caches', async () => {
         const {
             clearAllCollectionThumbnailCaches,
@@ -838,10 +849,12 @@ describe('collectionRepo membership helpers', () => {
             clearAllCollectionThumbnailCaches,
             clearCollectionThumbnailCacheForCollections,
             clearCollectionThumbnailCacheForImages,
+            clearInvokeBoardThumbnailCaches,
         } = await import('../collectionRepo');
 
         await clearCollectionThumbnailCacheForCollections(['c1']);
         await clearCollectionThumbnailCacheForImages(['image-1']);
+        await clearInvokeBoardThumbnailCaches();
         await clearAllCollectionThumbnailCaches();
 
         expect(dbMocks.getDb).not.toHaveBeenCalled();

--- a/src/services/db/__tests__/imageRepo.test.ts
+++ b/src/services/db/__tests__/imageRepo.test.ts
@@ -800,7 +800,7 @@ describe('imageRepo batch removal', () => {
         );
     });
 
-    it('syncs all board-linked images when no id filter is supplied', async () => {
+    it('syncs all board-linked images without invalidating smart collection thumbnail caches', async () => {
         const db = {
             select: vi.fn(async () => []),
             execute: vi.fn(),
@@ -814,6 +814,11 @@ describe('imageRepo batch removal', () => {
             expect.not.stringContaining('AND id IN'),
             []
         );
+        const cacheUpdateSql = db.execute.mock.calls
+            .map(([query]) => query as string)
+            .find(query => query.includes('UPDATE collections'));
+        expect(cacheUpdateSql).toContain("source = 'invoke'");
+        expect(cacheUpdateSql).toContain('filter_state IS NULL');
         expect(db.select).not.toHaveBeenCalled();
     });
 

--- a/src/services/db/collectionRepo.ts
+++ b/src/services/db/collectionRepo.ts
@@ -247,6 +247,22 @@ export const clearCollectionThumbnailCacheForImages = async (imageIds: string[])
     await clearDynamicThumbnailCacheForCollections(db, collectionIds);
 };
 
+export const clearInvokeBoardThumbnailCaches = async () => {
+    if (isBrowserMockMode()) return;
+
+    const db = await getDb();
+    await db.execute(
+        `UPDATE collections
+         SET dynamic_thumbnail_path = NULL,
+             dynamic_safe_thumbnail_path = NULL,
+             dynamic_thumbnail_is_sensitive = NULL,
+             dynamic_thumbnail_cached_at = NULL
+         WHERE source = 'invoke'
+           AND filter_state IS NULL
+           AND (custom_thumbnail IS NULL OR custom_thumbnail = '')`
+    );
+};
+
 export const clearAllCollectionThumbnailCaches = async () => {
     if (isBrowserMockMode()) return;
 

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -19,6 +19,7 @@ import {
     clearAllCollectionThumbnailCaches,
     clearCollectionThumbnailCacheForCollections,
     clearCollectionThumbnailCacheForImages,
+    clearInvokeBoardThumbnailCaches,
 } from './collectionRepo';
 import { scanImageNative } from '../metadataParser';
 
@@ -444,7 +445,7 @@ export const syncCollectionImages = async (ids?: string[]) => {
         if (ids && ids.length > 0) {
             await clearCollectionThumbnailCacheForImages(ids);
         } else {
-            await clearAllCollectionThumbnailCaches();
+            await clearInvokeBoardThumbnailCaches();
         }
         console.log('[DB] Bulk collection sync complete.');
     });


### PR DESCRIPTION
## Summary

- preserve persisted search-based smart collection thumbnails during full InvokeAI board reconciliation
- invalidate only non-smart Invoke board thumbnail caches
- add regression coverage for scoped cache clearing and full board sync behavior

## Root cause

Full InvokeAI reconciliation cleared every dynamic collection thumbnail cache. Search-query smart collections are intentionally skipped during automatic hydration, so their tiles stayed blank until each collection was selected.

## Impact

Manual InvokeAI syncs no longer blank persisted smart collection covers. Invoke board covers still refresh normally, custom thumbnails remain untouched, and the emergency clear-all path is unchanged.

## Validation

- `pnpm run test:run -- src/stores/__tests__/collectionStore.test.ts src/services/db/__tests__/collectionRepo.test.ts src/features/filters/components/__tests__/CollectionList.test.tsx src/services/db/__tests__/imageRepo.test.ts` — 159 tests passed
- `pnpm run typecheck`
- `git diff --check`