### PR TITLE
fix: persist smart collection counts

### DIFF
--- a/src-tauri/src/db/migrations/m62_smart_collection_count_cache.rs
+++ b/src-tauri/src/db/migrations/m62_smart_collection_count_cache.rs
@@ -1,0 +1,66 @@
+use tauri_plugin_sql::Migration;
+
+/// Migration 62: Cache the last calculated count for smart collections.
+pub fn migration62() -> Migration {
+    Migration {
+        version: 62,
+        description: "add_smart_collection_count_cache",
+        sql: r#"
+            ALTER TABLE collections ADD COLUMN dynamic_count INTEGER;
+        "#,
+        kind: tauri_plugin_sql::MigrationKind::Up,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::migration62;
+
+    #[test]
+    fn migration_adds_nullable_dynamic_count_and_preserves_existing_rows() {
+        let conn = rusqlite::Connection::open_in_memory().expect("in-memory db");
+        conn.execute_batch(
+            "
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            );
+
+            INSERT INTO collections (id, name, created_at)
+            VALUES ('existing', 'Existing collection', 123);
+            ",
+        )
+        .expect("setup schema");
+
+        conn.execute_batch(migration62().sql)
+            .expect("apply migration");
+
+        let column: (String, String, i64) = conn
+            .query_row(
+                "SELECT name, type, \"notnull\"
+                 FROM pragma_table_info('collections')
+                 WHERE name = 'dynamic_count'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("dynamic_count column");
+
+        assert_eq!(column, ("dynamic_count".into(), "INTEGER".into(), 0));
+
+        let existing: (String, String, i64, Option<i64>) = conn
+            .query_row(
+                "SELECT id, name, created_at, dynamic_count
+                 FROM collections
+                 WHERE id = 'existing'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .expect("existing collection");
+
+        assert_eq!(
+            existing,
+            ("existing".into(), "Existing collection".into(), 123, None)
+        );
+    }
+}

--- a/src-tauri/src/db/migrations/mod.rs
+++ b/src-tauri/src/db/migrations/mod.rs
@@ -28,6 +28,7 @@ pub mod m58_nullable_seed;
 pub mod m59_canonical_resource_lookup_indexes;
 pub mod m60_resource_inventory_cleanup;
 pub mod m61_auxiliary_resource_inventory_cleanup;
+pub mod m62_smart_collection_count_cache;
 
 pub fn init_db() -> Vec<Migration> {
     get_migrations()
@@ -65,6 +66,7 @@ pub fn get_migrations() -> Vec<Migration> {
     migrations.push(m59_canonical_resource_lookup_indexes::migration59());
     migrations.push(m60_resource_inventory_cleanup::migration60());
     migrations.push(m61_auxiliary_resource_inventory_cleanup::migration61());
+    migrations.push(m62_smart_collection_count_cache::migration62());
 
     migrations.sort_by_key(|m| m.version);
 
@@ -76,7 +78,7 @@ mod tests {
     use super::get_migrations;
 
     #[test]
-    fn migrations_include_mainline_through_auxiliary_resource_inventory_cleanup_61() {
+    fn migrations_include_mainline_through_smart_collection_count_cache_62() {
         let versions: Vec<i64> = get_migrations()
             .iter()
             .map(|migration| migration.version)
@@ -95,6 +97,7 @@ mod tests {
         assert!(versions.contains(&59));
         assert!(versions.contains(&60));
         assert!(versions.contains(&61));
+        assert!(versions.contains(&62));
     }
 
     #[test]
@@ -120,8 +123,7 @@ mod tests {
     }
 
     #[test]
-    fn database_at_mainline_49_has_migrations_through_auxiliary_resource_inventory_cleanup_61_pending(
-    ) {
+    fn database_at_mainline_49_has_migrations_through_smart_collection_count_cache_62_pending() {
         let migrations = get_migrations();
         let has_49 = migrations.iter().any(|migration| migration.version == 49);
         let pending_after_49: Vec<i64> = migrations
@@ -133,7 +135,7 @@ mod tests {
         assert!(has_49);
         assert_eq!(
             pending_after_49,
-            vec![50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61]
+            vec![50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62]
         );
     }
 }

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -28,6 +28,7 @@ import { useLibraryStore } from '../stores/libraryStore';
 import { patchImageFlagsInQueryCaches, restoreImagesInQueryCaches } from '../utils/imageQueryCache';
 import { applyOptimisticPinOrder } from '../utils/imageOptimisticUpdates';
 import { useSettingsStore } from '../stores/settingsStore';
+import { useCollectionStore } from '../stores/collectionStore';
 import { privacyMaskRefreshCoordinator } from '../utils/privacyMaskRefreshCoordinator';
 
 interface SearchContextType {
@@ -95,6 +96,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     const privacyMaskIndexStatus = useSettingsStore(state => state.privacyMaskIndexStatus);
     const privacyMaskIndexRetryToken = useSettingsStore(state => state.privacyMaskIndexRetryToken);
     const setPrivacyMaskIndexState = useSettingsStore(state => state.setPrivacyMaskIndexState);
+    const refreshSmartCounts = useCollectionStore(state => state.refreshSmartCounts);
 
 
 
@@ -312,7 +314,19 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
         await Promise.all(refreshTasks);
     }, [queryClient, refreshCollections]);
 
+    const refreshCollectionsAfterImageFlagChange = useCallback(() => {
+        void refreshCollections(true);
 
+        const activeCollectionId = useSearchStore.getState().filters.collectionId;
+        if (!activeCollectionId) return;
+
+        void refreshSmartCounts({
+            collectionIds: [activeCollectionId],
+            includeArchived: true,
+            includePromptSearch: true,
+            markPending: true
+        });
+    }, [refreshCollections, refreshSmartCounts]);
 
     const toggleFavorite = useCallback(async (id: string) => {
         const imgs = useSearchStore.getState().images;
@@ -324,12 +338,13 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
             setImages(imgs.map(i => i.id === id ? { ...i, isFavorite: newVal } : i));
             patchImageFlagsInQueryCaches(queryClient, [id], { isFavorite: newVal });
             await updateFavorite(id, newVal);
+            refreshCollectionsAfterImageFlagChange();
         } catch (e) {
             console.error("Toggle favorite failed", e);
             setImages(imgs);
             restoreImagesInQueryCaches(queryClient, imgs);
         }
-    }, [queryClient, setImages]);
+    }, [queryClient, refreshCollectionsAfterImageFlagChange, setImages]);
 
     const togglePin = useCallback(async (id: string, isPinned?: boolean) => {
         const imgs = useSearchStore.getState().images;
@@ -346,6 +361,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                 reorderQueryKey: imagesQueryKey
             });
             await updatePinned(id, newVal);
+            refreshCollectionsAfterImageFlagChange();
         } catch (e) {
             console.error("Toggle pin failed", e);
             setImages(imgs);
@@ -355,7 +371,7 @@ export const SearchProvider: React.FC<{ children: ReactNode }> = ({ children }) 
                 reorderQueryKey: imagesQueryKey
             });
         }
-    }, [filters.collectionId, imagesQueryKey, queryClient, setImages]);
+    }, [filters.collectionId, imagesQueryKey, queryClient, refreshCollectionsAfterImageFlagChange, setImages]);
 
     // ... Missing: setRecentSearches, loadFacet, availableHiddenContent
     // Store doesn't have recentSearches yet.

--- a/src/contexts/__tests__/SearchContext.test.tsx
+++ b/src/contexts/__tests__/SearchContext.test.tsx
@@ -38,7 +38,8 @@ const mocks = vi.hoisted(() => ({
     restoreImagesInQueryCaches: vi.fn(),
     applyOptimisticPinOrder: vi.fn(),
     incrementFacetCacheVersion: vi.fn(),
-    shouldPrefetchResultPages: vi.fn()
+    shouldPrefetchResultPages: vi.fn(),
+    refreshSmartCounts: vi.fn()
 }));
 
 vi.mock('../SettingsContext', () => ({ useSettings: () => mocks.settings.current }));
