### PR TITLE
feat: improve navbar search navigation

### DIFF
--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -6,7 +6,7 @@ Ambit combines search text, metadata filters, asset facets, date ranges, favorit
 
 ## Search Bar
 
-The search bar matches the positive prompt by default. Type plain words to find prompt text; Ambit updates after typing pauses, and pressing Enter applies the current search immediately.
+The search bar matches the positive prompt by default. In Grid and Timeline, Ambit updates after typing pauses, and pressing Enter applies the current search immediately. In Statistics and Maintenance, typing stays in the search field until you press Enter or choose a recent search; Ambit then opens Grid to show the matching images.
 
 Search bar tools include:
 
@@ -18,8 +18,10 @@ Search bar tools include:
 - Clear search to remove the current search text
 - Clear in Recent Searches to remove the recent-search list
 - an ISO-date readiness hint when a date operator is incomplete or invalid
+- current scope and match feedback while the field is focused
+- Search syntax to open the in-app operator reference directly
 
-When AI Search is enabled from the search bar, the placeholder changes to an assistant-style prompt. Network and AI behavior depends on your settings; see [Settings And Privacy](settings-and-privacy.md).
+When AI Search is enabled from the search bar, the placeholder changes to an assistant-style prompt. AI Search waits for Enter instead of applying the natural-language draft as an ordinary prompt search. It keeps the existing filters until analysis succeeds, then applies the generated filters. Network and AI behavior depends on your settings; see [Settings And Privacy](settings-and-privacy.md).
 
 Examples:
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,6 +9,7 @@ import App from './App';
 import { settingsPersistenceCoordinator } from './utils/settingsPersistenceCoordinator';
 
 type AppLayoutProbe = {
+    viewMode: ViewMode;
     changeViewMode: (mode: ViewMode) => void;
     setLayoutMode: (mode: LayoutMode) => void;
     handleLayoutChange: (columns: number, rowHeight: number) => void;
@@ -23,6 +24,8 @@ type AppLayoutProbe = {
     searchProps: {
         onFocus: () => void;
         onBlur: () => void;
+        submitSearch: (query: string) => void;
+        onOpenSearchHelp: () => void;
     };
     scopeName: string;
     scopeTotal: number;
@@ -611,6 +614,37 @@ describe('App orchestration', () => {
         requireProbe(captured.contextMenu, 'AppContextMenu').onMoveToCollection();
         expect(mocks.modals.setSourceCollectionId).toHaveBeenCalledWith('collection-a');
         requireProbe(captured.contextMenu, 'AppContextMenu').onClose();
+    });
+
+    it('routes committed navbar searches by view and opens syntax help', () => {
+        render(<App />);
+
+        let layout = requireProbe(captured.appLayout, 'AppLayout');
+        expect(layout.viewMode).toBe('grid');
+        act(() => layout.searchProps.submitSearch('grid query'));
+        expect(mocks.submitSearch).toHaveBeenLastCalledWith('grid query');
+        expect(requireProbe(captured.appLayout, 'AppLayout').viewMode).toBe('grid');
+
+        act(() => requireProbe(captured.appLayout, 'AppLayout').changeViewMode('timeline'));
+        layout = requireProbe(captured.appLayout, 'AppLayout');
+        act(() => layout.searchProps.submitSearch('timeline query'));
+        expect(requireProbe(captured.appLayout, 'AppLayout').viewMode).toBe('timeline');
+
+        act(() => requireProbe(captured.appLayout, 'AppLayout').changeViewMode('dashboard'));
+        layout = requireProbe(captured.appLayout, 'AppLayout');
+        act(() => layout.searchProps.submitSearch('dashboard query'));
+        expect(requireProbe(captured.appLayout, 'AppLayout').viewMode).toBe('grid');
+
+        act(() => requireProbe(captured.appLayout, 'AppLayout').changeViewMode('maintenance'));
+        layout = requireProbe(captured.appLayout, 'AppLayout');
+        act(() => layout.searchProps.submitSearch('   '));
+        expect(requireProbe(captured.appLayout, 'AppLayout').viewMode).toBe('maintenance');
+        act(() => requireProbe(captured.appLayout, 'AppLayout').searchProps.submitSearch('maintenance query'));
+        expect(requireProbe(captured.appLayout, 'AppLayout').viewMode).toBe('grid');
+
+        act(() => requireProbe(captured.appLayout, 'AppLayout').searchProps.onOpenSearchHelp());
+        expect(mocks.modals.setShortcutsModalTab).toHaveBeenCalledWith('search');
+        expect(mocks.modals.openModal).toHaveBeenCalledWith('shortcuts');
     });
 
     it('completes onboarding and handles browser and native import paths', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -333,6 +333,22 @@ export default function App() {
                 collectionId,
                 () => reconcileGlobalViewerAfterRemoval(imageId, collectionId)
             ), [colOps, reconcileGlobalViewerAfterRemoval]);
+    const submitNavbarSearch = useCallback((query: string) => {
+        if (!query.trim()) {
+            void submitSearch(query);
+            return;
+        }
+
+        void submitSearch(query);
+        if (viewMode === 'dashboard' || viewMode === 'maintenance') {
+            changeViewMode('grid');
+        }
+    }, [changeViewMode, submitSearch, viewMode]);
+
+    const openSearchHelp = useCallback(() => {
+        modals.setShortcutsModalTab('search');
+        modals.openModal('shortcuts');
+    }, [modals]);
 
     // --- Derived Memos ---
     const searchProps = React.useMemo(() => ({
@@ -340,11 +356,12 @@ export default function App() {
         isSearchingAi,
         inputRef,
         toggleAiSearch,
-        submitSearch,
+        submitSearch: submitNavbarSearch,
         isFocused: isSearchFocused,
         onFocus: () => setIsSearchFocused(true),
-        onBlur: () => setTimeout(() => setIsSearchFocused(false), 200)
-    }), [isAiSearchEnabled, isSearchingAi, inputRef, toggleAiSearch, submitSearch, isSearchFocused]);
+        onBlur: () => setIsSearchFocused(false),
+        onOpenSearchHelp: openSearchHelp,
+    }), [isAiSearchEnabled, isSearchingAi, inputRef, isSearchFocused, openSearchHelp, submitNavbarSearch, toggleAiSearch]);
 
     const activeCollection = filters.collectionId ? collections.find(c => c.id === filters.collectionId) : null;
     const activeSmartCollection = !activeCollection && filters.collectionId ? smartCollections.find(c => c.id === filters.collectionId) : null;

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -322,7 +322,15 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
             <main className="flex-1 flex flex-col min-w-0 bg-white dark:bg-zinc-900/95 backdrop-blur-xl rounded-2xl shadow-2xl shadow-black/20 border border-zinc-200 dark:border-white/10 overflow-hidden relative">
                 <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_50%_0%,rgba(139,174,124,0.08),transparent_70%)] dark:bg-[radial-gradient(circle_at_50%_0%,rgba(139,174,124,0.15),transparent_60%)] z-10" />
 
