### PR TITLE
fix: make viewer collection membership reliable

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -15,6 +15,7 @@ type AppLayoutProbe = {
     onOpenImportModal: () => void;
     handleRemoveFromCollection: () => Promise<void>;
     handleOpenCollectionModal: (mode?: 'add' | 'move') => void;
+    onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     onEditCollection: (id: string) => void;
     setExportIds: React.Dispatch<React.SetStateAction<Set<string>>>;
     setViewingImageId: React.Dispatch<React.SetStateAction<string | null>>;
@@ -81,7 +82,7 @@ type ViewerProbe = {
     onSearch: (term: string) => void;
     onRevertMetadata: (id: string) => void;
     onRecoverMetadata: () => void;
-    onAddToCollection: (id: string) => void;
+    onSetCollectionMembership: (id: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     onToggleSidebar: () => void;
 };
 
@@ -155,9 +156,16 @@ const mocks = vi.hoisted(() => ({
     handleImportFolders: vi.fn().mockResolvedValue(undefined),
     importImages: vi.fn(),
     handleInvokeSync: vi.fn(),
-    removeImagesFromCollection: vi.fn().mockResolvedValue(undefined),
+    removeImagesFromCollection: vi.fn(async (
+        _imageIds: string[],
+        _collectionId: string,
+        onPersisted?: () => void
+    ) => {
+        onPersisted?.();
+        return true;
+    }),
     moveImagesBetweenCollections: vi.fn().mockResolvedValue(undefined),
-    addImagesToCollection: vi.fn().mockResolvedValue(undefined),
+    addImagesToCollection: vi.fn().mockResolvedValue(true),
     deleteCollection: vi.fn().mockResolvedValue(undefined),
     updateCollectionFilters: vi.fn().mockResolvedValue(undefined),
     handleExportConfirm: vi.fn(),
@@ -482,6 +490,14 @@ describe('App orchestration', () => {
         mocks.setRecentSearches.mockImplementation((update: React.SetStateAction<string[]>) => {
             if (typeof update === 'function') update(['old']);
         });
+        mocks.removeImagesFromCollection.mockImplementation(async (
+            _imageIds: string[],
+            _collectionId: string,
+            onPersisted?: () => void
+        ) => {
+            onPersisted?.();
+            return true;
+        });
         vi.mocked(open).mockReset();
     });
 
@@ -578,6 +594,12 @@ describe('App orchestration', () => {
         await act(async () => layout.handleRemoveFromCollection());
         expect(mocks.removeImagesFromCollection).toHaveBeenCalledWith(['one'], 'collection-a');
         expect(mocks.addToast).toHaveBeenCalledWith('Removed 1 images from collection', 'info');
+        await act(async () => {
+            expect(await layout.onSetCollectionMembership('one', 'target', true)).toBe(true);
+            expect(await layout.onSetCollectionMembership('one', 'target', false)).toBe(true);
+        });
+        expect(mocks.addImagesToCollection).toHaveBeenCalledWith(['one'], 'target');
+        expect(mocks.removeImagesFromCollection).toHaveBeenCalledWith(['one'], 'target');
 
         act(() => layout.setExportIds(new Set(['one'])));
         requireProbe(captured.globalModals, 'GlobalModals').onExportConfirm('export', 'C:/out');
@@ -755,7 +777,10 @@ describe('App orchestration', () => {
         viewer.onDelete('one');
         viewer.onRevertMetadata('one');
         viewer.onOpenSettings();
-        viewer.onAddToCollection('one');
+        await act(async () => {
+            expect(await viewer.onSetCollectionMembership('one', 'target', true)).toBe(true);
+            expect(await viewer.onSetCollectionMembership('one', 'target', false)).toBe(true);
+        });
         viewer.onToggleSidebar();
         viewer.onClose();
 
@@ -764,7 +789,110 @@ describe('App orchestration', () => {
         expect(mocks.handleFavoriteImage).toHaveBeenCalledWith('one', { showToast: false });
         expect(mocks.handlePinImage).toHaveBeenCalledWith('one', true, { showToast: false });
         expect(mocks.handleDeleteViewerImage).toHaveBeenCalledWith('one');
+        expect(mocks.addImagesToCollection).toHaveBeenCalledWith(['one'], 'target');
+        expect(mocks.removeImagesFromCollection).toHaveBeenCalledWith(['one'], 'target', expect.any(Function));
+        expect(mocks.modals.openModal).not.toHaveBeenCalledWith('addToCollection');
         expect(mocks.settings.defaultTheaterMode).toBe(true);
+    });
+
+    it('closes the viewer after successfully removing its sole image from the active collection', async () => {
+        mocks.images = [image('one')];
+        mocks.collections = [{ id: 'active', name: 'Active', imageIds: ['one'], createdAt: 1 }];
+        mocks.filters = createDefaultFilters({ collectionId: 'active' });
+        const view = render(<App />);
+        act(() => requireProbe(captured.appLayout, 'AppLayout').setViewingImageId('one'));
+        await waitFor(() => expect(view.container.querySelector('[data-testid="image-viewer"]')).not.toBeNull());
+
+        await act(async () => {
+            expect(await requireProbe(captured.viewer, 'ImageViewer').onSetCollectionMembership('one', 'active', false)).toBe(true);
+        });
+
+        await waitFor(() => expect(view.container.querySelector('[data-testid="image-viewer"]')).toBeNull());
+        expect(mocks.shortcuts).toHaveBeenLastCalledWith(expect.objectContaining({ isViewerOpen: false }));
+    });
+
+    it('moves the viewer to the previous image after removing the last image from the active collection', async () => {
+        mocks.collections = [{ id: 'active', name: 'Active', imageIds: ['one', 'two'], createdAt: 1 }];
+        mocks.filters = createDefaultFilters({ collectionId: 'active' });
+        render(<App />);
+        act(() => requireProbe(captured.appLayout, 'AppLayout').setSelectedImageIndex(1));
+        await waitFor(() => expect(captured.viewer?.image.id).toBe('two'));
+
+        await act(async () => {
+            expect(await requireProbe(captured.viewer, 'ImageViewer').onSetCollectionMembership('two', 'active', false)).toBe(true);
+        });
+
+        await waitFor(() => expect(captured.viewer?.image.id).toBe('one'));
+    });
+
+    it('does not open the global viewer when Maintenance persists collection membership', async () => {
+        mocks.images = [image('one')];
+        mocks.collections = [{ id: 'active', name: 'Active', imageIds: ['one'], createdAt: 1 }];
+        mocks.filters = createDefaultFilters({ collectionId: 'active' });
+        const view = render(<App />);
+
+        await act(async () => {
+            expect(await requireProbe(captured.appLayout, 'AppLayout').onSetCollectionMembership('one', 'active', false)).toBe(true);
+        });
+
+        expect(view.container.querySelector('[data-testid="image-viewer"]')).toBeNull();
+        expect(mocks.removeImagesFromCollection).toHaveBeenCalledWith(['one'], 'active');
+    });
+
+    it('keeps deferred active-collection removals on the latest displayed image', async () => {
+        const firstRemoval = createDeferred<boolean>();
+        const secondRemoval = createDeferred<boolean>();
+        const persistenceCallbacks: Array<() => void> = [];
+        let rerenderApp: () => void = () => undefined;
+        mocks.removeImagesFromCollection
+            .mockImplementationOnce((ids, _collectionId, onPersisted?: () => void) => {
+                persistenceCallbacks.push(() => {
+                    onPersisted?.();
+                    mocks.images = mocks.images.filter(candidate => !ids.includes(candidate.id));
+                    rerenderApp();
+                });
+                return firstRemoval.promise;
+            })
+            .mockImplementationOnce((ids, _collectionId, onPersisted?: () => void) => {
+                persistenceCallbacks.push(() => {
+                    onPersisted?.();
+                    mocks.images = mocks.images.filter(candidate => !ids.includes(candidate.id));
+                    rerenderApp();
+                });
+                return secondRemoval.promise;
+            });
+        mocks.images = [image('one'), image('two'), image('three')];
+        mocks.collections = [{ id: 'active', name: 'Active', imageIds: ['one', 'two', 'three'], createdAt: 1 }];
+        mocks.filters = createDefaultFilters({ collectionId: 'active' });
+        const view = render(<App />);
+        rerenderApp = () => view.rerender(<App />);
+        act(() => requireProbe(captured.appLayout, 'AppLayout').setSelectedImageIndex(0));
+        await waitFor(() => expect(captured.viewer?.image.id).toBe('one'));
+
+        let removeOne!: Promise<boolean>;
+        act(() => {
+            removeOne = requireProbe(captured.viewer, 'ImageViewer').onSetCollectionMembership('one', 'active', false);
+        });
+        act(() => requireProbe(captured.viewer, 'ImageViewer').onNext());
+        await waitFor(() => expect(captured.viewer?.image.id).toBe('two'));
+        let removeTwo!: Promise<boolean>;
+        act(() => {
+            removeTwo = requireProbe(captured.viewer, 'ImageViewer').onSetCollectionMembership('two', 'active', false);
+        });
+
+        await act(async () => {
+            persistenceCallbacks[0]();
+            firstRemoval.resolve(true);
+            expect(await removeOne).toBe(true);
+        });
+        await waitFor(() => expect(captured.viewer?.image.id).toBe('two'));
+
+        await act(async () => {
+            persistenceCallbacks[1]();
+            secondRemoval.resolve(true);
+            expect(await removeTwo).toBe(true);
+        });
+        await waitFor(() => expect(captured.viewer?.image.id).toBe('three'));
     });
 
     it('removes viewer and compare/slideshow image exposure when SearchContext fails closed', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,14 @@ export default function App() {
         recentSearches, setRecentSearches,
         refreshMetadata
     } = useSearch();
+    const activeCollectionIdRef = useRef(filters.collectionId);
+    const imagesRef = useRef(images);
+    const selectedImageIndexRef = useRef(selectedImageIndex);
+    const viewingImageIdRef = useRef(viewingImageId);
+    activeCollectionIdRef.current = filters.collectionId;
+    imagesRef.current = images;
+    selectedImageIndexRef.current = selectedImageIndex;
+    viewingImageIdRef.current = viewingImageId;
     // const images = useSearchStore(s => s.images);
     // const setImages = useSearchStore(s => s.setImages);
     // const filters = useSearchStore(s => s.filters);
@@ -277,6 +285,55 @@ export default function App() {
         modals.openModal('addToCollection');
     }, [modals]);
 
+    const handleSetCollectionMembership = useCallback((
+        imageId: string,
+        collectionId: string,
+        shouldBelong: boolean
+    ): Promise<boolean> => shouldBelong
+            ? colOps.addImagesToCollection([imageId], collectionId)
+            : colOps.removeImagesFromCollection([imageId], collectionId), [colOps]);
+
+    const reconcileGlobalViewerAfterRemoval = useCallback((imageId: string, collectionId: string) => {
+        if (activeCollectionIdRef.current !== collectionId) return;
+
+        const previousImages = imagesRef.current;
+        const removedIndex = previousImages.findIndex(candidate => candidate.id === imageId);
+        if (removedIndex === -1) return;
+
+        const selectedIndex = selectedImageIndexRef.current;
+        const viewingId = viewingImageIdRef.current;
+        const displayedImageId = viewingId
+            ?? (selectedIndex !== null ? previousImages[selectedIndex]?.id : undefined);
+        const nextImages = previousImages.filter(candidate => candidate.id !== imageId);
+        imagesRef.current = nextImages;
+
+        if (!displayedImageId) return;
+
+        if (viewingId && viewingId !== imageId) return;
+
+        const nextIndex = displayedImageId === imageId
+            ? (nextImages.length === 0 ? null : Math.min(removedIndex, nextImages.length - 1))
+            : nextImages.findIndex(candidate => candidate.id === displayedImageId);
+        if (nextIndex === -1) return;
+
+        selectedImageIndexRef.current = nextIndex;
+        viewingImageIdRef.current = null;
+        setSelectedImageIndex(nextIndex);
+        setViewingImageId(null);
+    }, []);
+
+    const handleSetViewerCollectionMembership = useCallback((
+        imageId: string,
+        collectionId: string,
+        shouldBelong: boolean
+    ): Promise<boolean> => shouldBelong
+            ? colOps.addImagesToCollection([imageId], collectionId)
+            : colOps.removeImagesFromCollection(
+                [imageId],
+                collectionId,
+                () => reconcileGlobalViewerAfterRemoval(imageId, collectionId)
+            ), [colOps, reconcileGlobalViewerAfterRemoval]);
+
     // --- Derived Memos ---
     const searchProps = React.useMemo(() => ({
         isAiSearchEnabled,
@@ -438,6 +495,7 @@ export default function App() {
                 lastSelectedId={lastSelectedId}
                 handleRemoveFromCollection={handleRemoveFromCollection}
                 handleOpenCollectionModal={handleOpenCollectionModal}
+                onSetCollectionMembership={handleSetCollectionMembership}
                 onEditCollection={(id) => { modals.setCollectionToEditId(id); modals.openModal('collectionEditor'); }}
             />
 
@@ -629,7 +687,7 @@ export default function App() {
                             }}
                             onRevertMetadata={(id) => handlers.handleRevertMetadata(id)}
                             onRecoverMetadata={handleOpenRecovery}
-                            onAddToCollection={(id) => handleOpenCollectionModal('add')}
+                            onSetCollectionMembership={handleSetViewerCollectionMembership}
                             availableTags={availableTags}
                             isSidebarOpen={!settings.defaultTheaterMode}
                             onToggleSidebar={() => setSettings(p => ({ ...p, defaultTheaterMode: !p.defaultTheaterMode }))}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -104,6 +104,7 @@ interface AppLayoutProps {
     handleRemoveFromCollection: () => void;
 
     handleOpenCollectionModal: (mode: 'add' | 'move') => void;
+    onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     onEditCollection: (colId: string) => void;
 }
 
@@ -120,7 +121,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
     clearSelection, gridRef, handleLayoutChange,
     isSearchFocused, setIsSearchFocused, lastSelectedId,
 
-    handleRemoveFromCollection, handleOpenCollectionModal, onEditCollection
+    handleRemoveFromCollection, handleOpenCollectionModal, onSetCollectionMembership, onEditCollection
 }) => {
     // Hooks
     useProgressListeners();
@@ -389,6 +390,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                                         }}
                                         onToggleFavorite={(id) => toggleFavorite(id)}
                                         onTogglePin={actions.handlePinImage}
+                                        onSetCollectionMembership={onSetCollectionMembership}
                                         availableTags={availableTags}
                                     />
                                 </React.Suspense>

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -191,6 +191,7 @@ describe('AppLayout', () => {
         lastSelectedId: null,
         handleRemoveFromCollection: vi.fn(),
         handleOpenCollectionModal: vi.fn(),
+        onSetCollectionMembership: vi.fn().mockResolvedValue(true),
     };
 
     it('renders the main structures: Sidebar, Header, Content Area', () => {
@@ -293,9 +294,17 @@ describe('AppLayout', () => {
         expect(timeline.getAttribute('data-has-load-more')).toBe('true');
     });
 
-    it('renders MaintenanceView when viewMode is maintenance', async () => {
-        render(<AppLayout {...defaultProps} viewMode="maintenance" />);
+    it('forwards collection persistence to MaintenanceView', async () => {
+        const onSetCollectionMembership = vi.fn().mockResolvedValue(true);
+        render(
+            <AppLayout
+                {...defaultProps}
+                viewMode="maintenance"
+                onSetCollectionMembership={onSetCollectionMembership}
+            />
+        );
         expect(await screen.findByTestId('maintenance-view')).toBeTruthy();
+        expect(capturedProps.maintenance?.onSetCollectionMembership).toBe(onSetCollectionMembership);
     });
 
     it('filters by a dashboard model and returns to the grid', async () => {

--- a/src/features/maintenance/components/MaintenanceView.test.tsx
+++ b/src/features/maintenance/components/MaintenanceView.test.tsx
@@ -225,7 +225,7 @@ vi.mock('./ScanPlaceholder', () => ({
 }));
 
 vi.mock('../../../features/viewer/components/ImageViewer', () => ({
-    ImageViewer: ({ image, onDelete, onNext, onPrev, onClose, onToggleFavorite, onTogglePin, onAddToCollection, onSearch, onOpenSettings }: {
+    ImageViewer: ({ image, onDelete, onNext, onPrev, onClose, onToggleFavorite, onTogglePin, onSetCollectionMembership, onSearch, onOpenSettings }: {
         image: AIImage;
         onDelete?: () => void;
         onNext: () => void;
@@ -233,7 +233,7 @@ vi.mock('../../../features/viewer/components/ImageViewer', () => ({
         onClose: () => void;
         onToggleFavorite: (id: string) => void;
         onTogglePin?: (id: string, pinned: boolean) => void;
-        onAddToCollection: () => void;
+        onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
         onSearch: () => void;
         onOpenSettings: () => void;
     }) => (
@@ -244,7 +244,8 @@ vi.mock('../../../features/viewer/components/ImageViewer', () => ({
             <button onClick={onClose}>Close Viewer</button>
             <button onClick={() => onToggleFavorite(image.id)}>Favorite Viewer</button>
             {onTogglePin && <button onClick={() => onTogglePin(image.id, true)}>Pin Viewer</button>}
-            <button onClick={onAddToCollection}>Viewer Collection</button>
+            <button onClick={() => void onSetCollectionMembership(image.id, 'collection', true)}>Add Viewer Collection</button>
+            <button onClick={() => void onSetCollectionMembership(image.id, 'collection', false)}>Remove Viewer Collection</button>
             <button onClick={onSearch}>Viewer Search</button>
             <button onClick={onOpenSettings}>Viewer Settings</button>
         </div>
@@ -288,7 +289,8 @@ const createProps = (): React.ComponentProps<typeof MaintenanceView> => ({
     onRegenerateThumbnails: vi.fn().mockResolvedValue(undefined),
     maskedKeywords: [],
     onToggleFavorite: vi.fn(),
-    onTogglePin: vi.fn()
+    onTogglePin: vi.fn(),
+    onSetCollectionMembership: vi.fn().mockResolvedValue(true)
 });
 
 const renderView = (overrides: Partial<React.ComponentProps<typeof MaintenanceView>> = {}) => {
@@ -580,7 +582,8 @@ describe('MaintenanceView', () => {
         maintenanceDataMock.localMissingImages = [createImage({ id: 'missing-a' }), createImage({ id: 'missing-b' })];
         const onToggleFavorite = vi.fn();
         const onTogglePin = vi.fn();
-        renderView({ onToggleFavorite, onTogglePin });
+        const onSetCollectionMembership = vi.fn().mockResolvedValue(true);
+        renderView({ onToggleFavorite, onTogglePin, onSetCollectionMembership });
 
         fireEvent.click(screen.getByText('Select Missing Item'));
         expect(screen.getByTestId('maintenance-viewer').getAttribute('data-image-id')).toBe('missing-a');
@@ -593,7 +596,10 @@ describe('MaintenanceView', () => {
         fireEvent.click(screen.getByText('Pin Viewer'));
         expect(onToggleFavorite).toHaveBeenCalledWith('missing-a');
         expect(onTogglePin).toHaveBeenCalledWith('missing-a', true);
-        fireEvent.click(screen.getByText('Viewer Collection'));
+        fireEvent.click(screen.getByText('Add Viewer Collection'));
+        fireEvent.click(screen.getByText('Remove Viewer Collection'));
+        expect(onSetCollectionMembership).toHaveBeenNthCalledWith(1, 'missing-a', 'collection', true);
+        expect(onSetCollectionMembership).toHaveBeenNthCalledWith(2, 'missing-a', 'collection', false);
         fireEvent.click(screen.getByText('Viewer Search'));
         fireEvent.click(screen.getByText('Viewer Settings'));
         fireEvent.click(screen.getByText('Close Viewer'));

--- a/src/features/maintenance/components/MaintenanceView.tsx
+++ b/src/features/maintenance/components/MaintenanceView.tsx
@@ -38,6 +38,7 @@ interface MaintenanceViewProps {
     onRecoverMetadata?: () => void;
     onToggleFavorite?: (id: string) => void;
     onTogglePin?: (id: string, isPinned: boolean) => void;
+    onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     availableTags?: string[];
 }
 
@@ -59,6 +60,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
     onRecoverMetadata,
     onToggleFavorite,
     onTogglePin,
+    onSetCollectionMembership,
     availableTags
 }) => {
     // --- State ---
@@ -620,7 +622,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
                         const idx = list.findIndex(i => i.id === viewingImageId);
                         if (idx > 0) setViewingImageId(list[idx - 1].id);
                     }}
-                    onAddToCollection={() => { }}
+                    onSetCollectionMembership={onSetCollectionMembership}
                     onSearch={() => { }}
                     onToggleFavorite={(id) => onToggleFavorite?.(id)}
                     onTogglePin={onTogglePin}

--- a/src/features/viewer/components/ImageViewer.tsx
+++ b/src/features/viewer/components/ImageViewer.tsx
@@ -25,7 +25,7 @@ import {
 interface ImageViewerProps {
     image: AIImage;
     availableTags?: string[];
-    onAddToCollection: (imageId: string, collectionId: string) => void;
+    onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     onClose: () => void;
     onNext: () => void;
     onPrev: () => void;
@@ -106,7 +106,7 @@ const ViewerStatusHud: React.FC<ViewerStatusHudProps> = ({ isFavorite, isPinned,
 export const ImageViewer: React.FC<ImageViewerProps> = ({
     image,
     availableTags = [],
-    onAddToCollection,
+    onSetCollectionMembership,
     onClose,
     onNext,
     onPrev,
@@ -434,7 +434,7 @@ export const ImageViewer: React.FC<ImageViewerProps> = ({
                     onUpdateNegativePrompt={(id, np) => onUpdateNegativePrompt?.(id, np)}
                     onUpdateModel={(id, m) => onUpdateModel?.(id, m)}
                     onUpdateTool={(id, t) => onUpdateTool?.(id, t)}
-                    onAddToCollection={onAddToCollection}
+                    onSetCollectionMembership={onSetCollectionMembership}
                     onSearch={onSearch}
                     onClose={onClose}
                     onRecoverMetadata={onRecoverMetadata}

--- a/src/features/viewer/components/MetadataSidebar.tsx
+++ b/src/features/viewer/components/MetadataSidebar.tsx
@@ -29,7 +29,7 @@ interface MetadataSidebarProps {
     onUpdateNegativePrompt?: (imageId: string, negativePrompt: string) => void;
     onUpdateModel?: (imageId: string, newModel: string) => void;
     onUpdateTool?: (id: string, tool: GeneratorTool) => void;
-    onAddToCollection: (imageId: string, colId: string) => void;
+    onSetCollectionMembership: (imageId: string, colId: string, shouldBelong: boolean) => Promise<boolean>;
     onSearch: (term: string) => void;
     onClose: () => void;
     onRecoverMetadata?: () => void;
@@ -65,7 +65,7 @@ export const MetadataSidebar: React.FC<MetadataSidebarProps> = ({
     onUpdateNegativePrompt,
     onUpdateModel,
     onUpdateTool,
-    onAddToCollection,
+    onSetCollectionMembership,
     onSearch,
     onClose,
     onRecoverMetadata,
@@ -165,7 +165,7 @@ export const MetadataSidebar: React.FC<MetadataSidebarProps> = ({
                         setPromptValue={setPromptValue}
                         negativePromptValue={negativePromptValue}
                         setNegativePromptValue={setNegativePromptValue}
-                        onAddToCollection={onAddToCollection}
+                        onSetCollectionMembership={onSetCollectionMembership}
                         onUpdatePrompt={onUpdatePrompt}
                         onUpdateNegativePrompt={onUpdateNegativePrompt}
                         onUpdateNotes={onUpdateNotes}

--- a/src/features/viewer/components/__tests__/ImageViewer.accessibility.test.tsx
+++ b/src/features/viewer/components/__tests__/ImageViewer.accessibility.test.tsx
@@ -126,7 +126,7 @@ describe('ImageViewer full metadata loading', () => {
         mockGetImageWithFullMetadata.mockResolvedValue(lightImage);
         const viewerProps = {
             image: lightImage,
-            onAddToCollection: vi.fn(),
+            onSetCollectionMembership: vi.fn().mockResolvedValue(true),
             onClose: vi.fn(),
             onNext: vi.fn(),
             onPrev: vi.fn(),

--- a/src/features/viewer/components/__tests__/ImageViewer.test.tsx
+++ b/src/features/viewer/components/__tests__/ImageViewer.test.tsx
@@ -159,7 +159,7 @@ const lightImage: AIImage = {
 const renderViewer = (overrides: Partial<React.ComponentProps<typeof ImageViewer>> = {}) => {
     const props: React.ComponentProps<typeof ImageViewer> = {
         image: lightImage,
-        onAddToCollection: vi.fn(),
+        onSetCollectionMembership: vi.fn().mockResolvedValue(true),
         onClose: vi.fn(),
         onNext: vi.fn(),
         onPrev: vi.fn(),
@@ -214,7 +214,7 @@ describe('ImageViewer full metadata loading', () => {
 
         render(<ImageViewer
             image={lightImage}
-            onAddToCollection={vi.fn()}
+            onSetCollectionMembership={vi.fn().mockResolvedValue(true)}
             onClose={vi.fn()}
             onNext={vi.fn()}
             onPrev={vi.fn()}
@@ -297,7 +297,7 @@ describe('ImageViewer full metadata loading', () => {
         aiState.value.result = 'analysis result';
         const callbacks = {
             onUpdateNotes: vi.fn(), onUpdatePrompt: vi.fn(), onUpdateNegativePrompt: vi.fn(),
-            onUpdateModel: vi.fn(), onUpdateTool: vi.fn(), onAddToCollection: vi.fn(),
+            onUpdateModel: vi.fn(), onUpdateTool: vi.fn(), onSetCollectionMembership: vi.fn().mockResolvedValue(true),
             onSearch: vi.fn(), onRecoverMetadata: vi.fn(), onRevertMetadata: vi.fn(), onOpenSettings: vi.fn()
         };
         renderViewer(callbacks);
@@ -311,7 +311,7 @@ describe('ImageViewer full metadata loading', () => {
             onUpdateNegativePrompt: (id: string, value: string) => void;
             onUpdateModel: (id: string, value: string) => void;
             onUpdateTool: (id: string, value: GeneratorTool) => void;
-            onAddToCollection: (id: string, collection: string) => void;
+            onSetCollectionMembership: (id: string, collection: string, shouldBelong: boolean) => Promise<boolean>;
             onSearch: (term: string) => void;
             onRecoverMetadata: () => void; onRevertMetadata: (id: string) => void;
             onAIAnalysis: () => void; onGenerateVariations: () => void; onOpenAIResult: () => void;
@@ -327,7 +327,7 @@ describe('ImageViewer full metadata loading', () => {
         sidebar.onUpdateNegativePrompt('id', 'negative');
         sidebar.onUpdateModel('id', 'Flux');
         sidebar.onUpdateTool('id', GeneratorTool.COMFYUI);
-        sidebar.onAddToCollection('id', 'collection');
+        await sidebar.onSetCollectionMembership('id', 'collection', true);
         sidebar.onSearch('term');
         sidebar.onRecoverMetadata();
         sidebar.onRevertMetadata('id');
@@ -339,6 +339,7 @@ describe('ImageViewer full metadata loading', () => {
         expect(callbacks.onUpdateNegativePrompt).toHaveBeenCalledWith('id', 'negative');
         expect(callbacks.onUpdateModel).toHaveBeenCalledWith('id', 'Flux');
         expect(callbacks.onUpdateTool).toHaveBeenCalledWith('id', GeneratorTool.COMFYUI);
+        expect(callbacks.onSetCollectionMembership).toHaveBeenCalledWith('id', 'collection', true);
         expect(aiState.value.analyzePrompt).toHaveBeenCalledWith('Recovered prompt', callbacks.onOpenSettings);
         expect(aiState.value.generateVariations).toHaveBeenCalledWith('Recovered prompt', callbacks.onOpenSettings);
         expect(aiState.value.openModal).toHaveBeenCalled();

--- a/src/features/viewer/components/__tests__/MetadataSidebar.test.tsx
+++ b/src/features/viewer/components/__tests__/MetadataSidebar.test.tsx
@@ -19,7 +19,7 @@ const setup = (activeTab: 'info' | 'edit' | 'workflow', target = image()) => {
         image: target, activeTab, setActiveTab: vi.fn(), collections: [], availableTags: [], notes: '', setNotes: vi.fn(),
         promptValue: 'prompt', setPromptValue: vi.fn(), negativePromptValue: 'negative', setNegativePromptValue: vi.fn(),
         onUpdateNotes: vi.fn(), onUpdatePrompt: vi.fn(), onUpdateNegativePrompt: vi.fn(), onUpdateModel: vi.fn(), onUpdateTool: vi.fn(),
-        onAddToCollection: vi.fn(), onSearch: vi.fn(), onClose: vi.fn(), onRecoverMetadata: vi.fn(), onRevertMetadata: vi.fn(),
+        onSetCollectionMembership: vi.fn().mockResolvedValue(true), onSearch: vi.fn(), onClose: vi.fn(), onRecoverMetadata: vi.fn(), onRevertMetadata: vi.fn(),
         onAIAnalysis: vi.fn(), onGenerateVariations: vi.fn(), isAnalyzing: false, onOpenAIResult: vi.fn(), palette: ['#fff'], isPaletteLoading: false
     };
     const result = render(<MetadataSidebar {...props} />);
@@ -43,7 +43,7 @@ describe('MetadataSidebar', () => {
         const edit = setup('edit', image({ hasWorkflowHint: false }));
         expect(screen.getByText('edit-content')).toBeTruthy();
         expect(screen.queryByText('workflow')).toBeNull();
-        expect(captures.edit).toHaveBeenCalledWith(expect.objectContaining({ notes: '', onAddToCollection: edit.props.onAddToCollection }));
+        expect(captures.edit).toHaveBeenCalledWith(expect.objectContaining({ notes: '', onSetCollectionMembership: edit.props.onSetCollectionMembership }));
         edit.unmount();
 
         const workflow = setup('workflow', image({ hasWorkflowHint: true }));

--- a/src/features/viewer/components/metadata/MetadataEditTab.tsx
+++ b/src/features/viewer/components/metadata/MetadataEditTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import {
     Layout, Search, Check, Plus, FileText, ClipboardList, AlertCircle, Save, Code
 } from 'lucide-react';
@@ -18,11 +18,42 @@ interface MetadataEditTabProps {
     negativePromptValue: string;
     setNegativePromptValue: (s: string) => void;
 
-    onAddToCollection: (imageId: string, colId: string) => void;
+    onSetCollectionMembership: (imageId: string, colId: string, shouldBelong: boolean) => Promise<boolean>;
     onUpdatePrompt?: (imageId: string, prompt: string) => void;
     onUpdateNegativePrompt?: (imageId: string, negativePrompt: string) => void;
     onUpdateNotes?: (imageId: string, notes: string) => void;
 }
+
+type MembershipLoadState = {
+    imageId: string;
+    status: 'loading' | 'ready' | 'error';
+};
+
+const membershipKeySeparator = '\u0000';
+
+const retainRelevantMemberships = (
+    memberships: Map<string, string[]>,
+    activeImageId: string,
+    pendingKeys: Set<string>
+): Map<string, string[]> => {
+    const retainedImageIds = new Set([activeImageId]);
+    pendingKeys.forEach(key => retainedImageIds.add(key.split(membershipKeySeparator, 1)[0]));
+    if (memberships.size <= retainedImageIds.size
+        && [...memberships.keys()].every(imageId => retainedImageIds.has(imageId))) {
+        return memberships;
+    }
+
+    const retained = new Map<string, string[]>();
+    retainedImageIds.forEach(imageId => {
+        const imageMemberships = memberships.get(imageId);
+        if (imageMemberships) retained.set(imageId, imageMemberships);
+    });
+    return retained;
+};
+
+const hasPendingMembershipForImage = (pendingKeys: Set<string>, imageId: string): boolean => (
+    [...pendingKeys].some(key => key.startsWith(`${imageId}${membershipKeySeparator}`))
+);
 
 export const MetadataEditTab = ({
     image,
@@ -34,15 +65,39 @@ export const MetadataEditTab = ({
     setPromptValue,
     negativePromptValue,
     setNegativePromptValue,
-    onAddToCollection,
+    onSetCollectionMembership,
     onUpdatePrompt,
     onUpdateNegativePrompt,
     onUpdateNotes
 }: MetadataEditTabProps) => {
     // Local State
     const [collectionQuery, setCollectionQuery] = useState('');
-    const [imageCollections, setImageCollections] = useState<string[]>([]);
-    const [isLoadingCollections, setIsLoadingCollections] = useState(false);
+    const [membershipsByImage, setMembershipsByImage] = useState<Map<string, string[]>>(
+        () => new Map([[image.id, []]])
+    );
+    const [membershipLoadState, setMembershipLoadState] = useState<MembershipLoadState>({
+        imageId: image.id,
+        status: 'loading'
+    });
+    const [membershipRetryToken, setMembershipRetryToken] = useState(0);
+    const [pendingMembershipKeys, setPendingMembershipKeys] = useState<Set<string>>(() => new Set());
+    const pendingMembershipKeysRef = useRef(new Set<string>());
+    const activeImageIdRef = useRef(image.id);
+    const membershipRequestIdRef = useRef(0);
+    const imageCollections = membershipsByImage.get(image.id) ?? [];
+    const isMembershipLoading = membershipLoadState.imageId !== image.id
+        || membershipLoadState.status === 'loading';
+    const hasMembershipError = membershipLoadState.imageId === image.id
+        && membershipLoadState.status === 'error';
+    const isMembershipReady = membershipLoadState.imageId === image.id
+        && membershipLoadState.status === 'ready';
+
+    useLayoutEffect(() => {
+        activeImageIdRef.current = image.id;
+        setMembershipsByImage(prev => (
+            retainRelevantMemberships(prev, image.id, pendingMembershipKeysRef.current)
+        ));
+    }, [image.id]);
 
     const [isPromptDirty, setIsPromptDirty] = useState(false);
     const [isNegativePromptDirty, setIsNegativePromptDirty] = useState(false);
@@ -53,20 +108,35 @@ export const MetadataEditTab = ({
     // Fetch collections for this image on demand
     useEffect(() => {
         let isCancelled = false;
+        const imageId = image.id;
+        const requestId = membershipRequestIdRef.current + 1;
+        membershipRequestIdRef.current = requestId;
         const fetchImageMembership = async () => {
-            setIsLoadingCollections(true);
+            setMembershipLoadState({ imageId, status: 'loading' });
             try {
-                const colIds = await getCollectionsForImage(image.id);
-                if (!isCancelled) setImageCollections(colIds);
+                const colIds = await getCollectionsForImage(imageId);
+                if (!isCancelled && membershipRequestIdRef.current === requestId) {
+                    setMembershipsByImage(prev => {
+                        const next = new Map(retainRelevantMemberships(
+                            prev,
+                            imageId,
+                            pendingMembershipKeysRef.current
+                        ));
+                        next.set(imageId, colIds);
+                        return next;
+                    });
+                    setMembershipLoadState({ imageId, status: 'ready' });
+                }
             } catch (e) {
                 console.error("Failed to fetch image collections", e);
-            } finally {
-                if (!isCancelled) setIsLoadingCollections(false);
+                if (!isCancelled && membershipRequestIdRef.current === requestId) {
+                    setMembershipLoadState({ imageId, status: 'error' });
+                }
             }
         };
         fetchImageMembership();
         return () => { isCancelled = true; };
-    }, [image.id]);
+    }, [image.id, membershipRetryToken]);
 
     const handlePromptChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         setPromptValue(e.target.value);
@@ -112,28 +182,99 @@ export const MetadataEditTab = ({
                     <input type="text" placeholder="Find collection..." value={collectionQuery} onChange={(e) => setCollectionQuery(e.target.value)} className="w-full bg-white dark:bg-zinc-800/50 border border-gray-200 dark:border-white/10 rounded-lg pl-8 pr-2 py-1.5 text-xs text-gray-900 dark:text-white focus:border-sage-500 outline-none" />
                 </div>
                 <div className="space-y-2 max-h-60 overflow-y-auto custom-scrollbar pr-1 relative">
-                    {isLoadingCollections && (
+                    {isMembershipLoading && (
                         <div className="absolute inset-0 bg-white/50 dark:bg-zinc-900/50 flex items-center justify-center z-10 backdrop-blur-[1px]">
                             <div className="animate-spin rounded-full h-4 w-4 border-2 border-sage-500 border-t-transparent" />
                         </div>
                     )}
-                    {collections.filter(c => c.name.toLowerCase().includes(collectionQuery.toLowerCase())).map(col => {
+                    {hasMembershipError && (
+                        <div role="alert" className="absolute inset-0 bg-white/90 dark:bg-zinc-900/90 flex flex-col items-center justify-center gap-2 z-10 px-4 text-center">
+                            <span className="text-xs text-gray-600 dark:text-gray-300">Could not load collection membership.</span>
+                            <button
+                                type="button"
+                                onClick={() => setMembershipRetryToken(token => token + 1)}
+                                className="text-xs font-medium text-sage-700 dark:text-sage-300 hover:underline"
+                            >
+                                Retry
+                            </button>
+                        </div>
+                    )}
+                    {collections.filter(c => (
+                        !c.filters && c.name.toLowerCase().includes(collectionQuery.toLowerCase())
+                    )).map(col => {
                         const isIn = imageCollections.includes(col.id);
+                        const membershipKey = `${image.id}${membershipKeySeparator}${col.id}`;
+                        const isPending = pendingMembershipKeys.has(membershipKey);
                         return (
                             <button
+                                type="button"
                                 key={col.id}
+                                aria-pressed={isIn}
+                                aria-busy={isPending}
+                                disabled={!isMembershipReady || isPending}
                                 onClick={async () => {
-                                    // Optimistic UI for membership
                                     const wasIn = isIn;
-                                    setImageCollections(prev => wasIn ? prev.filter(id => id !== col.id) : [...prev, col.id]);
+                                    const shouldBelong = !wasIn;
+                                    const imageId = image.id;
+                                    if (pendingMembershipKeysRef.current.has(membershipKey)) return;
+                                    pendingMembershipKeysRef.current.add(membershipKey);
+                                    setPendingMembershipKeys(prev => {
+                                        const next = new Set(prev);
+                                        next.add(membershipKey);
+                                        return next;
+                                    });
+                                    setMembershipsByImage(prev => {
+                                        const memberships = prev.get(imageId) ?? [];
+                                        const next = new Map(retainRelevantMemberships(
+                                            prev,
+                                            activeImageIdRef.current,
+                                            pendingMembershipKeysRef.current
+                                        ));
+                                        next.set(imageId, shouldBelong
+                                            ? (memberships.includes(col.id) ? memberships : [...memberships, col.id])
+                                            : memberships.filter(id => id !== col.id));
+                                        return next;
+                                    });
+
+                                    let didPersist = false;
                                     try {
-                                        await onAddToCollection(image.id, col.id);
-                                    } catch (e) {
-                                        // Rollback if needed (though onAddToCollection is usually reliable)
-                                        setImageCollections(prev => wasIn ? [...prev, col.id] : prev.filter(id => id !== col.id));
+                                        didPersist = await onSetCollectionMembership(imageId, col.id, shouldBelong);
+                                    } catch {
+                                        didPersist = false;
                                     }
+
+                                    const settledMembership = didPersist ? shouldBelong : wasIn;
+                                    pendingMembershipKeysRef.current.delete(membershipKey);
+                                    setMembershipsByImage(prev => {
+                                        const memberships = prev.get(imageId) ?? [];
+                                        const next = new Map(retainRelevantMemberships(
+                                            prev,
+                                            activeImageIdRef.current,
+                                            pendingMembershipKeysRef.current
+                                        ));
+                                        if (
+                                            activeImageIdRef.current === imageId
+                                            || hasPendingMembershipForImage(pendingMembershipKeysRef.current, imageId)
+                                        ) {
+                                            next.set(imageId, settledMembership
+                                                ? (memberships.includes(col.id) ? memberships : [...memberships, col.id])
+                                                : memberships.filter(id => id !== col.id));
+                                        }
+                                        return next;
+                                    });
+
+                                    if (activeImageIdRef.current === imageId) {
+                                        membershipRequestIdRef.current += 1;
+                                        setMembershipLoadState({ imageId, status: 'ready' });
+                                    }
+
+                                    setPendingMembershipKeys(prev => {
+                                        const next = new Set(prev);
+                                        next.delete(membershipKey);
+                                        return next;
+                                    });
                                 }}
-                                className={`w-full text-left px-4 py-3 rounded-xl text-sm flex items-center justify-between border transition-all ${isIn ? 'bg-sage-100 dark:bg-sage-900/20 border-sage-300 dark:border-sage-500/40 text-sage-700 dark:text-sage-300' : 'bg-white dark:bg-zinc-800/50 border-gray-200 dark:border-white/5 text-gray-500 hover:bg-gray-50 dark:hover:bg-white/5'}`}
+                                className={`w-full text-left px-4 py-3 rounded-xl text-sm flex items-center justify-between border transition-all disabled:cursor-wait disabled:opacity-70 ${isIn ? 'bg-sage-100 dark:bg-sage-900/20 border-sage-300 dark:border-sage-500/40 text-sage-700 dark:text-sage-300' : 'bg-white dark:bg-zinc-800/50 border-gray-200 dark:border-white/5 text-gray-500 hover:bg-gray-50 dark:hover:bg-white/5'}`}
                             >
                                 <span className="truncate">{col.name}</span>
                                 {isIn ? <Check className="w-3.5 h-3.5 text-sage-500" /> : <Plus className="w-3.5 h-3.5" />}

--- a/src/features/viewer/components/metadata/__tests__/MetadataEditTab.test.tsx
+++ b/src/features/viewer/components/metadata/__tests__/MetadataEditTab.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AIImage, Collection, GeneratorTool } from '../../../../../types';
+import { createDefaultFilters } from '../../../../../utils/filterState';
 import { MetadataEditTab } from '../MetadataEditTab';
 
 const collectionRepoMocks = vi.hoisted(() => ({ getCollectionsForImage: vi.fn() }));
@@ -39,8 +40,9 @@ const collections: Collection[] = [
 
 interface HarnessProps {
     image?: AIImage;
+    collectionItems?: Collection[];
     availableTags?: string[];
-    onAddToCollection?: (imageId: string, collectionId: string) => void;
+    onSetCollectionMembership?: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     onUpdatePrompt?: (imageId: string, prompt: string) => void;
     onUpdateNegativePrompt?: (imageId: string, prompt: string) => void;
     onUpdateNotes?: (imageId: string, notes: string) => void;
@@ -48,8 +50,9 @@ interface HarnessProps {
 
 const EditorHarness = ({
     image = createImage(),
+    collectionItems = collections,
     availableTags = ['cat', 'castle', 'camera', 'candle', 'cape', 'canyon', 'dog'],
-    onAddToCollection = () => undefined,
+    onSetCollectionMembership = async () => true,
     onUpdatePrompt,
     onUpdateNegativePrompt,
     onUpdateNotes,
@@ -61,7 +64,7 @@ const EditorHarness = ({
     return (
         <MetadataEditTab
             image={image}
-            collections={collections}
+            collections={collectionItems}
             availableTags={availableTags}
             notes={notes}
             setNotes={setNotes}
@@ -69,7 +72,7 @@ const EditorHarness = ({
             setPromptValue={setPromptValue}
             negativePromptValue={negativePromptValue}
             setNegativePromptValue={setNegativePromptValue}
-            onAddToCollection={onAddToCollection}
+            onSetCollectionMembership={onSetCollectionMembership}
             onUpdatePrompt={onUpdatePrompt}
             onUpdateNegativePrompt={onUpdateNegativePrompt}
             onUpdateNotes={onUpdateNotes}
@@ -105,9 +108,9 @@ describe('MetadataEditTab', () => {
         }
     });
 
-    it('loads membership, filters collections, and toggles membership optimistically', async () => {
-        const onAddToCollection = vi.fn().mockResolvedValue(undefined);
-        const { container } = render(<EditorHarness onAddToCollection={onAddToCollection} />);
+    it('loads membership, filters collections, and persists the requested membership state', async () => {
+        const onSetCollectionMembership = vi.fn().mockResolvedValue(true);
+        const { container } = render(<EditorHarness onSetCollectionMembership={onSetCollectionMembership} />);
 
         expect(container.querySelector('.animate-spin')).toBeTruthy();
         await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).className).toContain('bg-sage-100'));
@@ -121,16 +124,32 @@ describe('MetadataEditTab', () => {
         fireEvent.change(search, { target: { value: '' } });
         fireEvent.click(screen.getByRole('button', { name: 'Portraits' }));
         expect(screen.getByRole('button', { name: 'Portraits' }).className).not.toContain('bg-sage-100');
-        expect(onAddToCollection).toHaveBeenCalledWith('image-1', 'one');
+        expect(screen.getByRole('button', { name: 'Portraits' }).getAttribute('aria-pressed')).toBe('false');
+        expect(onSetCollectionMembership).toHaveBeenCalledWith('image-1', 'one', false);
 
         fireEvent.click(screen.getByRole('button', { name: 'Landscapes' }));
         expect(screen.getByRole('button', { name: 'Landscapes' }).className).toContain('bg-sage-100');
-        expect(onAddToCollection).toHaveBeenCalledWith('image-1', 'two');
+        expect(screen.getByRole('button', { name: 'Landscapes' }).getAttribute('aria-pressed')).toBe('true');
+        expect(onSetCollectionMembership).toHaveBeenCalledWith('image-1', 'two', true);
     });
 
-    it('rolls collection membership back when persistence rejects', async () => {
-        const onAddToCollection = vi.fn().mockRejectedValue(new Error('write failed'));
-        render(<EditorHarness onAddToCollection={onAddToCollection} />);
+    it('does not offer smart collections as manual assignment targets', async () => {
+        const smartCollection: Collection = {
+            id: 'smart',
+            name: 'Favorite Images',
+            imageIds: [],
+            createdAt: 4,
+            filters: createDefaultFilters({ favoritesOnly: true })
+        };
+        render(<EditorHarness collectionItems={[...collections, smartCollection]} />);
+
+        await waitFor(() => expect((screen.getByRole('button', { name: 'Portraits' }) as HTMLButtonElement).disabled).toBe(false));
+        expect(screen.queryByRole('button', { name: 'Favorite Images' })).toBeNull();
+    });
+
+    it('rolls collection membership back when persistence reports failure', async () => {
+        const onSetCollectionMembership = vi.fn().mockResolvedValue(false);
+        render(<EditorHarness onSetCollectionMembership={onSetCollectionMembership} />);
         await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).className).toContain('bg-sage-100'));
 
         fireEvent.click(screen.getByRole('button', { name: 'Portraits' }));
@@ -140,12 +159,170 @@ describe('MetadataEditTab', () => {
         await waitFor(() => expect(screen.getByRole('button', { name: 'Landscapes' }).className).not.toContain('bg-sage-100'));
     });
 
+    it('rolls collection membership back when persistence rejects unexpectedly', async () => {
+        const onSetCollectionMembership = vi.fn().mockRejectedValue(new Error('write failed'));
+        render(<EditorHarness onSetCollectionMembership={onSetCollectionMembership} />);
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Landscapes' })).toBeTruthy());
+
+        fireEvent.click(screen.getByRole('button', { name: 'Landscapes' }));
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Landscapes' }).className).not.toContain('bg-sage-100'));
+    });
+
+    it('disables a pending membership row and ignores duplicate clicks', async () => {
+        const pending = deferred<boolean>();
+        const onSetCollectionMembership = vi.fn().mockReturnValue(pending.promise);
+        render(<EditorHarness onSetCollectionMembership={onSetCollectionMembership} />);
+        await waitFor(() => expect((screen.getByRole('button', { name: 'Landscapes' }) as HTMLButtonElement).disabled).toBe(false));
+
+        const landscapes = screen.getByRole('button', { name: 'Landscapes' });
+        fireEvent.click(landscapes);
+        expect((landscapes as HTMLButtonElement).disabled).toBe(true);
+        expect(landscapes.getAttribute('aria-busy')).toBe('true');
+        fireEvent.click(landscapes);
+        expect(onSetCollectionMembership).toHaveBeenCalledTimes(1);
+
+        await act(async () => pending.resolve(true));
+        await waitFor(() => expect((landscapes as HTMLButtonElement).disabled).toBe(false));
+    });
+
+    it('does not apply a late rollback to a different image', async () => {
+        const pending = deferred<boolean>();
+        const onSetCollectionMembership = vi.fn().mockReturnValue(pending.promise);
+        collectionRepoMocks.getCollectionsForImage
+            .mockResolvedValueOnce(['one'])
+            .mockResolvedValueOnce([]);
+        const { rerender } = render(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).className).toContain('bg-sage-100'));
+        fireEvent.click(screen.getByRole('button', { name: 'Portraits' }));
+
+        rerender(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-2')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(collectionRepoMocks.getCollectionsForImage).toHaveBeenCalledWith('image-2'));
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).className).not.toContain('bg-sage-100'));
+
+        await act(async () => pending.resolve(false));
+        expect(screen.getByRole('button', { name: 'Portraits' }).className).not.toContain('bg-sage-100');
+    });
+
+    it('preserves a successful membership change across navigation and a stale refetch', async () => {
+        const pendingMembership = deferred<boolean>();
+        const staleRefetch = deferred<string[]>();
+        const onSetCollectionMembership = vi.fn().mockReturnValue(pendingMembership.promise);
+        collectionRepoMocks.getCollectionsForImage
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([])
+            .mockReturnValueOnce(staleRefetch.promise);
+        const { rerender } = render(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect((screen.getByRole('button', { name: 'Landscapes' }) as HTMLButtonElement).disabled).toBe(false));
+        fireEvent.click(screen.getByRole('button', { name: 'Landscapes' }));
+
+        rerender(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-2')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(collectionRepoMocks.getCollectionsForImage).toHaveBeenCalledWith('image-2'));
+        rerender(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(collectionRepoMocks.getCollectionsForImage).toHaveBeenCalledTimes(3));
+        expect(screen.getByRole('button', { name: 'Landscapes' }).className).toContain('bg-sage-100');
+
+        await act(async () => pendingMembership.resolve(true));
+        expect(screen.getByRole('button', { name: 'Landscapes' }).className).toContain('bg-sage-100');
+
+        await act(async () => staleRefetch.resolve([]));
+        expect(screen.getByRole('button', { name: 'Landscapes' }).className).toContain('bg-sage-100');
+    });
+
+    it('merges opposite membership outcomes by row across navigation', async () => {
+        const failedAdd = deferred<boolean>();
+        const successfulRemoval = deferred<boolean>();
+        const staleRefetch = deferred<string[]>();
+        const onSetCollectionMembership = vi.fn((_: string, collectionId: string) => (
+            collectionId === 'two' ? failedAdd.promise : successfulRemoval.promise
+        ));
+        collectionRepoMocks.getCollectionsForImage
+            .mockResolvedValueOnce(['one'])
+            .mockResolvedValueOnce([])
+            .mockReturnValueOnce(staleRefetch.promise);
+        const { rerender } = render(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).className).toContain('bg-sage-100'));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Landscapes' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Portraits' }));
+        rerender(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-2')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(collectionRepoMocks.getCollectionsForImage).toHaveBeenCalledWith('image-2'));
+        await act(async () => failedAdd.resolve(false));
+
+        rerender(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} onSetCollectionMembership={onSetCollectionMembership} />,
+        );
+        await waitFor(() => expect(collectionRepoMocks.getCollectionsForImage).toHaveBeenCalledTimes(3));
+        await act(async () => successfulRemoval.resolve(true));
+        await act(async () => staleRefetch.resolve(['one']));
+
+        expect(screen.getByRole('button', { name: 'Portraits' }).getAttribute('aria-pressed')).toBe('false');
+        expect(screen.getByRole('button', { name: 'Landscapes' }).getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('evicts inactive membership snapshots while retaining only active or pending images', async () => {
+        const reloadedMembership = deferred<string[]>();
+        collectionRepoMocks.getCollectionsForImage
+            .mockResolvedValueOnce(['one'])
+            .mockResolvedValueOnce([])
+            .mockReturnValueOnce(reloadedMembership.promise);
+        const { rerender } = render(
+            <EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} />,
+        );
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).getAttribute('aria-pressed')).toBe('true'));
+
+        rerender(<EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-2')} />);
+        await waitFor(() => expect((screen.getByRole('button', { name: 'Portraits' }) as HTMLButtonElement).disabled).toBe(false));
+        rerender(<EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} />);
+
+        expect(screen.getByRole('button', { name: 'Portraits' }).getAttribute('aria-pressed')).toBe('false');
+        await act(async () => reloadedMembership.resolve(['one']));
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).getAttribute('aria-pressed')).toBe('true'));
+    });
+
+    it('shows a retryable error when membership loading fails after navigation', async () => {
+        const rejectedMembership = deferred<string[]>();
+        collectionRepoMocks.getCollectionsForImage
+            .mockResolvedValueOnce(['one'])
+            .mockReturnValueOnce(rejectedMembership.promise)
+            .mockResolvedValueOnce([]);
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const { rerender } = render(<EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-1')} />);
+        await waitFor(() => expect(screen.getByRole('button', { name: 'Portraits' }).className).toContain('bg-sage-100'));
+
+        rerender(<EditorHarness image={createImage(GeneratorTool.AUTOMATIC1111, 'image-2')} />);
+        await act(async () => rejectedMembership.reject(new Error('read failed')));
+
+        expect(screen.getByRole('alert').textContent).toContain('Could not load collection membership.');
+        expect((screen.getByRole('button', { name: 'Portraits' }) as HTMLButtonElement).disabled).toBe(true);
+        expect(document.querySelector('.animate-spin')).toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+        await waitFor(() => expect((screen.getByRole('button', { name: 'Portraits' }) as HTMLButtonElement).disabled).toBe(false));
+        expect(collectionRepoMocks.getCollectionsForImage).toHaveBeenLastCalledWith('image-2');
+        consoleError.mockRestore();
+    });
+
     it('handles membership fetch failures and ignores completion after unmount', async () => {
         const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
         collectionRepoMocks.getCollectionsForImage.mockRejectedValueOnce(new Error('read failed'));
         const first = render(<EditorHarness />);
         await waitFor(() => expect(consoleError).toHaveBeenCalledWith('Failed to fetch image collections', expect.any(Error)));
         expect(first.container.querySelector('.animate-spin')).toBeNull();
+        expect(screen.getByRole('alert').textContent).toContain('Could not load collection membership.');
         first.unmount();
 
         const pending = deferred<string[]>();

--- a/src/hooks/__tests__/useCollectionOperations.test.tsx
+++ b/src/hooks/__tests__/useCollectionOperations.test.tsx
@@ -40,6 +40,16 @@ vi.mock('../../services/db/collectionRepo', () => ({
     setCollectionCustomThumbnail: vi.fn(),
 }));
 
+const deferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+};
+
 describe('useCollectionOperations', () => {
     const mockSetAllCollections = vi.fn();
     const mockRefreshCollections = vi.fn();
@@ -266,11 +276,13 @@ describe('useCollectionOperations', () => {
         it('should increment count optimistically', async () => {
             const { addImagesToCollection: addImgs } = await import('../../services/db/collectionRepo');
             const { result } = renderHook(() => useCollectionOperations(props));
+            let didPersist = false;
 
             await act(async () => {
-                await result.current.addImagesToCollection(['img2'], 'col1');
+                didPersist = await result.current.addImagesToCollection(['img2'], 'col1');
             });
 
+            expect(didPersist).toBe(true);
             const updater = mockSetAllCollections.mock.calls[0][0];
             const nextState = updater(mockCollections);
             expect(nextState[0].count).toBe(6); // 5 + 1
@@ -290,6 +302,7 @@ describe('useCollectionOperations', () => {
         });
 
         it('refreshes targeted smart summaries after adding images to a smart collection', async () => {
+            const { upsertCollection } = await import('../../services/db/collectionRepo');
             const smartCollection: SmartCollection = {
                 id: 'smart1',
                 name: 'Smart Collection',
@@ -310,6 +323,7 @@ describe('useCollectionOperations', () => {
             });
 
             expect(mockRefreshCollectionThumbnails).not.toHaveBeenCalled();
+            expect(upsertCollection).not.toHaveBeenCalled();
             expect(mockRefreshSmartCounts).toHaveBeenCalledTimes(1);
             expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
                 collectionIds: ['smart1'],
@@ -318,6 +332,7 @@ describe('useCollectionOperations', () => {
                 markPending: true
             });
         });
+
     });
 
     describe('removeImagesFromCollection', () => {
@@ -339,11 +354,13 @@ describe('useCollectionOperations', () => {
                 smartCollections: [smartCollection],
                 activeCollectionId: 'smart1'
             }));
+            let didPersist = false;
 
             await act(async () => {
-                await result.current.removeImagesFromCollection(['img1'], 'smart1');
+                didPersist = await result.current.removeImagesFromCollection(['img1'], 'smart1');
             });
 
+            expect(didPersist).toBe(true);
             const imageUpdater = mockSetImages.mock.calls[0][0] as (images: AIImage[]) => AIImage[];
             expect(imageUpdater([makeImage({ id: 'img1' }), makeImage({ id: 'img2' })]).map(image => image.id)).toEqual(['img2']);
             expect(vi.mocked(upsertCollection).mock.calls[0][0]).toEqual(expect.objectContaining({
@@ -352,17 +369,52 @@ describe('useCollectionOperations', () => {
             expect(removeImagesFromCollection).toHaveBeenCalledWith('smart1', ['img1']);
         });
 
-        it('rolls back optimistic removal when the DB update fails', async () => {
+        it('keeps active collection images visible when the DB update fails', async () => {
             const { removeImagesFromCollection } = await import('../../services/db/collectionRepo');
             vi.mocked(removeImagesFromCollection).mockRejectedValueOnce(new Error('remove failed'));
-            const { result } = renderHook(() => useCollectionOperations(props));
+            const { result } = renderHook(() => useCollectionOperations({
+                ...props,
+                activeCollectionId: 'col1'
+            }));
+            let didPersist = true;
 
             await act(async () => {
-                await result.current.removeImagesFromCollection(['img1'], 'col1');
+                didPersist = await result.current.removeImagesFromCollection(['img1'], 'col1');
             });
 
+            expect(didPersist).toBe(false);
             expect(mockSetAllCollections).toHaveBeenCalledTimes(2);
+            expect(mockSetImages).not.toHaveBeenCalled();
+            expect(dispatchedImages.map(image => image.id)).toEqual(['img1', 'img2']);
             expect(mockAddToast).toHaveBeenCalledWith('Failed to remove from collection', 'error');
+        });
+
+        it('reconciles the active viewer immediately after persistence without waiting for refresh', async () => {
+            const pendingRefresh = deferred<void>();
+            mockRefreshCollections.mockReturnValueOnce(pendingRefresh.promise);
+            const onPersisted = vi.fn();
+            const { result } = renderHook(() => useCollectionOperations({
+                ...props,
+                activeCollectionId: 'col1'
+            }));
+            let removal!: Promise<boolean>;
+            let settled = false;
+
+            await act(async () => {
+                removal = result.current.removeImagesFromCollection(['img1'], 'col1', onPersisted);
+                void removal.then(() => { settled = true; });
+                await Promise.resolve();
+                await Promise.resolve();
+            });
+
+            expect(onPersisted).toHaveBeenCalledTimes(1);
+            expect(dispatchedImages.map(image => image.id)).toEqual(['img2']);
+            expect(settled).toBe(false);
+
+            await act(async () => {
+                pendingRefresh.resolve();
+                expect(await removal).toBe(true);
+            });
         });
 
         it('refreshes targeted smart summaries after removing images from a smart collection', async () => {
@@ -394,6 +446,36 @@ describe('useCollectionOperations', () => {
                 markPending: true
             });
         });
+    });
+
+    it('serializes same-collection add and remove mutations so a late failure cannot stale-rollback a success', async () => {
+        const { addImagesToCollection, removeImagesFromCollection } = await import('../../services/db/collectionRepo');
+        const pendingAdd = deferred<void>();
+        vi.mocked(addImagesToCollection).mockReturnValueOnce(pendingAdd.promise);
+        const { result } = renderHook(() => useCollectionOperations(props));
+        let addResult: Promise<boolean>;
+        let removeResult: Promise<boolean>;
+
+        await act(async () => {
+            addResult = result.current.addImagesToCollection(['img2'], 'col1');
+            await Promise.resolve();
+        });
+        await act(async () => {
+            removeResult = result.current.removeImagesFromCollection(['img1'], 'col1');
+            await Promise.resolve();
+        });
+
+        expect(removeImagesFromCollection).not.toHaveBeenCalled();
+        expect(dispatchedCollections[0].count).toBe(6);
+
+        await act(async () => {
+            pendingAdd.reject(new Error('add failed'));
+            expect(await addResult).toBe(false);
+            expect(await removeResult).toBe(true);
+        });
+
+        expect(removeImagesFromCollection).toHaveBeenCalledWith('col1', ['img1']);
+        expect(dispatchedCollections[0].count).toBe(4);
     });
 
     describe('moveImagesBetweenCollections', () => {
@@ -642,6 +724,8 @@ describe('useCollectionOperations', () => {
 
     it('no-ops every collection mutation when its collection is missing', async () => {
         const { result } = renderHook(() => useCollectionOperations(props));
+        let addResult = true;
+        let removeResult = true;
         await act(async () => {
             await result.current.updateCollectionFilters('missing', smartFilters);
             await result.current.deleteCollection('missing');
@@ -649,11 +733,13 @@ describe('useCollectionOperations', () => {
             await result.current.setCollectionColor('missing', 'red');
             await result.current.toggleArchiveCollection('missing');
             await result.current.togglePinCollection('missing');
-            await result.current.addImagesToCollection(['img1'], 'missing');
-            await result.current.removeImagesFromCollection(['img1'], 'missing');
+            addResult = await result.current.addImagesToCollection(['img1'], 'missing');
+            removeResult = await result.current.removeImagesFromCollection(['img1'], 'missing');
             await result.current.moveImagesBetweenCollections(['img1'], 'missing', 'col1');
             await result.current.moveImagesBetweenCollections(['img1'], 'col1', 'missing');
         });
+        expect(addResult).toBe(false);
+        expect(removeResult).toBe(false);
         expect(mockSetAllCollections).not.toHaveBeenCalled();
     });
 
@@ -730,9 +816,35 @@ describe('useCollectionOperations', () => {
         const extra = { id: 'extra', name: 'Extra', createdAt: 2, source: 'ambit' as const, count: 0, imageIds: [] };
         dispatchedCollections = [zero, extra];
         const { result } = renderHook(() => useCollectionOperations({ ...props, collections: [zero, extra] }));
-        await act(async () => result.current.addImagesToCollection(['img'], 'col1'));
+        let didPersist = true;
+        await act(async () => {
+            didPersist = await result.current.addImagesToCollection(['img'], 'col1');
+        });
+        expect(didPersist).toBe(false);
         expect(dispatchedCollections).toEqual([zero, extra]);
         expect(mockAddToast).toHaveBeenCalledWith('Failed to add to collection', 'error');
+    });
+
+    it('keeps successful membership results when post-write refresh fails', async () => {
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const { result } = renderHook(() => useCollectionOperations(props));
+        let addResult = false;
+        let removeResult = false;
+
+        mockRefreshCollections.mockRejectedValueOnce(new Error('add refresh failed'));
+        await act(async () => {
+            addResult = await result.current.addImagesToCollection(['img'], 'col1');
+        });
+        mockRefreshCollections.mockRejectedValueOnce(new Error('remove refresh failed'));
+        await act(async () => {
+            removeResult = await result.current.removeImagesFromCollection(['img'], 'col1');
+        });
+
+        expect(addResult).toBe(true);
+        expect(removeResult).toBe(true);
+        expect(errorSpy).toHaveBeenCalledWith('[Collections] Failed to refresh after adding images', expect.any(Error));
+        expect(errorSpy).toHaveBeenCalledWith('[Collections] Failed to refresh after removing images', expect.any(Error));
+        errorSpy.mockRestore();
     });
 
     it('updates non-self filters and rolls them back alongside unrelated collections', async () => {

--- a/src/hooks/useCollectionOperations.ts
+++ b/src/hooks/useCollectionOperations.ts
@@ -38,6 +38,25 @@ export const useCollectionOperations = ({
   const maskedKeywords = useSettingsStore(s => s.settings.maskedKeywords);
   const refreshCollectionThumbnails = useCollectionStore(s => s.refreshCollectionThumbnails);
   const refreshSmartCounts = useCollectionStore(s => s.refreshSmartCounts);
+  const activeCollectionIdRef = React.useRef(activeCollectionId);
+  const membershipMutationTailsRef = React.useRef(new Map<string, Promise<void>>());
+  activeCollectionIdRef.current = activeCollectionId;
+
+  const serializeCollectionMembershipMutation = useCallback(<T,>(
+    collectionId: string,
+    mutation: () => Promise<T>
+  ): Promise<T> => {
+    const previous = membershipMutationTailsRef.current.get(collectionId) ?? Promise.resolve();
+    const result = previous.then(mutation);
+    const tail = result.then(() => undefined, () => undefined);
+    membershipMutationTailsRef.current.set(collectionId, tail);
+    void tail.then(() => {
+      if (membershipMutationTailsRef.current.get(collectionId) === tail) {
+        membershipMutationTailsRef.current.delete(collectionId);
+      }
+    });
+    return result;
+  }, []);
 
   const refreshAffectedCollectionThumbnails = useCallback((affectedCollections: Collection[]) => {
     const hasStaticCollection = affectedCollections.some(collection => !collection.filters);
@@ -222,67 +241,101 @@ export const useCollectionOperations = ({
     }
   }, [collections, smartCollections, setAllCollections, refreshCollections]);
 
-  const addImagesToCollection = useCallback(async (imageIds: string[], collectionId: string) => {
+  const addImagesToCollection = useCallback(async (imageIds: string[], collectionId: string): Promise<boolean> => {
     const col = [...collections, ...smartCollections].find(c => c.id === collectionId);
-    if (!col) return;
+    if (!col) return false;
 
-    // Optimistic Update: Increment count
-    setAllCollections(prev => prev.map(c =>
-      c.id === collectionId ? { ...c, count: (c.count || 0) + imageIds.length } : c
-    ));
+    return serializeCollectionMembershipMutation(collectionId, async () => {
+      let collectionBeforeMutation = col;
 
-    try {
-      await addImgsToCol(collectionId, imageIds);
-      addToast(`Added images to collection`, 'success');
-      // Background refresh for safety and smart collection updates
-      await Promise.all([
-        refreshCollections(),
-        queryClient.invalidateQueries({ queryKey: ['images'] })
-      ]);
-      refreshAffectedCollectionThumbnails([col]);
-    } catch (e) {
-      // Rollback
-      setAllCollections(prev => prev.map(c => c.id === collectionId ? col : c));
-      addToast("Failed to add to collection", "error");
-    }
-  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast]);
+      // Optimistic Update: Increment count
+      setAllCollections(prev => prev.map(c => {
+        if (c.id !== collectionId) return c;
+        collectionBeforeMutation = c;
+        return { ...c, count: (c.count || 0) + imageIds.length };
+      }));
 
-  const removeImagesFromCollection = useCallback(async (imageIds: string[], collectionId: string) => {
-    const col = [...collections, ...smartCollections].find(c => c.id === collectionId);
-    if (!col) return;
-
-    // Optimistic Update: Decrement count
-    setAllCollections(prev => prev.map(c =>
-      c.id === collectionId ? { ...c, count: Math.max(0, (c.count || 0) - imageIds.length) } : c
-    ));
-
-    // Optimistic Grid Removal: Remove from current view if we are looking at this collection
-    if (activeCollectionId === collectionId) {
-      setImages(prev => prev.filter(img => !imageIds.includes(img.id)));
-    }
-
-    try {
-      // Handle Manual Exclusions for Hybrid Smart Collections
-      if (col.filters) {
-        const currentExclusions = col.manualExclusions || [];
-        const newExclusions = [...new Set([...currentExclusions, ...imageIds])];
-        await upsertCollection({ ...col, manualExclusions: newExclusions });
+      try {
+        await addImgsToCol(collectionId, imageIds);
+      } catch (e) {
+        // Rollback to the state at the start of this serialized mutation.
+        setAllCollections(prev => prev.map(c => c.id === collectionId ? collectionBeforeMutation : c));
+        addToast("Failed to add to collection", "error");
+        return false;
       }
 
-      // Always attempt removal from junction table (handles manual additions)
-      await removeImgsFromCol(collectionId, imageIds);
+      addToast(`Added images to collection`, 'success');
+      try {
+        await Promise.all([
+          refreshCollections(),
+          queryClient.invalidateQueries({ queryKey: ['images'] })
+        ]);
+      } catch (e) {
+        console.error("[Collections] Failed to refresh after adding images", e);
+      }
+
+      refreshAffectedCollectionThumbnails([collectionBeforeMutation]);
+      return true;
+    });
+  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast, serializeCollectionMembershipMutation]);
+
+  const removeImagesFromCollection = useCallback(async (
+    imageIds: string[],
+    collectionId: string,
+    onPersisted?: () => void
+  ): Promise<boolean> => {
+    const col = [...collections, ...smartCollections].find(c => c.id === collectionId);
+    if (!col) return false;
+
+    return serializeCollectionMembershipMutation(collectionId, async () => {
+      let collectionBeforeMutation = col;
+
+      // Optimistic Update: Decrement count
+      setAllCollections(prev => prev.map(c => {
+        if (c.id !== collectionId) return c;
+        collectionBeforeMutation = c;
+        return { ...c, count: Math.max(0, (c.count || 0) - imageIds.length) };
+      }));
+
+      try {
+        // Handle Manual Exclusions for Hybrid Smart Collections
+        if (collectionBeforeMutation.filters) {
+          const currentExclusions = collectionBeforeMutation.manualExclusions || [];
+          const newExclusions = [...new Set([...currentExclusions, ...imageIds])];
+          await upsertCollection({ ...collectionBeforeMutation, manualExclusions: newExclusions });
+        }
+
+        // Always attempt removal from junction table (handles manual additions)
+        await removeImgsFromCol(collectionId, imageIds);
+      } catch (e) {
+        // Rollback to the state at the start of this serialized mutation.
+        setAllCollections(prev => prev.map(c => c.id === collectionId ? collectionBeforeMutation : c));
+        addToast("Failed to remove from collection", "error");
+        return false;
+      }
+
+      onPersisted?.();
+
+      // Keep the active grid stable until persistence succeeds so a failed viewer
+      // edit cannot close or advance away from an image that still belongs here.
+      if (activeCollectionIdRef.current === collectionId) {
+        setImages(prev => prev.filter(img => !imageIds.includes(img.id)));
+      }
+
       addToast("Removed from collection", "info");
-      await Promise.all([
-        refreshCollections(),
-        queryClient.invalidateQueries({ queryKey: ['images'] })
-      ]);
-      refreshAffectedCollectionThumbnails([col]);
-    } catch (e) {
-      // Rollback
-      setAllCollections(prev => prev.map(c => c.id === collectionId ? col : c));
-      addToast("Failed to remove from collection", "error");
-    }
-  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast]);
+      try {
+        await Promise.all([
+          refreshCollections(),
+          queryClient.invalidateQueries({ queryKey: ['images'] })
+        ]);
+      } catch (e) {
+        console.error("[Collections] Failed to refresh after removing images", e);
+      }
+
+      refreshAffectedCollectionThumbnails([collectionBeforeMutation]);
+      return true;
+    });
+  }, [collections, smartCollections, setAllCollections, refreshCollections, refreshAffectedCollectionThumbnails, addToast, setImages, serializeCollectionMembershipMutation]);
 
   // Deprecated/Aliased for backward compat
   const saveSmartCollection = useCallback(async (name: string, filters: FilterState) => {

--- a/src/services/db/__tests__/collectionRepo.test.ts
+++ b/src/services/db/__tests__/collectionRepo.test.ts
@@ -995,7 +995,7 @@ describe('collectionRepo membership helpers', () => {
         errorSpy.mockRestore();
     });
 
-    it('returns collection memberships and falls back safely when membership queries fail', async () => {
+    it('returns collection memberships and propagates failures so callers do not treat them as empty membership', async () => {
         dbMocks.select.mockResolvedValueOnce([{ collection_id: 'c1' }, { collection_id: 'c2' }]);
 
         const { getCollectionsForImage, getCollectionImageIds } = await import('../collectionRepo');
@@ -1006,7 +1006,7 @@ describe('collectionRepo membership helpers', () => {
         await expect(getCollectionImageIds('c1')).resolves.toEqual(['img-1', 'img-2']);
 
         dbMocks.select.mockRejectedValueOnce(new Error('sqlite busy'));
-        await expect(getCollectionsForImage('img-1')).resolves.toEqual([]);
+        await expect(getCollectionsForImage('img-1')).rejects.toThrow('sqlite busy');
     });
 
     it('falls back to no image ids when collection image lookup fails', async () => {

--- a/src/services/db/collectionRepo.ts
+++ b/src/services/db/collectionRepo.ts
@@ -900,16 +900,11 @@ export const getCollectionsForImage = async (imageId: string): Promise<string[]>
     }
 
     const db = await getDb();
-    try {
-        const res = await db.select<{ collection_id: string }[]>(
-            'SELECT collection_id FROM collection_images WHERE image_id = ?',
-            [imageId]
-        );
-        return res.map(r => r.collection_id);
-    } catch (e) {
-        console.error('[DB] Failed to get collections for image', e);
-        return [];
-    }
+    const res = await db.select<{ collection_id: string }[]>(
+        'SELECT collection_id FROM collection_images WHERE image_id = ?',
+        [imageId]
+    );
+    return res.map(r => r.collection_id);
 };
 
 /**


### PR DESCRIPTION
## What changed

- make collection rows in the image viewer edit sidebar toggle membership directly without opening the collection modal
- add retryable membership loading and row-scoped pending/error state
- serialize same-collection mutations and propagate persistence failures correctly
- keep Maintenance membership edits separate from global viewer navigation
- reconcile the active viewer immediately and safely when its image is removed from the current collection
- bound cached membership snapshots while preserving pending cross-image edits

## Why

The sidebar row click combined two different interactions: it changed collection membership and also opened the bulk collection modal. The surrounding async flow also allowed failed or overlapping writes to leave optimistic state, viewer selection, or cached memberships inconsistent.

## Impact

Users can now add or remove the viewed image from collections in place. Successful edits remain responsive, failures stay retryable, and removing an image from the active collection advances or closes the viewer consistently.

## Validation

- 174 affected frontend tests passed
- TypeScript check passed
- ESLint passed
- `git diff --check` passed
- final independent full-diff review returned clean