@@ -75,6 +76,10 @@ vi.mock('../../services/db/collectionRepo', () => ({
 }));
 vi.mock('../../stores/libraryStore', () => ({
     useLibraryStore: { getState: () => ({ incrementFacetCacheVersion: mocks.incrementFacetCacheVersion }) }
+}));
+vi.mock('../../stores/collectionStore', () => ({
+    useCollectionStore: (selector: (state: { refreshSmartCounts: typeof mocks.refreshSmartCounts }) => unknown) =>
+        selector({ refreshSmartCounts: mocks.refreshSmartCounts })
 }));
 vi.mock('../../utils/imageQueryCache', () => ({
     patchImageFlagsInQueryCaches: mocks.patchImageFlagsInQueryCaches,
@@ -325,6 +330,7 @@ describe('SearchProvider', () => {
         const untouched = image({ id: 'image-2' });
         const pinned = image({ isPinned: true });
         (mocks.searchState.current as SearchValue).images = [original, untouched];
+        (mocks.searchState.current as SearchValue).filters = { ...baseFilters, collectionId: 'smart-prompt' };
         mocks.applyOptimisticPinOrder.mockReturnValue([pinned]);
         renderProvider();
 
@@ -335,6 +341,18 @@ describe('SearchProvider', () => {
 
         expect(mocks.updateFavorite).toHaveBeenCalledWith(original.id, true);
         expect(mocks.updatePinned).toHaveBeenCalledWith(original.id, true);
+        const refreshCollections = (mocks.collections.current as {
+            refreshCollections: ReturnType<typeof vi.fn>;
+        }).refreshCollections;
+        expect(refreshCollections).toHaveBeenCalledTimes(2);
+        expect(refreshCollections).toHaveBeenCalledWith(true);
+        expect(mocks.refreshSmartCounts).toHaveBeenCalledTimes(2);
+        expect(mocks.refreshSmartCounts).toHaveBeenCalledWith({
+            collectionIds: ['smart-prompt'],
+            includeArchived: true,
+            includePromptSearch: true,
+            markPending: true
+        });
         expect(mocks.patchImageFlagsInQueryCaches).toHaveBeenCalledWith(mocks.queryClient, [original.id], { isFavorite: true });
         const optimisticFavoriteImages = ((mocks.searchState.current as SearchValue).setImages as ReturnType<typeof vi.fn>).mock.calls[0][0] as AIImage[];
         expect(optimisticFavoriteImages[1]).toBe(untouched);
@@ -342,7 +360,7 @@ describe('SearchProvider', () => {
             [expect.objectContaining({ id: original.id, isFavorite: true }), untouched],
             [original.id],
             true,
-            false
+            true
         );
     });
 

--- a/src/features/collections/components/AddToCollectionModal.tsx
+++ b/src/features/collections/components/AddToCollectionModal.tsx
@@ -8,6 +8,7 @@ import { PrivacyAwareThumbnail } from '../../../components/ui/PrivacyAwareThumbn
 import { CollectionThumbnailSkeleton } from '../../../components/ui/CollectionThumbnailSkeleton';
 import { useCollectionStore } from '../../../stores/collectionStore';
 import { TooltipButton } from '../../../components/ui/InfoTooltip';
+import { compareCollectionsByCount, getCollectionCount } from '../../../utils/collectionCount';
 
 interface AddToCollectionModalProps {
     isOpen: boolean;
@@ -77,8 +78,8 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
             switch (sort) {
                 case 'name_asc': return a.name.localeCompare(b.name);
                 case 'name_desc': return b.name.localeCompare(a.name);
-                case 'count_asc': return (a.count ?? a.imageIds.length) - (b.count ?? b.imageIds.length);
-                case 'count_desc': return (b.count ?? b.imageIds.length) - (a.count ?? a.imageIds.length);
+                case 'count_asc': return compareCollectionsByCount(a, b, 'asc');
+                case 'count_desc': return compareCollectionsByCount(a, b, 'desc');
                 case 'date_asc': return a.createdAt - b.createdAt;
                 case 'date_desc': default: return b.createdAt - a.createdAt;
             }
@@ -191,6 +192,7 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
                         <div className="grid grid-cols-1 gap-1">
                             {filtered.map(col => {
                                 const showThumbnailSkeleton = (!!thumbnailHydrationPendingIds[col.id] || !!smartSummaryPendingIds[col.id]) && !col.thumbnail;
+                                const count = getCollectionCount(col);
 
                                 return (
                                     <button
@@ -247,7 +249,13 @@ export const AddToCollectionModal: React.FC<AddToCollectionModalProps> = ({
                                                         <span className="text-[8px] bg-gray-200 dark:bg-white/10 text-gray-500 px-1 rounded uppercase tracking-tighter">Archived</span>
                                                     )}
                                                 </div>
-                                                <div className="text-[10px] text-gray-500 dark:text-gray-500 uppercase tracking-wider">{col.count ?? col.imageIds.length} images</div>
+                                                <div
+                                                    className="text-[10px] text-gray-500 dark:text-gray-500 uppercase tracking-wider"
+                                                    aria-label={count === undefined ? 'Count not calculated' : undefined}
+                                                    title={count === undefined ? 'Count not calculated' : undefined}
+                                                >
+                                                    {count === undefined ? '\u2014' : `${count} images`}
+                                                </div>
                                             </div>
                                         </div>
                                         <div className="opacity-0 group-hover:opacity-100 transform translate-x-2 group-hover:translate-x-0 transition-all text-sage-600">

--- a/src/features/collections/components/__tests__/AddToCollectionModal.test.tsx
+++ b/src/features/collections/components/__tests__/AddToCollectionModal.test.tsx
@@ -177,6 +177,37 @@ describe('AddToCollectionModal thumbnail hydration states', () => {
         expect(names.map(button => button.textContent?.match(/Alpha|Beta/)?.[0])).toEqual(expected);
     });
 
+    it('renders unknown smart counts as uncalculated and sorts them last in both count directions', () => {
+        const unknown = {
+            ...baseCollection,
+            id: 'unknown',
+            name: 'Unknown',
+            count: undefined,
+            imageIds: ['one', 'two', 'three'],
+            filters: createDefaultFilters()
+        };
+        const empty = { ...baseCollection, id: 'empty', name: 'Empty', count: 0 };
+        const full = { ...baseCollection, id: 'full', name: 'Full', count: undefined, imageIds: ['one', 'two'] };
+        renderModal([unknown, empty, full]);
+
+        const unknownCount = screen.getByTitle('Count not calculated');
+        expect(unknownCount.textContent).toBe('\u2014');
+        expect(unknownCount.getAttribute('aria-label')).toBe('Count not calculated');
+        expect(screen.getByText('0 images')).toBeTruthy();
+
+        const collectionOrder = () => screen.getAllByRole('button')
+            .map(button => button.textContent?.match(/Unknown|Empty|Full/)?.[0])
+            .filter((name): name is string => !!name);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Sort Collections' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Most Images' }));
+        expect(collectionOrder()).toEqual(['Full', 'Empty', 'Unknown']);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Sort Collections' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Fewest Images' }));
+        expect(collectionOrder()).toEqual(['Empty', 'Full', 'Unknown']);
+    });
+
     it('closes the sort menu from its backdrop and closes the modal from header and overlay', () => {
         const onClose = vi.fn();
         const { container } = renderModal([baseCollection], { onClose });

--- a/src/features/filters/components/CollectionItem.tsx
+++ b/src/features/filters/components/CollectionItem.tsx
@@ -5,6 +5,7 @@ import { PrivacyAwareThumbnail } from '../../../components/ui/PrivacyAwareThumbn
 import { CollectionThumbnailSkeleton } from '../../../components/ui/CollectionThumbnailSkeleton';
 import { formatCountCompact } from '../../../utils/formatUtils';
 import { createCollectionSelectionFilters } from '../../../utils/filterState';
+import { getCollectionCount } from '../../../utils/collectionCount';
 
 interface CollectionItemProps {
     col: Collection;
@@ -66,6 +67,9 @@ export const CollectionItem: React.FC<CollectionItemProps> = ({
     const isSelected = filters.collectionId === col.id;
     const thumbUrl = col.thumbnail || '';
     const showThumbnailSkeleton = isThumbnailPending && !thumbUrl;
+    const count = getCollectionCount(col);
+    const countText = count === undefined ? '\u2014' : formatCountCompact(count);
+    const unknownCountLabel = count === undefined ? 'Count not calculated' : undefined;
     return (
         <div
             key={col.id}
@@ -156,8 +160,12 @@ export const CollectionItem: React.FC<CollectionItemProps> = ({
                     {/* Count Badge - Hover Only for ALL items, always Top Right */}
                     {!isSelected && (
                         <div className="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 transition-opacity z-10">
-                            <div className="px-1.5 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-[9px] font-bold text-white/90 shadow-sm">
-                                {formatCountCompact(col.count ?? col.imageIds.length)}
+                            <div
+                                className="px-1.5 py-0.5 rounded-md bg-black/40 backdrop-blur-sm text-[9px] font-bold text-white/90 shadow-sm"
+                                aria-label={unknownCountLabel}
+                                title={unknownCountLabel}
+                            >
+                                {countText}
                             </div>
                         </div>
                     )}
@@ -223,9 +231,13 @@ export const CollectionItem: React.FC<CollectionItemProps> = ({
                         <div className="absolute left-0 top-2 bottom-2 w-[3px] bg-sage-500 dark:bg-sage-400 rounded-r-full" />
                     )}
 
-                    <span className={`absolute right-2 text-[10px] px-1.5 py-0.5 rounded-md pointer-events-none transition-opacity duration-200 ${isSelected ? 'bg-gray-300 dark:bg-zinc-600 text-gray-800 dark:text-white' : 'bg-gray-100 dark:bg-zinc-800 text-gray-500 opacity-60 group-hover:opacity-100'
-                        }`}>
-                        {formatCountCompact(col.count ?? col.imageIds.length)}
+                    <span
+                        className={`absolute right-2 text-[10px] px-1.5 py-0.5 rounded-md pointer-events-none transition-opacity duration-200 ${isSelected ? 'bg-gray-300 dark:bg-zinc-600 text-gray-800 dark:text-white' : 'bg-gray-100 dark:bg-zinc-800 text-gray-500 opacity-60 group-hover:opacity-100'
+                            }`}
+                        aria-label={unknownCountLabel}
+                        title={unknownCountLabel}
+                    >
+                        {countText}
                     </span>
                 </div>
             )

--- a/src/features/filters/components/CollectionList.tsx
+++ b/src/features/filters/components/CollectionList.tsx
@@ -10,6 +10,7 @@ import { CollectionItem } from './CollectionItem';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { useCollectionStore } from '../../../stores/collectionStore';
 import { TooltipButton } from '../../../components/ui/InfoTooltip';
+import { compareCollectionsByCount } from '../../../utils/collectionCount';
 
 interface CollectionListProps<T extends Collection> {
     collections: T[];
@@ -108,7 +109,11 @@ export function CollectionList<T extends Collection>({
         const selectedSmartCollection = collections.find(collection =>
             collection.id === filters.collectionId && !!collection.filters
         );
-        if (!selectedSmartCollection || lastSelectedSmartRefresh.current === selectedSmartCollection.id) return;
+        if (!selectedSmartCollection) {
+            lastSelectedSmartRefresh.current = null;
+            return;
+        }
+        if (lastSelectedSmartRefresh.current === selectedSmartCollection.id) return;
 
         lastSelectedSmartRefresh.current = selectedSmartCollection.id;
         void refreshSmartCounts({
@@ -192,8 +197,8 @@ export function CollectionList<T extends Collection>({
             switch (sort) {
                 case 'name_asc': return a.name.localeCompare(b.name);
                 case 'name_desc': return b.name.localeCompare(a.name);
-                case 'count_asc': return (a.count ?? a.imageIds.length) - (b.count ?? b.imageIds.length);
-                case 'count_desc': return (b.count ?? b.imageIds.length) - (a.count ?? a.imageIds.length);
+                case 'count_asc': return compareCollectionsByCount(a, b, 'asc');
+                case 'count_desc': return compareCollectionsByCount(a, b, 'desc');
                 case 'date_asc': return a.createdAt - b.createdAt;
                 case 'date_desc': return b.createdAt - a.createdAt;
                 case 'recent_asc': return (a.updatedAt || a.createdAt) - (b.updatedAt || b.createdAt);

--- a/src/features/filters/components/__tests__/CollectionItem.test.tsx
+++ b/src/features/filters/components/__tests__/CollectionItem.test.tsx
@@ -143,6 +143,57 @@ describe('CollectionItem thumbnail hydration states', () => {
         expect(screen.queryByTestId('privacy-aware-thumbnail')).toBeNull();
     });
 
+    it('shows an unknown smart count distinctly from a verified zero in both views', () => {
+        const unknownSmart = { ...smartCollection, count: undefined, imageIds: ['one', 'two'] };
+        const view = renderCollectionItem(unknownSmart);
+
+        const listCount = screen.getByTitle('Count not calculated');
+        expect(listCount.textContent).toBe('\u2014');
+        expect(listCount.getAttribute('aria-label')).toBe('Count not calculated');
+
+        view.rerender(
+            <CollectionItem
+                col={unknownSmart}
+                filters={filters}
+                setFilters={() => { }}
+                editingColId={null}
+                editName=""
+                setEditName={() => { }}
+                setEditingColId={() => { }}
+                handleRenameSubmit={() => { }}
+                handleDragEnter={noopDrag}
+                handleDragOver={noopDrag}
+                handleDragLeave={() => { }}
+                handleDrop={noopDrop}
+                handleContextMenu={noopContextMenu}
+                dropTargetId={null}
+                viewMode="grid"
+            />
+        );
+        expect(screen.getByTitle('Count not calculated').textContent).toBe('\u2014');
+
+        view.rerender(
+            <CollectionItem
+                col={{ ...unknownSmart, count: 0 }}
+                filters={filters}
+                setFilters={() => { }}
+                editingColId={null}
+                editName=""
+                setEditName={() => { }}
+                setEditingColId={() => { }}
+                handleRenameSubmit={() => { }}
+                handleDragEnter={noopDrag}
+                handleDragOver={noopDrag}
+                handleDragLeave={() => { }}
+                handleDrop={noopDrop}
+                handleContextMenu={noopContextMenu}
+                dropTargetId={null}
+            />
+        );
+        expect(screen.queryByTitle('Count not calculated')).toBeNull();
+        expect(screen.getByText('0')).toBeTruthy();
+    });
+
     it('routes inline rename changes, submission, and blur cancellation', () => {
         const setEditName = vi.fn();
         const setEditingColId = vi.fn();
@@ -219,7 +270,7 @@ describe('CollectionItem thumbnail hydration states', () => {
             handleRenameSubmit: vi.fn(), handleDragEnter: noopDrag, handleDragOver: noopDrag, handleDragLeave: vi.fn(),
             handleDrop: noopDrop, handleContextMenu: noopContextMenu, dropTargetId: null
         };
-        const { container, rerender } = render(<CollectionItem {...shared} col={{ ...smartCollection, thumbnail: 'thumb', isArchived: true, isPinned: true, color: 'red', count: undefined, imageIds: ['a', 'b'] }} />);
+        const { container, rerender } = render(<CollectionItem {...shared} col={{ ...smartCollection, thumbnail: 'thumb', isArchived: true, isPinned: true, color: 'red', count: 2, imageIds: ['a', 'b'] }} />);
         expect(screen.getByTestId('privacy-aware-thumbnail')).toBeTruthy();
         expect(screen.getByText('2')).toBeTruthy();
         expect(container.querySelector('.bg-red-500')).toBeTruthy();

--- a/src/features/filters/components/__tests__/CollectionList.test.tsx
+++ b/src/features/filters/components/__tests__/CollectionList.test.tsx
@@ -272,7 +272,7 @@ describe('CollectionList interactions', () => {
         expect(screen.getByRole('button', { name: 'Hide Archived' })).toBeTruthy();
     });
 
-    it('refreshes a selected smart collection once per id', async () => {
+    it('refreshes once while selected and retries after the same smart collection is reselected', async () => {
         const smart = { ...makeCollection({ id: 'smart', name: 'Smart', createdAt: 1, updatedAt: 1 }), filters: { ...filters } };
         const view = renderList({ collections: [smart], filters: { ...filters, collectionId: 'smart' } });
         await waitFor(() => expect(refreshSmartCounts).toHaveBeenCalledWith({
@@ -281,6 +281,12 @@ describe('CollectionList interactions', () => {
         refreshSmartCounts.mockClear();
         view.rerender(<CollectionList {...view.props} />);
         expect(refreshSmartCounts).not.toHaveBeenCalled();
+
+        view.rerender(<CollectionList {...view.props} filters={{ ...filters, collectionId: null }} />);
+        view.rerender(<CollectionList {...view.props} />);
+        await waitFor(() => expect(refreshSmartCounts).toHaveBeenCalledWith({
+            collectionIds: ['smart'], includeArchived: true, includePromptSearch: true, markPending: true
+        }));
     });
 
     it('separates pinned collections and forwards pending thumbnail state', () => {
@@ -414,21 +420,23 @@ describe('CollectionList interactions', () => {
         logSpy.mockRestore();
     });
 
-    it('uses image-id counts and created dates when optional sort fields are absent', () => {
+    it('uses static membership counts, sorts unknown smart counts last, and falls back to created dates', () => {
         settingsContextMocks.resourceSortOptions = { collections: 'count_asc' };
         const countAsc = renderList({ collections: [
+            { ...makeCollection({ id: 'unknown', name: 'Unknown', createdAt: 3, updatedAt: 3 }), count: undefined, imageIds: ['1', '2', '3'], filters: { ...filters } },
             { ...makeCollection({ id: 'two', name: 'Two', createdAt: 2, updatedAt: 2 }), count: undefined, imageIds: ['1', '2'] },
             { ...makeCollection({ id: 'one', name: 'One', createdAt: 1, updatedAt: 1 }), count: undefined, imageIds: ['1'] }
         ] });
-        expectCollectionOrder(['One', 'Two']);
+        expectCollectionOrder(['One', 'Two', 'Unknown']);
         countAsc.unmount();
 
         settingsContextMocks.resourceSortOptions = { collections: 'count_desc' };
         const countDesc = renderList({ collections: [
+            { ...makeCollection({ id: 'unknown', name: 'Unknown', createdAt: 3, updatedAt: 3 }), count: undefined, imageIds: ['1', '2', '3'], filters: { ...filters } },
             { ...makeCollection({ id: 'two', name: 'Two', createdAt: 2, updatedAt: 2 }), count: undefined, imageIds: ['1', '2'] },
             { ...makeCollection({ id: 'one', name: 'One', createdAt: 1, updatedAt: 1 }), count: undefined, imageIds: ['1'] }
         ] });
-        expectCollectionOrder(['Two', 'One']);
+        expectCollectionOrder(['Two', 'One', 'Unknown']);
         countDesc.unmount();
 
         settingsContextMocks.resourceSortOptions = { collections: 'recent_asc' };

--- a/src/hooks/__tests__/useAppActions.test.tsx
+++ b/src/hooks/__tests__/useAppActions.test.tsx
@@ -19,6 +19,7 @@ const mockRebuildThumbnailFacetCache = vi.fn();
 const mockBackfillParameterColumns = vi.fn();
 const mockIncrementFacetCacheVersion = vi.fn();
 const mockRefreshCollections = vi.fn();
+const mockRefreshSmartCounts = vi.fn();
 const mockSetPrivacyEnabled = vi.fn();
 let mockStoreImages = [
     { id: '1', isFavorite: false, isPinned: false, filename: '1.png', timestamp: 100 },
@@ -69,6 +70,7 @@ vi.mock('../../stores/libraryStore', () => ({
 vi.mock('../../stores/collectionStore', () => ({
     useCollectionStore: (selector: any) => selector({
         refreshCollections: mockRefreshCollections,
+        refreshSmartCounts: mockRefreshSmartCounts,
     }),
 }));
 
@@ -178,6 +180,13 @@ describe('useAppActions', () => {
         expect(mockSetImages).toHaveBeenCalled();
         const update = mockSetImages.mock.calls[0][0] as (images: typeof mockStoreImages) => typeof mockStoreImages;
         expect(update(mockStoreImages).map(image => image.isFavorite)).toEqual([true, true]);
+        expect(mockRefreshCollections).toHaveBeenCalledWith(true);
+        expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
+            collectionIds: ['col1'],
+            includeArchived: true,
+            includePromptSearch: true,
+            markPending: true
+        });
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Favorited'), 'success');
     });
 
@@ -217,6 +226,12 @@ describe('useAppActions', () => {
         expect(mockSetImages).toHaveBeenCalled();
         expect(mockSetImages.mock.calls[0][0].map((img: { id: string }) => img.id)).toEqual(['2', '1']);
         expect(mockRefreshCollections).toHaveBeenCalledWith(true);
+        expect(mockRefreshSmartCounts).toHaveBeenCalledWith({
+            collectionIds: ['col1'],
+            includeArchived: true,
+            includePromptSearch: true,
+            markPending: true
+        });
         expect(mockAddToast).toHaveBeenCalledWith(expect.stringContaining('Pinned'), 'info');
     });
 

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -71,8 +71,22 @@ export const useAppActions = ({
     const setPrivacyEnabled = useSettingsStore(s => s.setPrivacyEnabled);
 
     const refreshCollections = useCollectionStore(s => s.refreshCollections);
+    const refreshSmartCounts = useCollectionStore(s => s.refreshSmartCounts);
 
     const { openModal, closeModal, pendingViewerDeleteId, setPendingViewerDeleteId } = modals;
+
+    const refreshCollectionsAfterImageFlagChange = React.useCallback(() => {
+        void refreshCollections(true);
+
+        if (!filters.collectionId) return;
+
+        void refreshSmartCounts({
+            collectionIds: [filters.collectionId],
+            includeArchived: true,
+            includePromptSearch: true,
+            markPending: true
+        });
+    }, [filters.collectionId, refreshCollections, refreshSmartCounts]);
 
     const persistPinChanges = React.useCallback(async (
         ids: string[],
@@ -83,7 +97,7 @@ export const useAppActions = ({
     ) => {
         try {
             await Promise.all(ids.map(id => toggleImagePin(id, isPinned)));
-            void refreshCollections(true);
+            refreshCollectionsAfterImageFlagChange();
         } catch (error) {
             console.error('[Pin] Failed to persist pin state', error);
             setImages(previousImages);
@@ -94,7 +108,7 @@ export const useAppActions = ({
             });
             addToast(errorMessage, 'error');
         }
-    }, [refreshCollections, setImages, addToast, queryClient, imagesQueryKey]);
+    }, [refreshCollectionsAfterImageFlagChange, setImages, addToast, queryClient, imagesQueryKey]);
 
     const persistFavoriteChanges = React.useCallback(async (
         ids: string[],
@@ -103,13 +117,14 @@ export const useAppActions = ({
     ) => {
         try {
             await Promise.all(ids.map(id => toggleImageFavorite(id, isFavorite)));
+            refreshCollectionsAfterImageFlagChange();
         } catch (error) {
             console.error('[Favorite] Failed to persist favorite state', error);
             setImages(previousImages);
             restoreImagesInQueryCaches(queryClient, previousImages);
             addToast('Failed to update favorite state', 'error');
         }
-    }, [addToast, queryClient, setImages]);
+    }, [addToast, queryClient, refreshCollectionsAfterImageFlagChange, setImages]);
 
     const executeDeleteByIds = React.useCallback((ids: string[], targetDeleteId: string | null) => {
         fileOps.deleteImages(ids);

--- a/src/services/db/__tests__/collectionRepo.test.ts
+++ b/src/services/db/__tests__/collectionRepo.test.ts
@@ -56,6 +56,7 @@ const makeCollectionRow = (overrides: Record<string, unknown> = {}) => ({
     dynamic_safe_thumbnail_path: null,
     dynamic_thumbnail_is_sensitive: null,
     dynamic_thumbnail_cached_at: null,
+    dynamic_count: null,
     filter_state: null,
     manual_exclusions: null,
     source: 'ambit',
@@ -159,7 +160,7 @@ describe('collectionRepo filter normalization', () => {
         expect(flagParams[7]).toBe('["image-a"]');
     });
 
-    it('backfills missing dynamic thumbnail cache columns from the TypeScript schema guard', async () => {
+    it('backfills missing dynamic collection cache columns from the TypeScript schema guard', async () => {
         dbMocks.select.mockResolvedValue([{ name: 'id' }, { name: 'created_at' }, { name: 'updated_at' }]);
 
         const { ensureCollectionSchema } = await import('../collectionRepo');
@@ -169,6 +170,29 @@ describe('collectionRepo filter normalization', () => {
         expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_safe_thumbnail_path TEXT');
         expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_is_sensitive INTEGER');
         expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_thumbnail_cached_at INTEGER');
+        expect(dbMocks.execute).toHaveBeenCalledWith('ALTER TABLE collections ADD COLUMN dynamic_count INTEGER');
+    });
+
+    it('invalidates cached smart counts and advances their revision when the definition changes', async () => {
+        const { upsertCollection } = await import('../collectionRepo');
+
+        await upsertCollection({
+            id: 'smart-a',
+            name: 'Smart A',
+            updatedAt: 10,
+            filters: makeFilters({ searchQuery: 'portrait' }),
+        });
+
+        const sql = dbMocks.execute.mock.calls[0]?.[0] as string;
+        const params = dbMocks.execute.mock.calls[0]?.[1] as unknown[];
+        expect(sql).toContain('dynamic_count = CASE');
+        expect(sql).toContain('collections.filter_state IS excluded.filter_state');
+        expect(sql).toContain('collections.manual_exclusions IS excluded.manual_exclusions');
+        expect(sql).toContain('THEN collections.dynamic_count');
+        expect(sql).toContain('ELSE NULL');
+        expect(sql).toMatch(/updated_at = CASE[\s\S]*ELSE MAX\(COALESCE\(collections\.updated_at, 0\) \+ 1, \?\)/);
+        expect(params.at(-1)).toEqual(expect.any(Number));
+        expect(params.at(-1)).toBeGreaterThan(10);
     });
 
     it('adds and backfills updated_at when older collection databases lack it', async () => {
@@ -380,7 +404,7 @@ describe('collectionRepo thumbnail hydration', () => {
         expect(dbMocks.execute).not.toHaveBeenCalled();
     });
 
-    it('keeps cached smart thumbnails during full collection reloads until smart hydration runs', async () => {
+    it('keeps cached smart thumbnails and counts during full collection reloads', async () => {
         const queries: string[] = [];
         dbMocks.select.mockImplementation(async (query: string) => {
             queries.push(query);
@@ -391,7 +415,8 @@ describe('collectionRepo thumbnail hydration', () => {
                     filter_state: JSON.stringify({ dateRange: 'today' }),
                     dynamic_thumbnail_path: 'C:/thumbs/cached-smart.webp',
                     dynamic_safe_thumbnail_path: 'C:/thumbs/cached-smart-safe.webp',
-                    dynamic_thumbnail_is_sensitive: 0
+                    dynamic_thumbnail_is_sensitive: 0,
+                    dynamic_count: 12
                 })];
             }
             if (query.includes('COUNT(*) as count')) return [];
@@ -403,7 +428,7 @@ describe('collectionRepo thumbnail hydration', () => {
 
         expect(collections[0]).toEqual(expect.objectContaining({
             id: 'smart-1',
-            count: 0,
+            count: 12,
             thumbnail: 'asset://C:/thumbs/cached-smart.webp',
             safeThumbnail: 'asset://C:/thumbs/cached-smart-safe.webp',
             thumbnailIsSensitive: false,
@@ -411,6 +436,32 @@ describe('collectionRepo thumbnail hydration', () => {
         }));
         expect(queries.join('\n')).not.toContain('ranked_thumbnails');
         expect(dbMocks.execute).not.toHaveBeenCalled();
+    });
+
+    it('distinguishes unknown smart counts from a verified zero during collection load', async () => {
+        dbMocks.select.mockImplementation(async (query: string) => {
+            if (query.includes('SELECT * FROM collections')) {
+                return [
+                    makeCollectionRow({
+                        id: 'smart-unknown',
+                        filter_state: JSON.stringify({ searchQuery: 'unknown' }),
+                        dynamic_count: null,
+                    }),
+                    makeCollectionRow({
+                        id: 'smart-empty',
+                        filter_state: JSON.stringify({ searchQuery: 'empty' }),
+                        dynamic_count: 0,
+                    }),
+                ];
+            }
+            return [];
+        });
+
+        const { getAllCollectionsWithStats } = await import('../collectionRepo');
+        const collections = await getAllCollectionsWithStats({ includeThumbnails: false });
+
+        expect(collections.find(collection => collection.id === 'smart-unknown')?.count).toBeUndefined();
+        expect(collections.find(collection => collection.id === 'smart-empty')?.count).toBe(0);
     });
 
     it('does not display a cached dynamic thumbnail over a custom thumbnail', async () => {
@@ -650,7 +701,14 @@ describe('collectionRepo thumbnail hydration', () => {
         ]);
 
         expect(summaries['smart-empty']).toMatchObject({ count: 0, thumbnail: undefined });
-        expect(dbMocks.execute).toHaveBeenCalledTimes(1);
+        expect(dbMocks.execute).not.toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_count'),
+            expect.anything()
+        );
+        const thumbnailCacheWrites = dbMocks.execute.mock.calls.filter(([query]) =>
+            (query as string).includes('dynamic_thumbnail_path')
+        );
+        expect(thumbnailCacheWrites).toHaveLength(1);
     });
 });
 
@@ -869,7 +927,7 @@ describe('collectionRepo membership helpers', () => {
         expect(dbMocks.getDb).not.toHaveBeenCalled();
     });
 
-    it('can load smart counts without thumbnail hydration when callers only need totals', async () => {
+    it('returns count summaries without persisting before the caller accepts them', async () => {
         dbMocks.select.mockResolvedValue([{ id: 'smart-1', count: 4 }]);
 
         const { getSmartCollectionSummaries } = await import('../collectionRepo');
@@ -882,6 +940,85 @@ describe('collectionRepo membership helpers', () => {
 
         expect(dbMocks.select).toHaveBeenCalledTimes(1);
         expect(dbMocks.execute).not.toHaveBeenCalled();
+    });
+
+    it('guards accepted count cache writes with the collection revision', async () => {
+        const { cacheSmartCollectionCount } = await import('../collectionRepo');
+
+        await cacheSmartCollectionCount('smart-1', 4, 1);
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            expect.stringMatching(/dynamic_count[\s\S]*updated_at = \?/),
+            [4, 'smart-1', 1]
+        );
+    });
+
+    it('serializes accepted count cache writes for the same collection', async () => {
+        let signalFirstWriteStarted!: () => void;
+        const firstWriteStarted = new Promise<void>(resolve => {
+            signalFirstWriteStarted = resolve;
+        });
+        let releaseFirstWrite!: () => void;
+        const firstWrite = new Promise<void>(resolve => {
+            releaseFirstWrite = resolve;
+        });
+        dbMocks.execute
+            .mockImplementationOnce(() => {
+                signalFirstWriteStarted();
+                return firstWrite;
+            })
+            .mockResolvedValueOnce(undefined);
+
+        const { cacheSmartCollectionCount } = await import('../collectionRepo');
+        const olderWrite = cacheSmartCollectionCount('smart-1', 4, 1);
+        await firstWriteStarted;
+        const newerWrite = cacheSmartCollectionCount('smart-1', 5, 1);
+
+        await Promise.resolve();
+        expect(dbMocks.execute).toHaveBeenCalledTimes(1);
+
+        releaseFirstWrite();
+        await Promise.all([olderWrite, newerWrite]);
+
+        expect(dbMocks.execute).toHaveBeenNthCalledWith(1, expect.any(String), [4, 'smart-1', 1]);
+        expect(dbMocks.execute).toHaveBeenNthCalledWith(2, expect.any(String), [5, 'smart-1', 1]);
+    });
+
+    it('treats accepted count cache failures as best effort', async () => {
+        dbMocks.execute.mockRejectedValueOnce(new Error('count cache failed'));
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const { cacheSmartCollectionCount } = await import('../collectionRepo');
+        await expect(cacheSmartCollectionCount('smart-1', 4, 1)).resolves.toBeUndefined();
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[DB] Failed to cache smart collection count smart-1',
+            expect.any(Error)
+        );
+        errorSpy.mockRestore();
+    });
+
+    it('hydrates smart thumbnails independently from count cache persistence', async () => {
+        dbMocks.select
+            .mockResolvedValueOnce([{ id: 'smart-1', count: 4 }])
+            .mockResolvedValueOnce([{ thumbnail_path: 'C:/thumbs/smart.webp', privacy_hidden: 0 }])
+            .mockResolvedValueOnce([{ thumbnail_path: 'C:/thumbs/smart.webp' }]);
+
+        const { getSmartCollectionSummaries } = await import('../collectionRepo');
+        await expect(getSmartCollectionSummaries([makeCollection({
+            id: 'smart-1',
+            filters: makeFilters({ dateRange: 'today' }),
+        })])).resolves.toEqual({
+            'smart-1': expect.objectContaining({
+                count: 4,
+                thumbnail: 'asset://C:/thumbs/smart.webp'
+            })
+        });
+
+        expect(dbMocks.execute).toHaveBeenCalledWith(
+            expect.stringContaining('dynamic_thumbnail_path'),
+            expect.any(Array)
+        );
     });
 
     it('returns partial smart summaries when smart thumbnail queries fail', async () => {

--- a/src/services/db/collectionRepo.ts
+++ b/src/services/db/collectionRepo.ts
@@ -32,6 +32,7 @@ export interface DbCollection {
     dynamic_safe_thumbnail_path?: string | null;
     dynamic_thumbnail_is_sensitive?: number | null;
     dynamic_thumbnail_cached_at?: number | null;
+    dynamic_count?: number | null;
 }
 
 interface CollectionThumbnailRow {
@@ -79,6 +80,14 @@ interface DynamicThumbnailCacheUpdate {
     safeThumbnailPath?: string | null;
     thumbnailIsSensitive?: boolean | null;
 }
+
+interface DynamicCountCacheUpdate {
+    collectionId: string;
+    count: number;
+    collectionUpdatedAt: number;
+}
+
+const dynamicCountCacheWriteTails = new Map<string, Promise<void>>();
 
 interface CollectionStatsOptions {
     includeThumbnails?: boolean;
@@ -195,6 +204,41 @@ const writeDynamicThumbnailCache = async (
                 update.collectionId
             ]
         );
+    }
+};
+
+export const cacheSmartCollectionCount = async (
+    collectionId: string,
+    count: number,
+    collectionUpdatedAt: number
+): Promise<void> => {
+    if (isBrowserMockMode()) return;
+
+    const previousWrite = dynamicCountCacheWriteTails.get(collectionId) ?? Promise.resolve();
+    const update: DynamicCountCacheUpdate = { collectionId, count, collectionUpdatedAt };
+    const write = previousWrite.then(async () => {
+        try {
+            const db = await getDb();
+            await db.execute(
+                `UPDATE collections
+                 SET dynamic_count = ?
+                 WHERE id = ?
+                   AND filter_state IS NOT NULL
+                   AND updated_at = ?`,
+                [update.count, update.collectionId, update.collectionUpdatedAt]
+            );
+        } catch (error) {
+            console.error(`[DB] Failed to cache smart collection count ${update.collectionId}`, error);
+        }
+    });
+
+    dynamicCountCacheWriteTails.set(collectionId, write);
+    try {
+        await write;
+    } finally {
+        if (dynamicCountCacheWriteTails.get(collectionId) === write) {
+            dynamicCountCacheWriteTails.delete(collectionId);
+        }
     }
 };
 
@@ -449,6 +493,10 @@ export const ensureCollectionSchema = async () => {
                 'dynamic_thumbnail_cached_at',
                 'ALTER TABLE collections ADD COLUMN dynamic_thumbnail_cached_at INTEGER'
             );
+            await addColumnIfMissing(
+                'dynamic_count',
+                'ALTER TABLE collections ADD COLUMN dynamic_count INTEGER'
+            );
         } catch (e) {
             console.error('[DB] Failed to ensure collection schema', e);
         }
@@ -478,11 +526,22 @@ export const upsertCollection = async (collection: Partial<Collection> & { id: s
                 is_archived = excluded.is_archived,
                 is_pinned = excluded.is_pinned,
                 created_at = excluded.created_at,
+                dynamic_count = CASE
+                    WHEN collections.filter_state IS excluded.filter_state
+                     AND collections.manual_exclusions IS excluded.manual_exclusions
+                    THEN collections.dynamic_count
+                    ELSE NULL
+                END,
                 filter_state = excluded.filter_state,
                 manual_exclusions = excluded.manual_exclusions,
                 custom_thumbnail = excluded.custom_thumbnail,
                 source = excluded.source,
-                updated_at = excluded.updated_at`,
+                updated_at = CASE
+                    WHEN collections.filter_state IS excluded.filter_state
+                     AND collections.manual_exclusions IS excluded.manual_exclusions
+                    THEN excluded.updated_at
+                    ELSE MAX(COALESCE(collections.updated_at, 0) + 1, ?)
+                END`,
                 [
                     collection.id,
                     collection.name,
@@ -494,7 +553,8 @@ export const upsertCollection = async (collection: Partial<Collection> & { id: s
                     collection.manualExclusions ? JSON.stringify(collection.manualExclusions) : null,
                     collection.customThumbnail || null,
                     collection.source || 'ambit',
-                    collection.updatedAt || now
+                    collection.updatedAt || now,
+                    now
                 ]
             );
         } catch (e) {
@@ -591,6 +651,7 @@ export const getAllCollectionsWithStats = async (options: CollectionStatsOptions
     const countMap = new Map(counts.map(c => [c.collection_id, c.count]));
 
     let mappedCollections: Collection[] = collections.map(c => {
+        const filters = parsePersistedCollectionFilters(c.filter_state);
         const collection: Collection = {
             id: c.id,
             name: c.name,
@@ -599,10 +660,10 @@ export const getAllCollectionsWithStats = async (options: CollectionStatsOptions
             isPinned: !!c.is_pinned,
             createdAt: c.created_at,
             updatedAt: c.updated_at || c.created_at, // Fallback to created_at if updated_at is null
-            count: countMap.get(c.id) || 0,
+            count: filters ? c.dynamic_count ?? undefined : countMap.get(c.id) || 0,
             imageIds: [],
             customThumbnail: c.custom_thumbnail,
-            filters: parsePersistedCollectionFilters(c.filter_state),
+            filters,
             manualExclusions: c.manual_exclusions ? JSON.parse(c.manual_exclusions) : undefined,
             source: c.source
         };
@@ -632,12 +693,8 @@ export const getAllCollectionsWithStats = async (options: CollectionStatsOptions
         logStartupDuration('collection thumbnail hydration', thumbnailStartedAt);
     }
 
-    // Smart collection counts are calculated lazily via refreshSmartCollectionCounts().
-    // Do not block the initial collection list on smart-thumbnail queries: those can
-    // require prompt scans on large libraries and make collections appear missing.
-    const result = mappedCollections.map(c => c.filters ? { ...c, count: 0 } : c);
     logStartupDuration('collection load', startedAt);
-    return result;
+    return mappedCollections;
 };
 
 export const getCollectionThumbnailSummaries = async (

--- a/src/stores/__tests__/collectionStore.test.ts
+++ b/src/stores/__tests__/collectionStore.test.ts
@@ -7,6 +7,7 @@ import { createDefaultFilters } from '../../utils/filterState';
 const collectionRepoMocks = vi.hoisted(() => ({
     mockGetAllCollectionsWithStats: vi.fn(),
     mockGetSmartCollectionSummaries: vi.fn(),
+    mockCacheSmartCollectionCount: vi.fn(),
     mockGetCollectionThumbnailSummaries: vi.fn(),
     mockEnsureCollectionSchema: vi.fn(),
     mockUpsertCollection: vi.fn(),
@@ -22,6 +23,7 @@ const libraryStoreMocks = vi.hoisted(() => ({
 const {
     mockGetAllCollectionsWithStats,
     mockGetSmartCollectionSummaries,
+    mockCacheSmartCollectionCount,
     mockGetCollectionThumbnailSummaries
 } = collectionRepoMocks;
 
@@ -36,6 +38,7 @@ vi.mock('../libraryStore', () => ({
 vi.mock('../../services/db/collectionRepo', () => ({
     getAllCollectionsWithStats: collectionRepoMocks.mockGetAllCollectionsWithStats,
     getSmartCollectionSummaries: collectionRepoMocks.mockGetSmartCollectionSummaries,
+    cacheSmartCollectionCount: collectionRepoMocks.mockCacheSmartCollectionCount,
     getCollectionThumbnailSummaries: collectionRepoMocks.mockGetCollectionThumbnailSummaries,
     ensureCollectionSchema: collectionRepoMocks.mockEnsureCollectionSchema,
     upsertCollection: collectionRepoMocks.mockUpsertCollection,
@@ -79,6 +82,7 @@ describe('collectionStore smart count refresh', () => {
         vi.clearAllMocks();
         mockGetAllCollectionsWithStats.mockResolvedValue([]);
         mockGetSmartCollectionSummaries.mockResolvedValue({});
+        mockCacheSmartCollectionCount.mockResolvedValue(undefined);
         mockGetCollectionThumbnailSummaries.mockResolvedValue({});
         collectionRepoMocks.mockEnsureCollectionSchema.mockResolvedValue(undefined);
         collectionRepoMocks.mockUpsertCollection.mockResolvedValue(undefined);
@@ -613,6 +617,8 @@ describe('collectionStore smart count refresh', () => {
             thumbnail: 'asset://replacement-thumb.webp',
             thumbnailSourceKind: 'dynamic'
         }));
+        expect(mockCacheSmartCollectionCount).toHaveBeenCalledTimes(1);
+        expect(mockCacheSmartCollectionCount).toHaveBeenCalledWith('smart-date', 14, 2);
     });
 
     it('clears smart pending ids when an import-skip refresh supersedes thumbnail hydration', async () => {
@@ -704,7 +710,7 @@ describe('collectionStore smart count refresh', () => {
         }));
     });
 
-    it('keeps cached prompt-search smart thumbnails visible during automatic refreshes', async () => {
+    it('keeps cached prompt-search smart counts and thumbnails visible during automatic refreshes', async () => {
         act(() => {
             useCollectionStore.setState({
                 collections: [{
@@ -713,7 +719,7 @@ describe('collectionStore smart count refresh', () => {
                     createdAt: 1,
                     updatedAt: 1,
                     source: 'ambit',
-                    count: 0,
+                    count: 9,
                     imageIds: [],
                     filters: createDefaultFilters({ searchQuery: 'apple' }),
                     thumbnail: 'asset://cached-prompt-thumb.webp',
@@ -728,9 +734,115 @@ describe('collectionStore smart count refresh', () => {
         expect(mockGetSmartCollectionSummaries).not.toHaveBeenCalled();
         expect(useCollectionStore.getState().smartSummaryPendingIds).toEqual({});
         expect(useCollectionStore.getState().collections[0]).toEqual(expect.objectContaining({
+            count: 9,
             thumbnail: 'asset://cached-prompt-thumb.webp',
             thumbnailSourceKind: 'dynamic'
         }));
+    });
+
+    it('automatically refreshes pinned prompt-search smart collections', async () => {
+        mockGetSmartCollectionSummaries.mockResolvedValue({
+            'smart-prompt': {
+                count: 11,
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [{
+                    id: 'smart-prompt',
+                    name: 'Pinned Prompt Smart',
+                    createdAt: 1,
+                    updatedAt: 1,
+                    source: 'ambit',
+                    isPinned: true,
+                    count: 9,
+                    imageIds: [],
+                    filters: createDefaultFilters({ searchQuery: 'apple' })
+                }],
+                isLoaded: true
+            });
+        });
+
+        await useCollectionStore.getState().refreshSmartCounts({ includeThumbnails: false });
+
+        expect(mockGetSmartCollectionSummaries).toHaveBeenCalledWith(
+            [expect.objectContaining({ id: 'smart-prompt', isPinned: true })],
+            { includeThumbnails: false }
+        );
+        expect(useCollectionStore.getState().collections[0].count).toBe(11);
+    });
+
+    it('does not let an automatic refresh cancel a selected pinned prompt collection refresh', async () => {
+        let resolvePromptSummary: ((value: Record<string, unknown>) => void) | undefined;
+        mockGetSmartCollectionSummaries
+            .mockImplementationOnce(() => new Promise(resolve => {
+                resolvePromptSummary = resolve;
+            }))
+            .mockResolvedValueOnce({
+                'smart-date': {
+                    count: 12,
+                    thumbnailSourceKind: 'dynamic'
+                }
+            });
+
+        act(() => {
+            useCollectionStore.setState({
+                collections: [
+                    {
+                        id: 'smart-prompt',
+                        name: 'Prompt Smart',
+                        createdAt: 1,
+                        updatedAt: 1,
+                        source: 'ambit',
+                        isPinned: true,
+                        count: 9,
+                        imageIds: [],
+                        filters: createDefaultFilters({ searchQuery: 'apple' })
+                    },
+                    {
+                        id: 'smart-date',
+                        name: 'Date Smart',
+                        createdAt: 2,
+                        updatedAt: 2,
+                        source: 'ambit',
+                        count: 0,
+                        imageIds: [],
+                        filters: createDefaultFilters({ dateRange: 'today' })
+                    }
+                ],
+                isLoaded: true
+            });
+        });
+
+        const selectedRefresh = useCollectionStore.getState().refreshSmartCounts({
+            collectionIds: ['smart-prompt'],
+            includeArchived: true,
+            includePromptSearch: true,
+            includeThumbnails: false
+        });
+        await waitFor(() => expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(1));
+
+        await useCollectionStore.getState().refreshSmartCounts({ includeThumbnails: false });
+        resolvePromptSummary?.({
+            'smart-prompt': {
+                count: 5,
+                thumbnailSourceKind: 'dynamic'
+            }
+        });
+        await selectedRefresh;
+
+        expect(mockGetSmartCollectionSummaries).toHaveBeenCalledTimes(2);
+        expect(mockGetSmartCollectionSummaries).toHaveBeenNthCalledWith(
+            2,
+            [expect.objectContaining({ id: 'smart-date' })],
+            { includeThumbnails: false }
+        );
+        expect(useCollectionStore.getState().collections).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: 'smart-prompt', count: 5 }),
+            expect.objectContaining({ id: 'smart-date', count: 12 })
+        ]));
     });
 
     it('hydrates prompt-search smart collections when explicitly selected', async () => {

--- a/src/stores/collectionStore.ts
+++ b/src/stores/collectionStore.ts
@@ -5,6 +5,7 @@ import { appRepository } from '../services/repository';
 import { shouldAutoRefreshSmartCollectionSummary } from '../utils/smartCollectionRefresh';
 import {
     addImagesToCollection,
+    cacheSmartCollectionCount,
     deleteCollectionFromDb,
     ensureCollectionSchema,
     getAllCollectionsWithStats,
@@ -18,6 +19,7 @@ import { useLibraryStore } from './libraryStore';
 let initPromise: Promise<void> | null = null;
 let collectionRefreshRunId = 0;
 let smartCountRunId = 0;
+const smartCountRunsByCollection = new Map<string, { runId: number; includesPromptSearch: boolean }>();
 let thumbnailRefreshRunId = 0;
 
 const invalidateCollectionRefreshes = () => {
@@ -189,66 +191,84 @@ export const useCollectionStore = create<CollectionState>()(
             },
 
             refreshSmartCounts: async (input = {}) => {
-                const runId = ++smartCountRunId;
                 const collectionsSnapshot = Array.isArray(input) ? input : undefined;
                 const options: RefreshSmartCountsOptions = Array.isArray(input)
                     ? { includePromptSearch: true }
                     : input;
                 const includeThumbnails = options.includeThumbnails !== false;
                 const shouldManagePending = includeThumbnails && options.markPending;
-
-                if (!shouldManagePending) {
-                    set({ smartSummaryPendingIds: {} });
-                }
+                let runId = 0;
+                let smartCols: Collection[] = [];
 
                 try {
                     if (useLibraryStore.getState().isImporting) {
                         console.log('[CollectionStore] Skipping smart counts refresh - Import already in progress');
-                        if (shouldManagePending && runId === smartCountRunId) {
-                            set({ smartSummaryPendingIds: {} });
-                        }
+                        smartCountRunsByCollection.clear();
+                        set({ smartSummaryPendingIds: {} });
                         return;
-                    }
-
-                    if (options.delayMs && options.delayMs > 0) {
-                        await delay(options.delayMs);
-                        if (runId !== smartCountRunId) return;
                     }
 
                     const currentCols = collectionsSnapshot ?? get().collections;
                     const allowedIds = options.collectionIds ? new Set(options.collectionIds) : null;
-                    const smartCols = currentCols.filter(c =>
+                    const eligibleSmartCols = currentCols.filter(c =>
                         !!c.filters
                         && (!!collectionsSnapshot || options.includeArchived || !c.isArchived)
                         && (!allowedIds || allowedIds.has(c.id))
                         && (options.includePromptSearch || shouldAutoRefreshSmartCollectionSummary(c))
                     );
 
-                    if (smartCols.length === 0) {
-                        if (shouldManagePending) {
-                            set({ smartSummaryPendingIds: {} });
-                        }
-                        return;
-                    }
+                    if (eligibleSmartCols.length === 0) return;
+
+                    runId = ++smartCountRunId;
+                    const includesPromptSearch = !!options.includePromptSearch;
+                    smartCols = eligibleSmartCols.filter(collection => {
+                        const activeRun = smartCountRunsByCollection.get(collection.id);
+                        if (activeRun?.includesPromptSearch && !includesPromptSearch) return false;
+
+                        smartCountRunsByCollection.set(collection.id, { runId, includesPromptSearch });
+                        return true;
+                    });
+
+                    if (smartCols.length === 0) return;
 
                     if (shouldManagePending) {
-                        set({
-                            smartSummaryPendingIds: Object.fromEntries(
-                                smartCols
-                                    .filter(collection => !collection.thumbnail && !collection.customThumbnail)
-                                    .map(collection => [collection.id, true] as const)
-                            )
+                        set((state) => {
+                            const pending = { ...state.smartSummaryPendingIds };
+                            smartCols.forEach(collection => {
+                                delete pending[collection.id];
+                                if (!collection.thumbnail && !collection.customThumbnail) {
+                                    pending[collection.id] = true;
+                                }
+                            });
+                            return { smartSummaryPendingIds: pending };
+                        });
+                    } else {
+                        set((state) => {
+                            const pending = { ...state.smartSummaryPendingIds };
+                            smartCols.forEach(collection => delete pending[collection.id]);
+                            return { smartSummaryPendingIds: pending };
                         });
                     }
 
+                    if (options.delayMs && options.delayMs > 0) {
+                        await delay(options.delayMs);
+                    }
+
                     for (const smartCol of smartCols) {
-                        if (runId !== smartCountRunId) return;
+                        if (smartCountRunsByCollection.get(smartCol.id)?.runId !== runId) continue;
 
                         const summaries = await getSmartCollectionSummaries([smartCol], { includeThumbnails });
-                        if (runId !== smartCountRunId) return;
+                        if (smartCountRunsByCollection.get(smartCol.id)?.runId !== runId) continue;
                         const summary = summaries[smartCol.id];
 
                         if (summary) {
+                            await cacheSmartCollectionCount(
+                                smartCol.id,
+                                summary.count,
+                                smartCol.updatedAt ?? smartCol.createdAt
+                            );
+                            if (smartCountRunsByCollection.get(smartCol.id)?.runId !== runId) continue;
+
                             set((state) => ({
                                 collections: state.collections.map(c =>
                                     c.id === smartCol.id && c.filters
@@ -283,11 +303,25 @@ export const useCollectionStore = create<CollectionState>()(
                             });
                         }
 
+                        if (smartCountRunsByCollection.get(smartCol.id)?.runId === runId) {
+                            smartCountRunsByCollection.delete(smartCol.id);
+                        }
+
                         await delay(SMART_COUNT_YIELD_MS);
                     }
                 } catch (e) {
-                    if (runId === smartCountRunId) {
-                        set({ smartSummaryPendingIds: {} });
+                    if (runId > 0) {
+                        const ownedIds = smartCols
+                            .filter(collection => smartCountRunsByCollection.get(collection.id)?.runId === runId)
+                            .map(collection => collection.id);
+                        if (ownedIds.length > 0) {
+                            set((state) => {
+                                const remaining = { ...state.smartSummaryPendingIds };
+                                ownedIds.forEach(id => delete remaining[id]);
+                                return { smartSummaryPendingIds: remaining };
+                            });
+                            ownedIds.forEach(id => smartCountRunsByCollection.delete(id));
+                        }
                     }
                     console.error('[CollectionStore] Failed to refresh smart counts', e);
                 }

--- a/src/utils/__tests__/collectionCount.test.ts
+++ b/src/utils/__tests__/collectionCount.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import type { Collection } from '../../types';
+import { createDefaultFilters } from '../filterState';
+import { compareCollectionsByCount, getCollectionCount } from '../collectionCount';
+
+const collection = (overrides: Partial<Collection> = {}): Collection => ({
+    id: 'collection',
+    name: 'Collection',
+    imageIds: [],
+    createdAt: 1,
+    source: 'ambit',
+    ...overrides
+});
+
+describe('collection count semantics', () => {
+    it('uses a verified count, including zero, before any fallback', () => {
+        expect(getCollectionCount(collection({ count: 0, imageIds: ['one'] }))).toBe(0);
+        expect(getCollectionCount(collection({ count: 3, imageIds: [] }))).toBe(3);
+    });
+
+    it('falls back to membership only for static collections', () => {
+        expect(getCollectionCount(collection({ imageIds: ['one', 'two'] }))).toBe(2);
+        expect(getCollectionCount(collection({
+            imageIds: ['one', 'two'],
+            filters: createDefaultFilters()
+        }))).toBeUndefined();
+    });
+
+    it.each([
+        ['asc', ['empty', 'populated', 'unknown']],
+        ['desc', ['populated', 'empty', 'unknown']]
+    ] as const)('sorts unknown counts last for %s order', (direction, expectedIds) => {
+        const collections = [
+            collection({ id: 'unknown', filters: createDefaultFilters() }),
+            collection({ id: 'populated', count: 5 }),
+            collection({ id: 'empty', count: 0 })
+        ];
+
+        expect(collections.sort((a, b) => compareCollectionsByCount(a, b, direction)).map(item => item.id))
+            .toEqual(expectedIds);
+    });
+});

--- a/src/utils/__tests__/smartCollectionRefresh.test.ts
+++ b/src/utils/__tests__/smartCollectionRefresh.test.ts
@@ -26,13 +26,24 @@ describe('smartCollectionRefresh', () => {
         expect(shouldAutoRefreshSmartCollectionSummary(smart)).toBe(true);
     });
 
-    it('blocks automatic summaries for prompt-search smart collections', () => {
+    it('blocks automatic summaries for unpinned prompt-search smart collections', () => {
         const smart = collection({
             filters: createDefaultFilters({ searchQuery: 'apple' }),
+            isPinned: false,
         });
 
         expect(hasPromptSearchFilter(smart)).toBe(true);
         expect(shouldAutoRefreshSmartCollectionSummary(smart)).toBe(false);
+    });
+
+    it('allows automatic summaries for pinned prompt-search smart collections', () => {
+        const smart = collection({
+            filters: createDefaultFilters({ searchQuery: 'apple' }),
+            isPinned: true,
+        });
+
+        expect(hasPromptSearchFilter(smart)).toBe(true);
+        expect(shouldAutoRefreshSmartCollectionSummary(smart)).toBe(true);
     });
 
     it('does not treat static collections as automatic smart summaries', () => {

--- a/src/utils/collectionCount.ts
+++ b/src/utils/collectionCount.ts
@@ -1,0 +1,21 @@
+import type { Collection } from '../types';
+
+export type CollectionCountSortDirection = 'asc' | 'desc';
+
+export const getCollectionCount = (collection: Collection): number | undefined => {
+    if (collection.count !== undefined) return collection.count;
+    return collection.filters ? undefined : collection.imageIds.length;
+};
+
+export const compareCollectionsByCount = (
+    a: Collection,
+    b: Collection,
+    direction: CollectionCountSortDirection
+): number => {
+    const aCount = getCollectionCount(a);
+    const bCount = getCollectionCount(b);
+
+    if (aCount === undefined) return bCount === undefined ? 0 : 1;
+    if (bCount === undefined) return -1;
+    return direction === 'asc' ? aCount - bCount : bCount - aCount;
+};

--- a/src/utils/smartCollectionRefresh.ts
+++ b/src/utils/smartCollectionRefresh.ts
@@ -4,4 +4,4 @@ export const hasPromptSearchFilter = (collection: Collection): boolean =>
     !!collection.filters?.searchQuery?.trim();
 
 export const shouldAutoRefreshSmartCollectionSummary = (collection: Collection): boolean =>
-    !!collection.filters && !hasPromptSearchFilter(collection);
+    !!collection.filters && (!hasPromptSearchFilter(collection) || !!collection.isPinned);


### PR DESCRIPTION
## Summary

- persist the last calculated smart collection count in SQLite and restore it on startup
- distinguish an unknown count from a verified zero in collection UI and sorting
- refresh active and pinned prompt collections without allowing stale concurrent runs to overwrite newer results

## Root cause

Smart collection rows were intentionally mapped to `count: 0` during startup. Prompt-search collections were excluded from automatic summary hydration, so clicking a collection calculated the correct value only for the current session. Restarting reintroduced the forced zero.

## User impact

Smart collection counts now appear from their last calculated cache after restart. Collections that have never been calculated show an em dash instead of a false zero. Non-prompt and pinned prompt collections refresh automatically; other prompt collections refresh when opened.

## Validation

- `pnpm run test:run` - 2,775 passed, 1 skipped
- `node_modules\.bin\tsc.cmd --noEmit`
- `node_modules\.bin\vite.cmd build`
- `cargo fmt --check`
- `cargo test --lib m62_smart_collection_count_cache`
- `cargo test --lib db::migrations::tests`
- browser click/reload smoke test