-                {isSearchFocused && <div className="absolute inset-0 z-40 bg-black/60 backdrop-blur-sm animate-in fade-in duration-300" onClick={() => setIsSearchFocused(false)} />}
+                {isSearchFocused && (
+                    <div
+                        className="absolute inset-0 z-40 bg-black/60 backdrop-blur-sm animate-in fade-in duration-300"
+                        onClick={() => {
+                            searchProps.inputRef.current?.blur();
+                            setIsSearchFocused(false);
+                        }}
+                    />
+                )}
 
                 <AppHeader
                     viewMode={viewMode}

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -154,7 +154,7 @@ describe('AppLayout', () => {
         addToast: vi.fn(),
         viewMode: 'grid',
         changeViewMode: vi.fn(),
-        searchProps: {} as any,
+        searchProps: { inputRef: { current: null } } as any,
         layoutMode: 'masonry',
         setLayoutMode: vi.fn(),
         sortOption: 'date-desc',
@@ -353,13 +353,20 @@ describe('AppLayout', () => {
 
     it('dismisses the search-focus overlay', () => {
         const setIsSearchFocused = vi.fn();
+        const blur = vi.fn();
         const { container } = render(
-            <AppLayout {...defaultProps} isSearchFocused setIsSearchFocused={setIsSearchFocused} />
+            <AppLayout
+                {...defaultProps}
+                isSearchFocused
+                setIsSearchFocused={setIsSearchFocused}
+                searchProps={{ inputRef: { current: { blur } } } as any}
+            />
         );
 
         const overlay = container.querySelector('.bg-black\\/60');
         expect(overlay).toBeTruthy();
         fireEvent.click(overlay as Element);
+        expect(blur).toHaveBeenCalledOnce();
         expect(setIsSearchFocused).toHaveBeenCalledWith(false);
     });
 

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -23,6 +23,7 @@ interface AppHeaderProps {
         isFocused: boolean;
         onFocus: () => void;
         onBlur: () => void;
+        onOpenSearchHelp: () => void;
     };
     layoutMode: LayoutMode;
     setLayoutMode: (mode: LayoutMode) => void;
@@ -126,6 +127,10 @@ export const AppHeader = React.memo(({
                         searchProps={searchProps}
                         recentSearches={recentSearches}
                         setRecentSearches={setRecentSearches}
+                        scopeName={scopeName}
+                        displayedCount={displayedCount}
+                        isFiltering={isFiltering ?? false}
+                        submitNavigatesToGrid={viewMode === 'dashboard' || viewMode === 'maintenance'}
                     />
                     {browserMockMode && (
                         <span className="shrink-0 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] font-semibold text-amber-700 dark:text-amber-300">

--- a/src/components/ui/ShortcutsModal.tsx
+++ b/src/components/ui/ShortcutsModal.tsx
@@ -1,14 +1,26 @@
 import * as React from 'react';
 import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Keyboard, Command, Search, ChevronDown, ChevronRight, Monitor, Hash, Puzzle, Sliders, Calendar } from 'lucide-react';
+import { X, Keyboard, Search, ChevronDown, ChevronRight, Monitor, Puzzle, Sliders, Calendar } from 'lucide-react';
 import { APP_NAME } from '../../constants/app';
+import { SEARCH_OPERATOR_DEFINITIONS, type SearchOperatorCategory } from '../../constants/searchOperators';
 
 interface ShortcutsModalProps {
     isOpen: boolean;
     onClose: () => void;
     initialTab?: 'shortcuts' | 'search';
 }
+
+const getSearchOperatorIcon = (category: SearchOperatorCategory) => {
+    const className = 'w-3 h-3';
+    switch (category) {
+        case 'content': return <Search className={className} />;
+        case 'resource': return <Puzzle className={className} />;
+        case 'parameter': return <Sliders className={className} />;
+        case 'date': return <Calendar className={className} />;
+        case 'dimension': return <Monitor className={className} />;
+    }
+};
 
 export const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose, initialTab = 'shortcuts' }) => {
     const [activeTab, setActiveTab] = useState<'shortcuts' | 'search'>(initialTab);
@@ -108,37 +120,6 @@ export const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose,
         }
     ];
 
-    const searchOperators = [
-        // Content Search
-        { op: 'sunset', desc: 'Search positive prompt (default)', icon: <Search className="w-3 h-3" /> },
-        { op: 'forest OR ocean', desc: 'Match either prompt term', icon: <Search className="w-3 h-3" /> },
-        { op: 'neg:blur', desc: 'Search negative prompt', icon: <Hash className="w-3 h-3" /> },
-        { op: 'file:portrait', desc: 'Search filename/path', icon: <Hash className="w-3 h-3" /> },
-        { op: 'all:anime', desc: 'Search all metadata (legacy)', icon: <Hash className="w-3 h-3" /> },
-
-        // Model & Resources
-        { op: 'model:sdxl', desc: 'Filter by model', icon: <Monitor className="w-3 h-3" /> },
-        { op: 'lora:detail', desc: 'Filter by LoRA', icon: <Puzzle className="w-3 h-3" /> },
-        { op: 'tool:invoke', desc: 'Filter by generator', icon: <Command className="w-3 h-3" /> },
-        { op: 'sampler:euler', desc: 'Filter by sampler', icon: <Sliders className="w-3 h-3" /> },
-
-        // Parameters
-        { op: 'steps:>30', desc: 'Steps greater than 30', icon: <Hash className="w-3 h-3" /> },
-        { op: 'cfg:<7', desc: 'CFG less than 7', icon: <Sliders className="w-3 h-3" /> },
-        { op: 'seed:12345', desc: 'Filter by seed', icon: <Hash className="w-3 h-3" /> },
-
-        // Dates
-        { op: 'date:2025', desc: 'All images from 2025', icon: <Calendar className="w-3 h-3" /> },
-        { op: 'date:2026-04', desc: 'All images from Apr 2026', icon: <Calendar className="w-3 h-3" /> },
-        { op: 'after:2026-04', desc: 'From Apr 2026 onward', icon: <Calendar className="w-3 h-3" /> },
-        { op: 'before:2025', desc: 'Through 2025', icon: <Calendar className="w-3 h-3" /> },
-
-        // Dimensions
-        { op: 'w:>1024', desc: 'Width filter', icon: <Monitor className="w-3 h-3" /> },
-        { op: 'h:<768', desc: 'Height filter', icon: <Monitor className="w-3 h-3" /> },
-        { op: 'upscaled:true', desc: 'Show upscaled only', icon: <Monitor className="w-3 h-3" /> },
-    ];
-
     return (
         <div
             className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm animate-in fade-in duration-300 ease-spring"
@@ -231,12 +212,12 @@ export const ShortcutsModal: React.FC<ShortcutsModalProps> = ({ isOpen, onClose,
                                         <div className="col-span-7">Description</div>
                                     </div>
                                     <div className="max-h-[300px] overflow-y-auto custom-scrollbar">
-                                        {searchOperators.map((op, i) => (
-                                            <div key={i} className="grid grid-cols-12 p-2 text-sm border-b border-gray-100 dark:border-white/5 last:border-0 hover:bg-white dark:hover:bg-white/5 transition-colors">
+                                        {SEARCH_OPERATOR_DEFINITIONS.map(operator => (
+                                            <div key={operator.example} className="grid grid-cols-12 p-2 text-sm border-b border-gray-100 dark:border-white/5 last:border-0 hover:bg-white dark:hover:bg-white/5 transition-colors">
                                                 <div className="col-span-5 font-mono text-sage-600 dark:text-sage-400 pl-2 flex items-center gap-2 whitespace-nowrap overflow-hidden text-ellipsis">
-                                                    {op.icon} {op.op}
+                                                    {getSearchOperatorIcon(operator.category)} {operator.example}
                                                 </div>
-                                                <div className="col-span-7 text-xs text-gray-600 dark:text-gray-400">{op.desc}</div>
+                                                <div className="col-span-7 text-xs text-gray-600 dark:text-gray-400">{operator.description}</div>
                                             </div>
                                         ))}
                                     </div>

--- a/src/components/ui/__tests__/AppHeader.accessibility.test.tsx
+++ b/src/components/ui/__tests__/AppHeader.accessibility.test.tsx
@@ -70,7 +70,8 @@ const defaultProps = {
         submitSearch: vi.fn(),
         isFocused: false,
         onFocus: vi.fn(),
-        onBlur: vi.fn()
+        onBlur: vi.fn(),
+        onOpenSearchHelp: vi.fn()
     },
     layoutMode: 'masonry' as const,
     setLayoutMode: vi.fn(),

--- a/src/components/ui/__tests__/AppHeader.test.tsx
+++ b/src/components/ui/__tests__/AppHeader.test.tsx
@@ -20,7 +20,9 @@ vi.mock('../../../hooks/useLibraryContext', () => ({
 }));
 
 vi.mock('../../../features/filters/components/SearchBar', () => ({
-    SearchBar: () => <div data-testid="search-bar" />
+    SearchBar: ({ submitNavigatesToGrid }: { submitNavigatesToGrid: boolean }) => (
+        <div data-testid="search-bar" data-submit-navigates-to-grid={String(submitNavigatesToGrid)} />
+    )
 }));
 
 vi.mock('../../../features/library/components/ViewControls', () => ({
@@ -98,7 +100,8 @@ const defaultProps = {
         submitSearch: vi.fn(),
         isFocused: false,
         onFocus: vi.fn(),
-        onBlur: vi.fn()
+        onBlur: vi.fn(),
+        onOpenSearchHelp: vi.fn()
     },
     layoutMode: 'masonry' as const,
     setLayoutMode: vi.fn(),
@@ -308,5 +311,19 @@ describe('AppHeader', () => {
 
         rerender(<AppHeader {...defaultProps} viewMode="dashboard" />);
         expect(screen.getByTestId('view-controls').getAttribute('data-slideshow')).toBe('false');
+    });
+
+    it('marks dashboard and maintenance searches as Grid-bound submissions', () => {
+        const { rerender } = render(<AppHeader {...defaultProps} viewMode="grid" />);
+        expect(screen.getByTestId('search-bar').getAttribute('data-submit-navigates-to-grid')).toBe('false');
+
+        rerender(<AppHeader {...defaultProps} viewMode="timeline" />);
+        expect(screen.getByTestId('search-bar').getAttribute('data-submit-navigates-to-grid')).toBe('false');
+
+        rerender(<AppHeader {...defaultProps} viewMode="dashboard" />);
+        expect(screen.getByTestId('search-bar').getAttribute('data-submit-navigates-to-grid')).toBe('true');
+
+        rerender(<AppHeader {...defaultProps} viewMode="maintenance" />);
+        expect(screen.getByTestId('search-bar').getAttribute('data-submit-navigates-to-grid')).toBe('true');
     });
 });

--- a/src/components/ui/__tests__/ShortcutsModal.test.tsx
+++ b/src/components/ui/__tests__/ShortcutsModal.test.tsx
@@ -36,7 +36,11 @@ describe('ShortcutsModal', () => {
         expect(await screen.findByText('Show this help dialog')).toBeTruthy();
 
         fireEvent.click(screen.getByRole('button', { name: 'Search Syntax' }));
-        expect(screen.getByText('Search positive prompt (default)')).toBeTruthy();
+        expect(screen.getByText('Search the positive prompt (default)')).toBeTruthy();
+        expect(screen.getByText('Filter by ControlNet; controlnet: is also supported')).toBeTruthy();
+        expect(screen.getByText('Filter width; width: is also supported')).toBeTruthy();
+        expect(screen.getByText('Filter generation steps with a number, <, or >')).toBeTruthy();
+        expect(screen.getByText('Filter CFG with a number, <, or >')).toBeTruthy();
         fireEvent.click(screen.getByRole('button', { name: 'Keyboard Shortcuts' }));
         expect(screen.getByText('Show this help dialog')).toBeTruthy();
 

--- a/src/constants/searchOperators.ts
+++ b/src/constants/searchOperators.ts
@@ -1,0 +1,150 @@
+export type SearchOperatorCategory = 'content' | 'resource' | 'parameter' | 'date' | 'dimension';
+
+export interface SearchOperatorDefinition {
+    example: string;
+    description: string;
+    category: SearchOperatorCategory;
+    suggestions: readonly string[];
+}
+
+export const SEARCH_OPERATOR_DEFINITIONS = [
+    {
+        example: 'sunset',
+        description: 'Search the positive prompt (default)',
+        category: 'content',
+        suggestions: [],
+    },
+    {
+        example: '"dark forest"',
+        description: 'Match an exact prompt phrase',
+        category: 'content',
+        suggestions: [],
+    },
+    {
+        example: 'forest OR ocean',
+        description: 'Match either adjacent prompt term',
+        category: 'content',
+        suggestions: ['OR'],
+    },
+    {
+        example: '-blurry',
+        description: 'Exclude a positive-prompt term; !blurry is also supported',
+        category: 'content',
+        suggestions: [],
+    },
+    {
+        example: 'neg:blur',
+        description: 'Search the negative prompt; negative: is also supported',
+        category: 'content',
+        suggestions: ['neg:', 'negative:'],
+    },
+    {
+        example: 'file:portrait',
+        description: 'Search file paths; filename: and path: are also supported',
+        category: 'content',
+        suggestions: ['file:', 'filename:', 'path:'],
+    },
+    {
+        example: 'all:anime',
+        description: 'Search paths and raw metadata (legacy)',
+        category: 'content',
+        suggestions: ['all:'],
+    },
+    {
+        example: 'model:sdxl',
+        description: 'Filter by model',
+        category: 'resource',
+        suggestions: ['model:'],
+    },
+    {
+        example: 'lora:detail',
+        description: 'Filter by LoRA',
+        category: 'resource',
+        suggestions: ['lora:'],
+    },
+    {
+        example: 'cn:pose',
+        description: 'Filter by ControlNet; controlnet: is also supported',
+        category: 'resource',
+        suggestions: ['cn:', 'controlnet:'],
+    },
+    {
+        example: 'ip:adapter',
+        description: 'Filter by IP-Adapter; ipadapter: is also supported',
+        category: 'resource',
+        suggestions: ['ip:', 'ipadapter:'],
+    },
+    {
+        example: 'tool:invoke',
+        description: 'Filter by generator',
+        category: 'resource',
+        suggestions: ['tool:'],
+    },
+    {
+        example: 'sampler:euler',
+        description: 'Filter by sampler',
+        category: 'resource',
+        suggestions: ['sampler:'],
+    },
+    {
+        example: 'steps:>30',
+        description: 'Filter generation steps with a number, <, or >',
+        category: 'parameter',
+        suggestions: ['steps:'],
+    },
+    {
+        example: 'cfg:<7',
+        description: 'Filter CFG with a number, <, or >',
+        category: 'parameter',
+        suggestions: ['cfg:'],
+    },
+    {
+        example: 'seed:12345',
+        description: 'Search seed values',
+        category: 'parameter',
+        suggestions: ['seed:'],
+    },
+    {
+        example: 'date:2026-04',
+        description: 'Filter by year, month, day, or an inclusive range',
+        category: 'date',
+        suggestions: ['date:'],
+    },
+    {
+        example: 'after:2026-04',
+        description: 'Match images from a date onward',
+        category: 'date',
+        suggestions: ['after:'],
+    },
+    {
+        example: 'before:2025',
+        description: 'Match images through a date',
+        category: 'date',
+        suggestions: ['before:'],
+    },
+    {
+        example: 'w:>1024',
+        description: 'Filter width; width: is also supported',
+        category: 'dimension',
+        suggestions: ['w:', 'width:'],
+    },
+    {
+        example: 'h:<768',
+        description: 'Filter height; height: is also supported',
+        category: 'dimension',
+        suggestions: ['h:', 'height:'],
+    },
+    {
+        example: 'upscaled:true',
+        description: 'Show upscaled or non-upscaled images',
+        category: 'dimension',
+        suggestions: ['upscaled:'],
+    },
+] as const satisfies readonly SearchOperatorDefinition[];
+
+export const SEARCH_OPERATOR_SUGGESTIONS = SEARCH_OPERATOR_DEFINITIONS.flatMap(
+    definition => definition.suggestions.map(value => ({
+        value,
+        description: definition.description,
+    }))
+);

--- a/src/features/filters/components/ActiveFilters.tsx
+++ b/src/features/filters/components/ActiveFilters.tsx
@@ -29,7 +29,6 @@ export const ActiveFilters: React.FC<ActiveFiltersProps> = () => {
         filters.loras.length > 0 ||
         filters.embeddings.length > 0 ||
         filters.hypernetworks.length > 0 ||
-        filters.searchQuery !== '' ||
         (filters.samplers && filters.samplers.length > 0) ||
         (filters.generationTypes && filters.generationTypes.length > 0) ||
         filters.minSteps !== undefined ||

--- a/src/features/filters/components/SearchBar.tsx
+++ b/src/features/filters/components/SearchBar.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { BookOpen, History, LoaderCircle, Search, Sparkles, X } from 'lucide-react';
+import { LoaderCircle, Search, Sparkles, X } from 'lucide-react';
 import { FilterState } from '../../../types';
 import { APP_NAME } from '../../../constants/app';
-import { SEARCH_OPERATOR_SUGGESTIONS } from '../../../constants/searchOperators';
 import { useSearch } from '../../../contexts/SearchContext';
 import { getAdvancedDateSearchReadiness } from '../../../utils/dateFilters';
 import { TooltipButton } from '../../../components/ui/InfoTooltip';
+import type { SearchBarOption } from './SearchBarPopover';
+
+const SearchBarPopover = React.lazy(() => import('./SearchBarPopover').then(module => ({ default: module.SearchBarPopover })));
 
 interface SearchBarProps {
     filters: FilterState;
@@ -29,13 +31,6 @@ interface SearchBarProps {
     submitNavigatesToGrid: boolean;
 }
 
-interface SearchOption {
-    id: string;
-    kind: 'operator' | 'recent';
-    value: string;
-    description?: string;
-}
-
 export const SearchBar = React.memo(({
     searchProps,
     recentSearches,
@@ -49,6 +44,7 @@ export const SearchBar = React.memo(({
     const [localValue, setLocalValue] = React.useState(filters.searchQuery);
     const [activeOptionIndex, setActiveOptionIndex] = React.useState(-1);
     const [areOptionsDismissed, setAreOptionsDismissed] = React.useState(false);
+    const [operatorSuggestions, setOperatorSuggestions] = React.useState<readonly { value: string; description: string }[]>([]);
     const listboxId = React.useId();
     const statusId = React.useId();
     const trimmedValue = localValue.trim();
@@ -61,18 +57,31 @@ export const SearchBar = React.memo(({
         : 'Use ISO dates like date:2026-04 or before:2025';
     const liveSearchEnabled = !searchProps.isAiSearchEnabled && !submitNavigatesToGrid;
 
+    React.useEffect(() => {
+        if (!searchProps.isFocused || searchProps.isAiSearchEnabled || operatorSuggestions.length > 0) return;
+
+        let isCurrent = true;
+        void import('../../../constants/searchOperators').then(module => {
+            if (isCurrent) setOperatorSuggestions(module.SEARCH_OPERATOR_SUGGESTIONS);
+        });
+
+        return () => {
+            isCurrent = false;
+        };
+    }, [operatorSuggestions.length, searchProps.isAiSearchEnabled, searchProps.isFocused]);
+
     const matchingOperators = React.useMemo(() => {
         if (searchProps.isAiSearchEnabled) return [];
         const lastToken = localValue.split(' ').pop()?.toLowerCase() || '';
         if (!lastToken) return [];
 
-        return SEARCH_OPERATOR_SUGGESTIONS.filter(operator => {
+        return operatorSuggestions.filter(operator => {
             const normalized = operator.value.toLowerCase();
             return normalized.startsWith(lastToken) && normalized !== lastToken;
         });
-    }, [localValue, searchProps.isAiSearchEnabled]);
+    }, [localValue, operatorSuggestions, searchProps.isAiSearchEnabled]);
 
-    const options = React.useMemo<SearchOption[]>(() => {
+    const options = React.useMemo<SearchBarOption[]>(() => {
         if (areOptionsDismissed) return [];
 
         if (matchingOperators.length > 0) {
@@ -163,7 +172,7 @@ export const SearchBar = React.memo(({
         searchProps.submitSearch(value);
     };
 
-    const selectOption = (option: SearchOption) => {
+    const selectOption = (option: SearchBarOption) => {
         if (option.kind === 'operator') {
             selectOperator(option.value);
         } else {
@@ -289,65 +298,20 @@ export const SearchBar = React.memo(({
                 ) : null}
 
                 {searchProps.isFocused ? (
-                    <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-white/10 rounded-xl shadow-2xl z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
-                        {dateSearchHint ? (
-                            <div id={statusId} role="status" className="px-4 py-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-100 dark:border-amber-900/40">
-                                {dateSearchHint}
-                            </div>
-                        ) : statusMessage ? (
-                            <div id={statusId} role="status" aria-live="polite" className="px-4 py-2 text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-black/20 border-b border-gray-100 dark:border-white/5">
-                                {statusMessage}
-                            </div>
-                        ) : null}
-
-                        {options.length > 0 ? (
-                            <div className="py-2">
-                                <div className="px-4 py-1 text-[10px] font-bold text-gray-400 uppercase tracking-wider flex justify-between items-center">
-                                    <span>{options[0].kind === 'recent' ? 'Recent Searches' : 'Suggestions'}</span>
-                                    {options[0].kind === 'recent' ? (
-                                        <button
-                                            type="button"
-                                            onClick={clearRecentSearches}
-                                            className="hover:text-red-500 transition-colors uppercase"
-                                        >
-                                            Clear recent searches
-                                        </button>
-                                    ) : null}
-                                </div>
-                                <div id={listboxId} role="listbox" aria-label={listLabel}>
-                                    {options.map((option, index) => (
-                                        <button
-                                            key={`${option.kind}-${option.value}`}
-                                            id={option.id}
-                                            type="button"
-                                            role="option"
-                                            tabIndex={-1}
-                                            aria-selected={activeOptionIndex === index}
-                                            onMouseDown={event => event.preventDefault()}
-                                            onClick={() => selectOption(option)}
-                                            className={`w-full text-left px-4 py-2 text-sm transition-colors flex items-center gap-2 ${activeOptionIndex === index ? 'bg-sage-100 dark:bg-sage-900/40 text-sage-900 dark:text-sage-100' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'}`}
-                                        >
-                                            {option.kind === 'recent' ? <History aria-hidden="true" className="w-3 h-3 text-gray-400" /> : null}
-                                            <span className={option.kind === 'operator' ? 'font-mono' : undefined}>{option.value}</span>
-                                            {option.description ? <span className="ml-auto text-xs text-gray-400 truncate">{option.description}</span> : null}
-                                        </button>
-                                    ))}
-                                </div>
-                            </div>
-                        ) : null}
-
-                        <div className="border-t border-gray-100 dark:border-white/5 px-3 py-2 flex items-center justify-between gap-3">
-                            <span className="text-[10px] text-gray-400">Plain text searches positive prompts.</span>
-                            <button
-                                type="button"
-                                onClick={searchProps.onOpenSearchHelp}
-                                className="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium text-sage-600 hover:text-sage-800 dark:text-sage-400 dark:hover:text-sage-200"
-                            >
-                                <BookOpen aria-hidden="true" className="w-3 h-3" />
-                                Search syntax
-                            </button>
-                        </div>
-                    </div>
+                    <React.Suspense fallback={null}>
+                        <SearchBarPopover
+                            activeOptionIndex={activeOptionIndex}
+                            dateSearchHint={dateSearchHint}
+                            listboxId={listboxId}
+                            listLabel={listLabel}
+                            options={options}
+                            statusId={statusId}
+                            statusMessage={statusMessage}
+                            onClearRecentSearches={clearRecentSearches}
+                            onOpenSearchHelp={searchProps.onOpenSearchHelp}
+                            onSelectOption={selectOption}
+                        />
+                    </React.Suspense>
                 ) : null}
             </div>
             <TooltipButton

--- a/src/features/filters/components/SearchBar.tsx
+++ b/src/features/filters/components/SearchBar.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { Search, X, Sparkles, History } from 'lucide-react';
+import { BookOpen, History, LoaderCircle, Search, Sparkles, X } from 'lucide-react';
 import { FilterState } from '../../../types';
 import { APP_NAME } from '../../../constants/app';
+import { SEARCH_OPERATOR_SUGGESTIONS } from '../../../constants/searchOperators';
 import { useSearch } from '../../../contexts/SearchContext';
 import { getAdvancedDateSearchReadiness } from '../../../utils/dateFilters';
 import { TooltipButton } from '../../../components/ui/InfoTooltip';
@@ -18,23 +19,39 @@ interface SearchBarProps {
         isFocused: boolean;
         onFocus: () => void;
         onBlur: () => void;
+        onOpenSearchHelp: () => void;
     };
     recentSearches: string[];
     setRecentSearches: React.Dispatch<React.SetStateAction<string[]>>;
+    scopeName: string;
+    displayedCount: number;
+    isFiltering: boolean;
+    submitNavigatesToGrid: boolean;
+}
+
+interface SearchOption {
+    id: string;
+    kind: 'operator' | 'recent';
+    value: string;
+    description?: string;
 }
 
 export const SearchBar = React.memo(({
     searchProps,
     recentSearches,
-    setRecentSearches
+    setRecentSearches,
+    scopeName,
+    displayedCount,
+    isFiltering,
+    submitNavigatesToGrid,
 }: SearchBarProps) => {
-    // Context Access
     const { filters, setFilters } = useSearch();
-
-    // 1. ISOLATED STATE: Typing here will NOT re-render the parent (App.tsx)
     const [localValue, setLocalValue] = React.useState(filters.searchQuery);
-    const [suggestions, setSuggestions] = React.useState<string[]>([]);
-    const [activeSuggestionIndex, setActiveSuggestionIndex] = React.useState(-1);
+    const [activeOptionIndex, setActiveOptionIndex] = React.useState(-1);
+    const [areOptionsDismissed, setAreOptionsDismissed] = React.useState(false);
+    const listboxId = React.useId();
+    const statusId = React.useId();
+    const trimmedValue = localValue.trim();
     const dateSearchReadiness = React.useMemo(
         () => getAdvancedDateSearchReadiness(localValue),
         [localValue]
@@ -42,187 +59,306 @@ export const SearchBar = React.memo(({
     const dateSearchHint = dateSearchReadiness.isReady
         ? null
         : 'Use ISO dates like date:2026-04 or before:2025';
+    const liveSearchEnabled = !searchProps.isAiSearchEnabled && !submitNavigatesToGrid;
 
-    // 2. EXTERNAL SYNC: If filters.searchQuery changes from outside (e.g. clear button), update local
-    React.useEffect(() => {
-        if (filters.searchQuery !== localValue) {
-            setLocalValue(filters.searchQuery);
+    const matchingOperators = React.useMemo(() => {
+        if (searchProps.isAiSearchEnabled) return [];
+        const lastToken = localValue.split(' ').pop()?.toLowerCase() || '';
+        if (!lastToken) return [];
+
+        return SEARCH_OPERATOR_SUGGESTIONS.filter(operator => {
+            const normalized = operator.value.toLowerCase();
+            return normalized.startsWith(lastToken) && normalized !== lastToken;
+        });
+    }, [localValue, searchProps.isAiSearchEnabled]);
+
+    const options = React.useMemo<SearchOption[]>(() => {
+        if (areOptionsDismissed) return [];
+
+        if (matchingOperators.length > 0) {
+            return matchingOperators.map((operator, index) => ({
+                id: `${listboxId}-option-${index}`,
+                kind: 'operator',
+                value: operator.value,
+                description: operator.description,
+            }));
         }
+
+        if (!localValue && recentSearches.length > 0) {
+            return recentSearches.map((value, index) => ({
+                id: `${listboxId}-option-${index}`,
+                kind: 'recent',
+                value,
+            }));
+        }
+
+        return [];
+    }, [areOptionsDismissed, listboxId, localValue, matchingOperators, recentSearches]);
+
+    const activeOption = activeOptionIndex >= 0 ? options[activeOptionIndex] : undefined;
+
+    React.useEffect(() => {
+        setLocalValue(filters.searchQuery);
+        setActiveOptionIndex(-1);
+        setAreOptionsDismissed(false);
     }, [filters.searchQuery]);
 
-    // 3. DEBOUNCED GLOBAL SYNC: Only update parent app after typing stops
     React.useEffect(() => {
+        if (!liveSearchEnabled) return;
         if (localValue === filters.searchQuery) return;
         if (!dateSearchReadiness.isReady) return;
 
         const timer = setTimeout(() => {
-            setFilters(f => ({ ...f, searchQuery: localValue }));
-        }, 500); // 500ms for safety on large libraries
+            setFilters(previous => ({ ...previous, searchQuery: localValue }));
+        }, 500);
 
         return () => clearTimeout(timer);
-    }, [dateSearchReadiness.isReady, localValue, filters.searchQuery, setFilters]);
+    }, [dateSearchReadiness.isReady, filters.searchQuery, liveSearchEnabled, localValue, setFilters]);
 
-    const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const val = e.target.value;
-        setLocalValue(val);
-        setActiveSuggestionIndex(-1);
+    const statusMessage = React.useMemo(() => {
+        if (dateSearchHint) return null;
+        if (searchProps.isSearchingAi) return 'Analyzing with Gemini…';
+        if (!trimmedValue) return null;
+        if (searchProps.isAiSearchEnabled) return 'Press Enter to analyze and apply filters.';
+        if (submitNavigatesToGrid) return 'Press Enter to view matching images in Grid.';
+        if (localValue !== filters.searchQuery || isFiltering) return `Searching ${scopeName}…`;
+        if (displayedCount === 0) return `No matches in ${scopeName}.`;
+        return `${displayedCount.toLocaleString()} ${displayedCount === 1 ? 'match' : 'matches'} in ${scopeName}.`;
+    }, [
+        dateSearchHint,
+        displayedCount,
+        filters.searchQuery,
+        isFiltering,
+        localValue,
+        scopeName,
+        searchProps.isAiSearchEnabled,
+        searchProps.isSearchingAi,
+        submitNavigatesToGrid,
+        trimmedValue,
+    ]);
 
-        // Suggestions logic (isolated)
-        const lastToken = val.split(' ').pop()?.toLowerCase() || '';
-        if (lastToken.length >= 1) {
-            const operators = ['OR', 'neg:', 'file:', 'all:', 'model:', 'tool:', 'lora:', 'sampler:', 'seed:', 'steps:', 'cfg:', 'w:', 'h:', 'date:', 'after:', 'before:', 'upscaled:'];
-            const opMatches = operators.filter(op => {
-                const normalized = op.toLowerCase();
-                return normalized.startsWith(lastToken) && normalized !== lastToken;
-            });
-            setSuggestions(opMatches);
-        } else {
-            setSuggestions([]);
-        }
+    const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setLocalValue(event.target.value);
+        setActiveOptionIndex(-1);
+        setAreOptionsDismissed(false);
     };
 
-    const selectSuggestion = (index: number) => {
-        const s = suggestions[index];
+    const selectOperator = (value: string) => {
         const lastSpace = localValue.lastIndexOf(' ');
         const prefix = lastSpace >= 0 ? localValue.substring(0, lastSpace + 1) : '';
-        const newVal = prefix + s + ' ';
-        setLocalValue(newVal);
-        setSuggestions([]);
-        if (getAdvancedDateSearchReadiness(newVal).isReady) {
-            setFilters(f => ({ ...f, searchQuery: newVal }));
+        const nextValue = `${prefix}${value} `;
+        setLocalValue(nextValue);
+        setActiveOptionIndex(-1);
+        setAreOptionsDismissed(true);
+
+        if (liveSearchEnabled && getAdvancedDateSearchReadiness(nextValue).isReady) {
+            setFilters(previous => ({ ...previous, searchQuery: nextValue }));
         }
     };
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (suggestions.length > 0) {
-            if (e.key === 'ArrowDown') {
-                e.preventDefault();
-                setActiveSuggestionIndex(prev => (prev + 1) % suggestions.length);
+    const selectRecentSearch = (value: string) => {
+        setLocalValue(value);
+        setActiveOptionIndex(-1);
+        setAreOptionsDismissed(true);
+        searchProps.submitSearch(value);
+    };
+
+    const selectOption = (option: SearchOption) => {
+        if (option.kind === 'operator') {
+            selectOperator(option.value);
+        } else {
+            selectRecentSearch(option.value);
+        }
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Escape' && options.length > 0) {
+            event.preventDefault();
+            event.stopPropagation();
+            setActiveOptionIndex(-1);
+            setAreOptionsDismissed(true);
+            return;
+        }
+
+        if (options.length > 0) {
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setActiveOptionIndex(previous => (previous + 1) % options.length);
                 return;
             }
-            if (e.key === 'ArrowUp') {
-                e.preventDefault();
-                setActiveSuggestionIndex(prev => (prev - 1 + suggestions.length) % suggestions.length);
+            if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setActiveOptionIndex(previous => (previous - 1 + options.length) % options.length);
                 return;
             }
-            if (e.key === 'Enter' || e.key === 'Tab') {
-                if (activeSuggestionIndex >= 0) {
-                    e.preventDefault();
-                    selectSuggestion(activeSuggestionIndex);
-                    return;
-                }
+            if (event.key === 'Enter' && activeOption) {
+                event.preventDefault();
+                selectOption(activeOption);
+                return;
+            }
+            if (event.key === 'Tab' && activeOption?.kind === 'operator') {
+                event.preventDefault();
+                selectOperator(activeOption.value);
+                return;
             }
         }
 
-        if (e.key === 'Enter') {
-            if (!dateSearchReadiness.isReady) {
-                e.preventDefault();
+        if (event.key === 'Enter') {
+            if (!dateSearchReadiness.isReady || searchProps.isSearchingAi) {
+                event.preventDefault();
                 return;
             }
-            setFilters(f => ({ ...f, searchQuery: localValue }));
             searchProps.submitSearch(localValue);
         }
     };
 
     const clearSearch = () => {
         setLocalValue('');
-        setFilters(f => ({ ...f, searchQuery: '' }));
-        setSuggestions([]);
-        setActiveSuggestionIndex(-1);
+        setFilters(previous => ({ ...previous, searchQuery: '' }));
+        setActiveOptionIndex(-1);
+        setAreOptionsDismissed(false);
         searchProps.inputRef.current?.focus();
     };
 
+    const clearRecentSearches = () => {
+        setRecentSearches([]);
+        setActiveOptionIndex(-1);
+        searchProps.inputRef.current?.focus();
+    };
+
+    const handleFocusCapture = (event: React.FocusEvent<HTMLDivElement>) => {
+        const previousTarget = event.relatedTarget as Node | null;
+        if (!previousTarget || !event.currentTarget.contains(previousTarget)) {
+            setAreOptionsDismissed(false);
+            searchProps.onFocus();
+        }
+    };
+
+    const handleBlurCapture = (event: React.FocusEvent<HTMLDivElement>) => {
+        const nextTarget = event.relatedTarget as Node | null;
+        if (!nextTarget || !event.currentTarget.contains(nextTarget)) {
+            searchProps.onBlur();
+        }
+    };
+
+    const listLabel = options[0]?.kind === 'recent' ? 'Recent searches' : 'Search operator suggestions';
+    const accessibleName = searchProps.isAiSearchEnabled
+        ? `Ask ${APP_NAME} with AI`
+        : `Search in ${scopeName}`;
+
     return (
-        <div className={`relative w-full max-w-lg group flex items-center gap-2 transition-all duration-300 ${searchProps.isFocused ? 'z-[70] scale-105' : 'z-30'}`}>
+        <div
+            className={`relative w-full max-w-lg group flex items-center gap-2 transition-all duration-300 ${searchProps.isFocused ? 'z-[70] scale-105' : 'z-30'}`}
+            onFocusCapture={handleFocusCapture}
+            onBlurCapture={handleBlurCapture}
+        >
             <div className="relative flex-1">
-                <Search className={`absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 transition-colors ${searchProps.isSearchingAi ? 'text-amethyst-600 dark:text-amethyst-400 animate-pulse' : 'text-gray-400 dark:text-zinc-500 group-focus-within:text-sage-600 dark:group-focus-within:text-sage-400'}`} />
+                {searchProps.isSearchingAi ? (
+                    <LoaderCircle aria-hidden="true" className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-amethyst-600 dark:text-amethyst-400 animate-spin" />
+                ) : (
+                    <Search aria-hidden="true" className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 transition-colors text-gray-400 dark:text-zinc-500 group-focus-within:text-sage-600 dark:group-focus-within:text-sage-400" />
+                )}
                 <input
                     ref={searchProps.inputRef}
                     type="text"
-                    placeholder={searchProps.isAiSearchEnabled ? `Ask ${APP_NAME}...` : "Search prompt..."}
+                    role="combobox"
+                    aria-label={accessibleName}
+                    aria-autocomplete="list"
+                    aria-expanded={searchProps.isFocused && options.length > 0}
+                    aria-controls={searchProps.isFocused && options.length > 0 ? listboxId : undefined}
+                    aria-activedescendant={searchProps.isFocused ? activeOption?.id : undefined}
+                    aria-describedby={searchProps.isFocused && (dateSearchHint || statusMessage) ? statusId : undefined}
+                    aria-busy={searchProps.isSearchingAi}
+                    readOnly={searchProps.isSearchingAi}
+                    placeholder={searchProps.isAiSearchEnabled ? `Ask ${APP_NAME}...` : `Search in ${scopeName}...`}
                     className={`w-full bg-gray-100 dark:bg-zinc-800/50 border rounded-xl py-2 pl-10 pr-10 text-sm focus:outline-none transition-all text-gray-900 dark:text-gray-100 placeholder-gray-500 ${searchProps.isAiSearchEnabled ? 'border-amethyst-300 dark:border-amethyst-800 focus:border-amethyst-500/50 focus:ring-1 focus:ring-amethyst-500/30' : 'border-gray-200 dark:border-white/10 focus:border-sage-500/50 focus:ring-1 focus:ring-sage-500/30'}`}
                     value={localValue}
                     onChange={handleSearchChange}
-                    onFocus={searchProps.onFocus}
-                    onBlur={searchProps.onBlur}
                     onKeyDown={handleKeyDown}
                     autoComplete="off"
                 />
-                {localValue && (
+                {localValue && !searchProps.isSearchingAi ? (
                     <button
                         type="button"
                         aria-label="Clear Search"
                         onClick={clearSearch}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-900 dark:text-zinc-500 dark:hover:text-white"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-900 dark:text-zinc-500 dark:hover:text-white"
                     >
-                        <X className="w-3.5 h-3.5" />
+                        <X aria-hidden="true" className="w-3.5 h-3.5" />
                     </button>
-                )}
+                ) : null}
 
-                {searchProps.isFocused && (
+                {searchProps.isFocused ? (
                     <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-white/10 rounded-xl shadow-2xl z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
-                        {dateSearchHint && (
-                            <div role="status" className="px-4 py-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-100 dark:border-amber-900/40">
+                        {dateSearchHint ? (
+                            <div id={statusId} role="status" className="px-4 py-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-100 dark:border-amber-900/40">
                                 {dateSearchHint}
                             </div>
-                        )}
-                        {suggestions.length > 0 && (
+                        ) : statusMessage ? (
+                            <div id={statusId} role="status" aria-live="polite" className="px-4 py-2 text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-black/20 border-b border-gray-100 dark:border-white/5">
+                                {statusMessage}
+                            </div>
+                        ) : null}
+
+                        {options.length > 0 ? (
                             <div className="py-2">
-                                <div className="px-4 py-1 text-[10px] font-bold text-gray-400 uppercase tracking-wider">Suggestions</div>
-                                {suggestions.map((s, idx) => (
-                                    <button
-                                        key={s}
-                                        onMouseDown={(e) => {
-                                            e.preventDefault();
-                                            selectSuggestion(idx);
-                                        }}
-                                        className={`w-full text-left px-4 py-2 text-sm transition-colors ${activeSuggestionIndex === idx ? 'bg-sage-100 dark:bg-sage-900/40 text-sage-900 dark:text-sage-100' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'}`}
-                                    >
-                                        {s}
-                                    </button>
-                                ))}
-                            </div>
-                        )}
-                        {!localValue && recentSearches.length > 0 && (
-                            <div className="py-2 border-t border-gray-100 dark:border-white/5 first:border-0">
                                 <div className="px-4 py-1 text-[10px] font-bold text-gray-400 uppercase tracking-wider flex justify-between items-center">
-                                    <span>Recent Searches</span>
-                                    <button
-                                        onMouseDown={(e) => {
-                                            e.preventDefault();
-                                            setRecentSearches([]);
-                                        }}
-                                        className="hover:text-red-500 transition-colors uppercase"
-                                    >
-                                        Clear
-                                    </button>
+                                    <span>{options[0].kind === 'recent' ? 'Recent Searches' : 'Suggestions'}</span>
+                                    {options[0].kind === 'recent' ? (
+                                        <button
+                                            type="button"
+                                            onClick={clearRecentSearches}
+                                            className="hover:text-red-500 transition-colors uppercase"
+                                        >
+                                            Clear recent searches
+                                        </button>
+                                    ) : null}
                                 </div>
-                                {recentSearches.map(s => (
-                                    <button
-                                        key={s}
-                                        onMouseDown={(e) => {
-                                            e.preventDefault();
-                                            setFilters(f => ({ ...f, searchQuery: s }));
-                                            setTimeout(() => searchProps.submitSearch(s), 0);
-                                        }}
-                                        className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors flex items-center gap-2"
-                                    >
-                                        <History className="w-3 h-3 text-gray-400" /> {s}
-                                    </button>
-                                ))}
+                                <div id={listboxId} role="listbox" aria-label={listLabel}>
+                                    {options.map((option, index) => (
+                                        <button
+                                            key={`${option.kind}-${option.value}`}
+                                            id={option.id}
+                                            type="button"
+                                            role="option"
+                                            tabIndex={-1}
+                                            aria-selected={activeOptionIndex === index}
+                                            onMouseDown={event => event.preventDefault()}
+                                            onClick={() => selectOption(option)}
+                                            className={`w-full text-left px-4 py-2 text-sm transition-colors flex items-center gap-2 ${activeOptionIndex === index ? 'bg-sage-100 dark:bg-sage-900/40 text-sage-900 dark:text-sage-100' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'}`}
+                                        >
+                                            {option.kind === 'recent' ? <History aria-hidden="true" className="w-3 h-3 text-gray-400" /> : null}
+                                            <span className={option.kind === 'operator' ? 'font-mono' : undefined}>{option.value}</span>
+                                            {option.description ? <span className="ml-auto text-xs text-gray-400 truncate">{option.description}</span> : null}
+                                        </button>
+                                    ))}
+                                </div>
                             </div>
-                        )}
+                        ) : null}
+
+                        <div className="border-t border-gray-100 dark:border-white/5 px-3 py-2 flex items-center justify-between gap-3">
+                            <span className="text-[10px] text-gray-400">Plain text searches positive prompts.</span>
+                            <button
+                                type="button"
+                                onClick={searchProps.onOpenSearchHelp}
+                                className="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium text-sage-600 hover:text-sage-800 dark:text-sage-400 dark:hover:text-sage-200"
+                            >
+                                <BookOpen aria-hidden="true" className="w-3 h-3" />
+                                Search syntax
+                            </button>
+                        </div>
                     </div>
-                )}
+                ) : null}
             </div>
             <TooltipButton
-                label={searchProps.isAiSearchEnabled ? "Disable AI Search" : "Enable AI Search"}
-                content={searchProps.isAiSearchEnabled ? "Return to standard library search." : "Use natural-language AI search."}
+                label={searchProps.isAiSearchEnabled ? 'Disable AI Search' : 'Enable AI Search'}
+                content={searchProps.isAiSearchEnabled ? 'Return to standard library search.' : 'Use natural-language AI search.'}
                 aria-pressed={searchProps.isAiSearchEnabled}
+                disabled={searchProps.isSearchingAi}
                 onClick={searchProps.toggleAiSearch}
-                className={`p-2 rounded-xl transition-all border ${searchProps.isAiSearchEnabled ? 'bg-amethyst-100 dark:bg-amethyst-600/20 border-amethyst-500/50 text-amethyst-600 dark:text-amethyst-300 shadow-[0_0_15px_rgba(139,92,246,0.2)]' : 'bg-gray-100 dark:bg-zinc-800/50 border-gray-200 dark:border-white/10 text-gray-500 dark:text-zinc-500 hover:text-sage-600 dark:hover:text-sage-400 hover:border-gray-300 dark:hover:border-white/10'}`}
+                className={`p-2 rounded-xl transition-all border disabled:cursor-wait disabled:opacity-60 ${searchProps.isAiSearchEnabled ? 'bg-amethyst-100 dark:bg-amethyst-600/20 border-amethyst-500/50 text-amethyst-600 dark:text-amethyst-300 shadow-[0_0_15px_rgba(139,92,246,0.2)]' : 'bg-gray-100 dark:bg-zinc-800/50 border-gray-200 dark:border-white/10 text-gray-500 dark:text-zinc-500 hover:text-sage-600 dark:hover:text-sage-400 hover:border-gray-300 dark:hover:border-white/10'}`}
             >
-                <Sparkles className="w-4 h-4" />
+                <Sparkles aria-hidden="true" className="w-4 h-4" />
             </TooltipButton>
         </div>
     );

--- a/src/features/filters/components/SearchBarPopover.tsx
+++ b/src/features/filters/components/SearchBarPopover.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { BookOpen, History } from 'lucide-react';
+
+export interface SearchBarOption {
+    id: string;
+    kind: 'operator' | 'recent';
+    value: string;
+    description?: string;
+}
+
+interface SearchBarPopoverProps {
+    activeOptionIndex: number;
+    dateSearchHint: string | null;
+    listboxId: string;
+    listLabel: string;
+    options: readonly SearchBarOption[];
+    statusId: string;
+    statusMessage: string | null;
+    onClearRecentSearches: () => void;
+    onOpenSearchHelp: () => void;
+    onSelectOption: (option: SearchBarOption) => void;
+}
+
+export const SearchBarPopover = React.memo(({
+    activeOptionIndex,
+    dateSearchHint,
+    listboxId,
+    listLabel,
+    options,
+    statusId,
+    statusMessage,
+    onClearRecentSearches,
+    onOpenSearchHelp,
+    onSelectOption,
+}: SearchBarPopoverProps) => (
+    <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-white/10 rounded-xl shadow-2xl z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
+        {dateSearchHint ? (
+            <div id={statusId} role="status" className="px-4 py-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-100 dark:border-amber-900/40">
+                {dateSearchHint}
+            </div>
+        ) : statusMessage ? (
+            <div id={statusId} role="status" aria-live="polite" className="px-4 py-2 text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-black/20 border-b border-gray-100 dark:border-white/5">
+                {statusMessage}
+            </div>
+        ) : null}
+
+        {options.length > 0 ? (
+            <div className="py-2">
+                <div className="px-4 py-1 text-[10px] font-bold text-gray-400 uppercase tracking-wider flex justify-between items-center">
+                    <span>{options[0].kind === 'recent' ? 'Recent Searches' : 'Suggestions'}</span>
+                    {options[0].kind === 'recent' ? (
+                        <button
+                            type="button"
+                            onClick={onClearRecentSearches}
+                            className="hover:text-red-500 transition-colors uppercase"
+                        >
+                            Clear recent searches
+                        </button>
+                    ) : null}
+                </div>
+                <div id={listboxId} role="listbox" aria-label={listLabel}>
+                    {options.map((option, index) => (
+                        <button
+                            key={`${option.kind}-${option.value}`}
+                            id={option.id}
+                            type="button"
+                            role="option"
+                            tabIndex={-1}
+                            aria-selected={activeOptionIndex === index}
+                            onMouseDown={event => event.preventDefault()}
+                            onClick={() => onSelectOption(option)}
+                            className={`w-full text-left px-4 py-2 text-sm transition-colors flex items-center gap-2 ${activeOptionIndex === index ? 'bg-sage-100 dark:bg-sage-900/40 text-sage-900 dark:text-sage-100' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-white/5'}`}
+                        >
+                            {option.kind === 'recent' ? <History aria-hidden="true" className="w-3 h-3 text-gray-400" /> : null}
+                            <span className={option.kind === 'operator' ? 'font-mono' : undefined}>{option.value}</span>
+                            {option.description ? <span className="ml-auto text-xs text-gray-400 truncate">{option.description}</span> : null}
+                        </button>
+                    ))}
+                </div>
+            </div>
+        ) : null}
+
+        <div className="border-t border-gray-100 dark:border-white/5 px-3 py-2 flex items-center justify-between gap-3">
+            <span className="text-[10px] text-gray-400">Plain text searches positive prompts.</span>
+            <button
+                type="button"
+                onClick={onOpenSearchHelp}
+                className="shrink-0 inline-flex items-center gap-1.5 text-xs font-medium text-sage-600 hover:text-sage-800 dark:text-sage-400 dark:hover:text-sage-200"
+            >
+                <BookOpen aria-hidden="true" className="w-3 h-3" />
+                Search syntax
+            </button>
+        </div>
+    </div>
+));

--- a/src/features/filters/components/__tests__/ActiveFilters.test.tsx
+++ b/src/features/filters/components/__tests__/ActiveFilters.test.tsx
@@ -101,7 +101,6 @@ describe('ActiveFilters', () => {
             { loras: ['lora'] },
             { embeddings: ['embedding'] },
             { hypernetworks: ['hyper'] },
-            { searchQuery: 'query' },
             { samplers: ['Euler'] },
             { generationTypes: ['txt2img'] },
             { minSteps: 1 },
@@ -124,6 +123,12 @@ describe('ActiveFilters', () => {
         searchMocks.state.filters = createFilters({ collectionId: 'regular' });
         render(<ActiveFiltersUnderTest />);
         expect(screen.getByRole('button', { name: /clear all/i })).toBeTruthy();
+    });
+
+    it('does not render a second filter strip for a navbar-query-only search', () => {
+        searchMocks.state.filters = createFilters({ searchQuery: 'query' });
+        const { container } = render(<ActiveFiltersUnderTest />);
+        expect(container.innerHTML).toBe('');
     });
 
     it('renders locked smart rules and deduplicates matching explicit chips', () => {

--- a/src/features/filters/components/__tests__/SearchBar.accessibility.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.accessibility.test.tsx
@@ -79,10 +79,10 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.toggleAiSearch).toHaveBeenCalledTimes(1);
     });
 
-    it('connects the combobox to its listbox and exposes keyboard selection', () => {
+    it('connects the combobox to its deferred listbox and exposes keyboard selection', async () => {
         const harness = renderSearchBar(createDefaultFilters(), {}, ['sunset']);
         const input = screen.getByRole('combobox', { name: 'Search in Library' });
-        const listbox = screen.getByRole('listbox', { name: 'Recent searches' });
+        const listbox = await screen.findByRole('listbox', { name: 'Recent searches' });
         const option = screen.getByRole('option', { name: 'sunset' });
 
         expect(input.getAttribute('aria-controls')).toBe(listbox.id);
@@ -94,11 +94,11 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('sunset');
     });
 
-    it('dismisses suggestions with Escape and opens search syntax help directly', () => {
+    it('dismisses deferred suggestions with Escape and opens search syntax help directly', async () => {
         const harness = renderSearchBar();
         const input = screen.getByRole('combobox', { name: 'Search in Library' });
         fireEvent.change(input, { target: { value: 'cn' } });
-        expect(screen.getByRole('listbox', { name: 'Search operator suggestions' })).toBeTruthy();
+        expect(await screen.findByRole('listbox', { name: 'Search operator suggestions' })).toBeTruthy();
 
         fireEvent.keyDown(input, { key: 'Escape' });
         expect(screen.queryByRole('listbox')).toBeNull();

--- a/src/features/filters/components/__tests__/SearchBar.accessibility.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.accessibility.test.tsx
@@ -22,12 +22,14 @@ const createSearchProps = (overrides: Partial<React.ComponentProps<typeof Search
     isFocused: true,
     onFocus: vi.fn(),
     onBlur: vi.fn(),
+    onOpenSearchHelp: vi.fn(),
     ...overrides,
 });
 
 const renderSearchBar = (
     initialFilters: FilterState = createDefaultFilters(),
     searchOverrides: Partial<React.ComponentProps<typeof SearchBar>['searchProps']> = {},
+    recentSearches: string[] = [],
 ) => {
     let currentFilters = initialFilters;
     const setFilters = vi.fn((update: React.SetStateAction<FilterState>) => {
@@ -47,8 +49,12 @@ const renderSearchBar = (
             filters={currentFilters}
             setFilters={setFilters}
             searchProps={searchProps}
-            recentSearches={[]}
+            recentSearches={recentSearches}
             setRecentSearches={vi.fn()}
+            scopeName="Library"
+            displayedCount={10}
+            isFiltering={false}
+            submitNavigatesToGrid={false}
         />
     );
 
@@ -71,5 +77,33 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(screen.getByRole('tooltip').textContent).toContain('natural-language');
         fireEvent.click(aiButton);
         expect(harness.searchProps.toggleAiSearch).toHaveBeenCalledTimes(1);
+    });
+
+    it('connects the combobox to its listbox and exposes keyboard selection', () => {
+        const harness = renderSearchBar(createDefaultFilters(), {}, ['sunset']);
+        const input = screen.getByRole('combobox', { name: 'Search in Library' });
+        const listbox = screen.getByRole('listbox', { name: 'Recent searches' });
+        const option = screen.getByRole('option', { name: 'sunset' });
+
+        expect(input.getAttribute('aria-controls')).toBe(listbox.id);
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        expect(input.getAttribute('aria-activedescendant')).toBe(option.id);
+        expect(option.getAttribute('aria-selected')).toBe('true');
+
+        fireEvent.keyDown(input, { key: 'Enter' });
+        expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('sunset');
+    });
+
+    it('dismisses suggestions with Escape and opens search syntax help directly', () => {
+        const harness = renderSearchBar();
+        const input = screen.getByRole('combobox', { name: 'Search in Library' });
+        fireEvent.change(input, { target: { value: 'cn' } });
+        expect(screen.getByRole('listbox', { name: 'Search operator suggestions' })).toBeTruthy();
+
+        fireEvent.keyDown(input, { key: 'Escape' });
+        expect(screen.queryByRole('listbox')).toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Search syntax' }));
+        expect(harness.searchProps.onOpenSearchHelp).toHaveBeenCalledOnce();
     });
 });

--- a/src/features/filters/components/__tests__/SearchBar.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.test.tsx
@@ -75,6 +75,15 @@ const renderSearchBar = (initialFilters: FilterState = createDefaultFilters(), o
     };
 };
 
+const flushSearchPopover = async () => {
+    await act(async () => {
+        await Promise.all([
+            import('../SearchBarPopover'),
+            import('../../../../constants/searchOperators'),
+        ]);
+    });
+};
+
 describe('SearchBar advanced date syntax guard', () => {
     beforeEach(() => {
         vi.useFakeTimers();
@@ -85,8 +94,9 @@ describe('SearchBar advanced date syntax guard', () => {
         vi.useRealTimers();
     });
 
-    it('keeps incomplete date syntax local and shows a hint', () => {
+    it('keeps incomplete date syntax local and shows a hint', async () => {
         const harness = renderSearchBar();
+        await flushSearchPopover();
 
         fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
             target: { value: 'date:2026-' },
@@ -128,8 +138,9 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.submitSearch).not.toHaveBeenCalled();
     });
 
-    it('does not commit a date operator suggestion before a value exists', () => {
+    it('does not commit a date operator suggestion before a value exists', async () => {
         const harness = renderSearchBar();
+        await flushSearchPopover();
 
         fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
             target: { value: 'dat' },
@@ -168,8 +179,9 @@ describe('SearchBar advanced date syntax guard', () => {
         expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('external');
     });
 
-    it('navigates suggestions with arrows and selects with Enter and Tab', () => {
+    it('navigates suggestions with arrows and selects with Enter and Tab', async () => {
         const harness = renderSearchBar();
+        await flushSearchPopover();
         const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'to' } });
         expect(screen.getByRole('option', { name: /tool:/ })).not.toBeNull();
@@ -186,8 +198,9 @@ describe('SearchBar advanced date syntax guard', () => {
         expect((input as HTMLInputElement).value).toBe('model: x file: ');
     });
 
-    it('falls through unrelated keys and submits when no suggestion is active', () => {
+    it('falls through unrelated keys and submits when no suggestion is active', async () => {
         const harness = renderSearchBar();
+        await flushSearchPopover();
         const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'to' } });
         fireEvent.keyDown(input, { key: 'Escape' });
@@ -199,8 +212,9 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.submitSearch).toHaveBeenCalledTimes(1);
     });
 
-    it('selects suggestions with the pointer and clears suggestions for blank tokens', () => {
+    it('selects suggestions with the pointer and clears suggestions for blank tokens', async () => {
         renderSearchBar();
+        await flushSearchPopover();
         const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'lo' } });
         fireEvent.click(screen.getByRole('option', { name: /lora:/ }));
@@ -229,9 +243,10 @@ describe('SearchBar advanced date syntax guard', () => {
         focus.mockRestore();
     });
 
-    it('clears and runs recent searches without blurring', () => {
+    it('clears and runs recent searches without blurring', async () => {
         const setRecentSearches = vi.fn();
         const harness = renderSearchBar(createDefaultFilters(), { recentSearches: ['sunset'], setRecentSearches });
+        await flushSearchPopover();
         const clear = screen.getByRole('button', { name: 'Clear recent searches' });
         fireEvent.click(clear);
         expect(setRecentSearches).toHaveBeenCalledWith([]);
@@ -257,11 +272,12 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.toggleAiSearch).not.toHaveBeenCalled();
     });
 
-    it('keeps dashboard drafts local until Enter routes the submitted query', () => {
+    it('keeps dashboard drafts local until Enter routes the submitted query', async () => {
         const harness = renderSearchBar(createDefaultFilters(), {
             scopeName: 'Statistics',
             submitNavigatesToGrid: true,
         });
+        await flushSearchPopover();
         const input = screen.getByRole('combobox', { name: 'Search in Statistics' });
 
         fireEvent.change(input, { target: { value: 'portrait' } });
@@ -274,11 +290,12 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('portrait');
     });
 
-    it('shows scope-aware no-match feedback for an applied query', () => {
+    it('shows scope-aware no-match feedback for an applied query', async () => {
         renderSearchBar(createDefaultFilters({ searchQuery: 'missing' }), {
             scopeName: 'Collection: Favorites',
             displayedCount: 0,
         });
+        await flushSearchPopover();
 
         expect(screen.getByRole('status').textContent).toBe('No matches in Collection: Favorites.');
     });

--- a/src/features/filters/components/__tests__/SearchBar.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.test.tsx
@@ -22,6 +22,7 @@ const createSearchProps = (overrides: Partial<React.ComponentProps<typeof Search
     isFocused: true,
     onFocus: vi.fn(),
     onBlur: vi.fn(),
+    onOpenSearchHelp: vi.fn(),
     ...overrides,
 });
 
@@ -29,6 +30,10 @@ interface SearchHarnessOptions {
     searchProps?: Partial<React.ComponentProps<typeof SearchBar>['searchProps']>;
     recentSearches?: string[];
     setRecentSearches?: React.Dispatch<React.SetStateAction<string[]>>;
+    scopeName?: string;
+    displayedCount?: number;
+    isFiltering?: boolean;
+    submitNavigatesToGrid?: boolean;
 }
 
 const renderSearchBar = (initialFilters: FilterState = createDefaultFilters(), options: SearchHarnessOptions = {}) => {
@@ -53,6 +58,10 @@ const renderSearchBar = (initialFilters: FilterState = createDefaultFilters(), o
             searchProps={searchProps}
             recentSearches={options.recentSearches ?? []}
             setRecentSearches={setRecentSearches}
+            scopeName={options.scopeName ?? 'Library'}
+            displayedCount={options.displayedCount ?? 10}
+            isFiltering={options.isFiltering ?? false}
+            submitNavigatesToGrid={options.submitNavigatesToGrid ?? false}
         />
     );
 
@@ -79,7 +88,7 @@ describe('SearchBar advanced date syntax guard', () => {
     it('keeps incomplete date syntax local and shows a hint', () => {
         const harness = renderSearchBar();
 
-        fireEvent.change(screen.getByPlaceholderText('Search prompt...'), {
+        fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
             target: { value: 'date:2026-' },
         });
 
@@ -94,7 +103,7 @@ describe('SearchBar advanced date syntax guard', () => {
     it('commits valid date syntax after the main debounce', () => {
         const harness = renderSearchBar();
 
-        fireEvent.change(screen.getByPlaceholderText('Search prompt...'), {
+        fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
             target: { value: 'date:2026-04' },
         });
 
@@ -108,7 +117,7 @@ describe('SearchBar advanced date syntax guard', () => {
 
     it('does not submit invalid date syntax on Enter', () => {
         const harness = renderSearchBar();
-        const input = screen.getByPlaceholderText('Search prompt...');
+        const input = screen.getByRole('combobox', { name: 'Search in Library' });
 
         fireEvent.change(input, {
             target: { value: 'before:june-2024' },
@@ -122,17 +131,17 @@ describe('SearchBar advanced date syntax guard', () => {
     it('does not commit a date operator suggestion before a value exists', () => {
         const harness = renderSearchBar();
 
-        fireEvent.change(screen.getByPlaceholderText('Search prompt...'), {
+        fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
             target: { value: 'dat' },
         });
-        fireEvent.mouseDown(screen.getByRole('button', { name: 'date:' }));
+        fireEvent.click(screen.getByRole('option', { name: /date:/ }));
 
         expect(harness.setFilters).not.toHaveBeenCalled();
     });
 
     it('replaces a pending debounce and commits only the latest query', () => {
         const harness = renderSearchBar();
-        const input = screen.getByPlaceholderText('Search prompt...');
+        const input = screen.getByRole('combobox', { name: 'Search in Library' });
         fireEvent.change(input, { target: { value: 'first' } });
         fireEvent.change(input, { target: { value: 'second' } });
         act(() => vi.advanceTimersByTime(500));
@@ -150,16 +159,20 @@ describe('SearchBar advanced date syntax guard', () => {
                 searchProps={harness.searchProps}
                 recentSearches={[]}
                 setRecentSearches={harness.setRecentSearches}
+                scopeName="Library"
+                displayedCount={10}
+                isFiltering={false}
+                submitNavigatesToGrid={false}
             />
         );
-        expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('external');
+        expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('external');
     });
 
     it('navigates suggestions with arrows and selects with Enter and Tab', () => {
         const harness = renderSearchBar();
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'to' } });
-        expect(screen.getByRole('button', { name: 'tool:' })).not.toBeNull();
+        expect(screen.getByRole('option', { name: /tool:/ })).not.toBeNull();
         fireEvent.keyDown(input, { key: 'ArrowDown' });
         fireEvent.keyDown(input, { key: 'ArrowUp' });
         fireEvent.keyDown(input, { key: 'ArrowDown' });
@@ -175,7 +188,7 @@ describe('SearchBar advanced date syntax guard', () => {
 
     it('falls through unrelated keys and submits when no suggestion is active', () => {
         const harness = renderSearchBar();
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'to' } });
         fireEvent.keyDown(input, { key: 'Escape' });
         fireEvent.keyDown(input, { key: 'Enter' });
@@ -188,9 +201,9 @@ describe('SearchBar advanced date syntax guard', () => {
 
     it('selects suggestions with the pointer and clears suggestions for blank tokens', () => {
         renderSearchBar();
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'lo' } });
-        fireEvent.mouseDown(screen.getByRole('button', { name: 'lora:' }));
+        fireEvent.click(screen.getByRole('option', { name: /lora:/ }));
         expect((input as HTMLInputElement).value).toBe('lora: ');
         fireEvent.change(input, { target: { value: ' ' } });
         expect(screen.queryByText('Suggestions')).toBeNull();
@@ -198,10 +211,10 @@ describe('SearchBar advanced date syntax guard', () => {
 
     it('submits ordinary searches on Enter', () => {
         const harness = renderSearchBar();
-        const input = screen.getByRole('textbox');
+        const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'portrait' } });
         fireEvent.keyDown(input, { key: 'Enter' });
-        expect(harness.getCurrentFilters().searchQuery).toBe('portrait');
+        expect(harness.setFilters).not.toHaveBeenCalled();
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('portrait');
     });
 
@@ -209,9 +222,9 @@ describe('SearchBar advanced date syntax guard', () => {
         const inputRef = React.createRef<HTMLInputElement>();
         const focus = vi.spyOn(HTMLInputElement.prototype, 'focus');
         const harness = renderSearchBar(createDefaultFilters({ searchQuery: 'portrait' }), { searchProps: { inputRef } });
-        fireEvent.click(screen.getAllByRole('button')[0]);
+        fireEvent.click(screen.getByRole('button', { name: 'Clear Search' }));
         expect(harness.getCurrentFilters().searchQuery).toBe('');
-        expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('');
+        expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('');
         expect(focus).toHaveBeenCalled();
         focus.mockRestore();
     });
@@ -219,25 +232,69 @@ describe('SearchBar advanced date syntax guard', () => {
     it('clears and runs recent searches without blurring', () => {
         const setRecentSearches = vi.fn();
         const harness = renderSearchBar(createDefaultFilters(), { recentSearches: ['sunset'], setRecentSearches });
-        const clear = screen.getByRole('button', { name: 'Clear' });
-        fireEvent.mouseDown(clear);
+        const clear = screen.getByRole('button', { name: 'Clear recent searches' });
+        fireEvent.click(clear);
         expect(setRecentSearches).toHaveBeenCalledWith([]);
-        fireEvent.mouseDown(screen.getByRole('button', { name: /sunset/i }));
+        fireEvent.click(screen.getByRole('option', { name: /sunset/i }));
         act(() => vi.runOnlyPendingTimers());
-        expect(harness.getCurrentFilters().searchQuery).toBe('sunset');
+        expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('sunset');
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('sunset');
     });
 
-    it('forwards focus, blur, and AI toggle behavior in enabled and searching states', () => {
+    it('forwards focus and blur while locking controls during AI analysis', () => {
         const harness = renderSearchBar(createDefaultFilters(), {
             searchProps: { isAiSearchEnabled: true, isSearchingAi: true, isFocused: false },
         });
-        const input = screen.getByPlaceholderText('Ask Ambit...');
+        const input = screen.getByRole('combobox', { name: 'Ask Ambit with AI' });
         fireEvent.focus(input);
         fireEvent.blur(input);
-        fireEvent.click(screen.getByRole('button', { name: 'Disable AI Search' }));
+        const aiButton = screen.getByRole('button', { name: 'Disable AI Search' });
         expect(harness.searchProps.onFocus).toHaveBeenCalledOnce();
         expect(harness.searchProps.onBlur).toHaveBeenCalledOnce();
-        expect(harness.searchProps.toggleAiSearch).toHaveBeenCalledOnce();
+        expect((aiButton as HTMLButtonElement).disabled).toBe(true);
+        expect(input.getAttribute('aria-busy')).toBe('true');
+        expect((input as HTMLInputElement).readOnly).toBe(true);
+        expect(harness.searchProps.toggleAiSearch).not.toHaveBeenCalled();
+    });
+
+    it('keeps dashboard drafts local until Enter routes the submitted query', () => {
+        const harness = renderSearchBar(createDefaultFilters(), {
+            scopeName: 'Statistics',
+            submitNavigatesToGrid: true,
+        });
+        const input = screen.getByRole('combobox', { name: 'Search in Statistics' });
+
+        fireEvent.change(input, { target: { value: 'portrait' } });
+        act(() => vi.advanceTimersByTime(600));
+
+        expect(harness.setFilters).not.toHaveBeenCalled();
+        expect(screen.getByRole('status').textContent).toBe('Press Enter to view matching images in Grid.');
+
+        fireEvent.keyDown(input, { key: 'Enter' });
+        expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('portrait');
+    });
+
+    it('shows scope-aware no-match feedback for an applied query', () => {
+        renderSearchBar(createDefaultFilters({ searchQuery: 'missing' }), {
+            scopeName: 'Collection: Favorites',
+            displayedCount: 0,
+        });
+
+        expect(screen.getByRole('status').textContent).toBe('No matches in Collection: Favorites.');
+    });
+
+    it('keeps AI prompts submit-only', () => {
+        const harness = renderSearchBar(createDefaultFilters({ searchQuery: 'existing' }), {
+            searchProps: { isAiSearchEnabled: true },
+        });
+        const input = screen.getByRole('combobox', { name: 'Ask Ambit with AI' });
+
+        fireEvent.change(input, { target: { value: 'warm portraits from last month' } });
+        act(() => vi.advanceTimersByTime(600));
+
+        expect(harness.setFilters).not.toHaveBeenCalled();
+        expect(screen.queryByRole('listbox')).toBeNull();
+        fireEvent.keyDown(input, { key: 'Enter' });
+        expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('warm portraits from last month');
     });
 });

--- a/src/hooks/__tests__/useAiSearchLogic.test.tsx
+++ b/src/hooks/__tests__/useAiSearchLogic.test.tsx
@@ -118,6 +118,8 @@ describe('useAiSearchLogic', () => {
 
     it('should call Gemini if AI search is enabled', async () => {
         const { result } = renderHook(() => useAiSearchLogic(props));
+        const blur = vi.fn();
+        result.current.inputRef.current = { blur } as unknown as HTMLInputElement;
 
         // Turn it on first
         act(() => {
@@ -142,8 +144,8 @@ describe('useAiSearchLogic', () => {
             undefined,
             'default'
         );
-        expect(mockSetFilters).toHaveBeenCalledTimes(2); // Local set + AI results set
-        const aiUpdate = mockSetFilters.mock.calls[1][0] as (prev: FilterState) => FilterState;
+        expect(mockSetFilters).toHaveBeenCalledTimes(1);
+        const aiUpdate = mockSetFilters.mock.calls[0][0] as (prev: FilterState) => FilterState;
         expect(aiUpdate(mockFilters)).toMatchObject({
             searchQuery: 'sunset',
             models: ['SDXL'],
@@ -152,6 +154,7 @@ describe('useAiSearchLogic', () => {
             dateTo: '2026-04-30'
         });
         expect(mockAddToast).toHaveBeenCalledWith('Filters updated by AI', 'success');
+        expect(blur).toHaveBeenCalledOnce();
     });
 
     it('should forward the FILTERS prompt override when developer features are enabled', async () => {
@@ -190,6 +193,9 @@ describe('useAiSearchLogic', () => {
 
     it('should handle AI search failure gracefully', async () => {
         const { result } = renderHook(() => useAiSearchLogic(props));
+        const focus = vi.fn();
+        const blur = vi.fn();
+        result.current.inputRef.current = { focus, blur } as unknown as HTMLInputElement;
 
         act(() => {
             result.current.toggleAiSearch();
@@ -202,6 +208,9 @@ describe('useAiSearchLogic', () => {
         });
 
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('failed'), 'error');
+        expect(mockSetFilters).not.toHaveBeenCalled();
+        expect(focus).toHaveBeenCalledOnce();
+        expect(blur).not.toHaveBeenCalled();
     });
 
     it('activates pending AI search after Settings enables the feature and focuses the input', async () => {
@@ -252,13 +261,37 @@ describe('useAiSearchLogic', () => {
 
         await act(async () => result.current.submitSearch('anything'));
 
-        const update = mockSetFilters.mock.calls[1][0] as (filters: FilterState) => FilterState;
+        const update = mockSetFilters.mock.calls[0][0] as (filters: FilterState) => FilterState;
         expect(update({ ...mockFilters, favoritesOnly: true })).toMatchObject({
             searchQuery: '',
             models: [],
             tools: [],
             dateRange: 'all',
             favoritesOnly: false,
+        });
+    });
+
+    it('ignores repeated AI submissions while the first request is active', async () => {
+        let resolveFilters: ((value: Record<string, never>) => void) | undefined;
+        const pendingFilters = new Promise<Record<string, never>>(resolve => {
+            resolveFilters = resolve;
+        });
+        const { result } = renderHook(() => useAiSearchLogic(props));
+        act(() => result.current.toggleAiSearch());
+        mockGenerateFilters.mockReturnValue(pendingFilters);
+
+        let firstRequest: Promise<void> | undefined;
+        await act(async () => {
+            firstRequest = result.current.submitSearch('find portraits');
+            await result.current.submitSearch('find portraits');
+        });
+
+        expect(mockGenerateFilters).toHaveBeenCalledOnce();
+        expect(mockSetRecentSearches).toHaveBeenCalledOnce();
+
+        await act(async () => {
+            resolveFilters?.({});
+            await firstRequest;
         });
     });
 });

--- a/src/hooks/useAiSearchLogic.ts
+++ b/src/hooks/useAiSearchLogic.ts
@@ -33,6 +33,7 @@ export const useAiSearchLogic = ({
   const [pendingAiActivation, setPendingAiActivation] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const isAiRequestActiveRef = useRef(false);
 
   // Sync state: If global setting is disabled, force local state off immediately
   useEffect(() => {
@@ -72,11 +73,10 @@ export const useAiSearchLogic = ({
     const trimmed = query.trim();
     if (!trimmed) return;
 
-    setFilters(f => ({ ...f, searchQuery: trimmed }));
-    setRecentSearches(prev => [trimmed, ...prev.filter(s => s !== trimmed)].slice(0, 8));
-    inputRef.current?.blur();
-
     if (isAiSearchEnabled && settings.enableAI) {
+      if (isAiRequestActiveRef.current) return;
+      isAiRequestActiveRef.current = true;
+      setRecentSearches(prev => [trimmed, ...prev.filter(s => s !== trimmed)].slice(0, 8));
       const apiKey = useSettingsStore.getState().geminiApiKey;
       setIsSearchingAi(true);
       addToast("Gemini is analyzing your request...", "info");
@@ -103,12 +103,20 @@ export const useAiSearchLogic = ({
           favoritesOnly: aiFilters.favoritesOnly || false,
         }));
         addToast("Filters updated by AI", "success");
+        inputRef.current?.blur();
       } catch (error) {
         addToast("AI Search failed. Check API Key.", "error");
+        inputRef.current?.focus();
       } finally {
+        isAiRequestActiveRef.current = false;
         setIsSearchingAi(false);
       }
+      return;
     }
+
+    setFilters(f => ({ ...f, searchQuery: trimmed }));
+    setRecentSearches(prev => [trimmed, ...prev.filter(s => s !== trimmed)].slice(0, 8));
+    inputRef.current?.blur();
   };
 
   return {


### PR DESCRIPTION
## Summary

- make navbar search behavior view-aware: Grid and Timeline remain live-debounced, while Statistics and Maintenance submit explicitly and route results to Grid
- add scope-aware match/loading feedback, accessible combobox navigation, recent-search actions, and direct Search Syntax help
- make AI search submit-only, preserve active filters until Gemini succeeds, and prevent duplicate requests
- centralize supported search operators for suggestions and the help dialog
- remove the redundant query-only active-filter strip and update the user manual

## Why

The navbar search looked global but behaved ambiguously outside image-browsing views, exposed little feedback about scope or results, and temporarily applied AI prompts as ordinary text searches. This makes submission and navigation predictable while improving keyboard and screen-reader support.

## User impact

Users can see where they are searching and how many matches were found. Statistics and Maintenance searches now open Grid only after an explicit submission. AI drafts no longer replace active filters before a successful analysis.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- focused search/navigation suite: 96 tests passed
- final syntax-reference regression suite: 20 tests passed
- repository suite: 2,740 passed and 1 skipped; one unrelated DonationModal test timed out under aggregate load and passed when rerun alone
- `git diff --check`
