### PR TITLE
feat(search): use hybrid search triggers

### DIFF
--- a/docs/manual/search-filters-collections.md
+++ b/docs/manual/search-filters-collections.md
@@ -6,7 +6,7 @@ Ambit combines search text, metadata filters, asset facets, date ranges, favorit
 
 ## Search Bar
 
-The search bar matches the positive prompt by default. In Grid and Timeline, Ambit updates after typing pauses, and pressing Enter applies the current search immediately. In Statistics and Maintenance, typing stays in the search field until you press Enter or choose a recent search; Ambit then opens Grid to show the matching images.
+The search bar matches the positive prompt by default. In Grid and Timeline, Ambit updates about half a second after typing pauses, while pressing Enter finishes immediately and closes the expanded search. The focused standard search leaves the current results visible. In Statistics and Maintenance, typing stays in the search field until you press Enter or choose a recent search; Ambit then opens Grid to show the matching images.
 
 Search bar tools include:
 
@@ -17,11 +17,11 @@ Search bar tools include:
 - recent searches when the field is focused and empty
 - Clear search to remove the current search text
 - Clear in Recent Searches to remove the recent-search list
-- an ISO-date readiness hint when a date operator is incomplete or invalid
+- readiness guidance when a quote, operator value, date, number, boolean, or `OR` expression is incomplete or invalid
 - current scope and match feedback while the field is focused
 - Search syntax to open the in-app operator reference directly
 
-When AI Search is enabled from the search bar, the placeholder changes to an assistant-style prompt. AI Search waits for Enter instead of applying the natural-language draft as an ordinary prompt search. It keeps the existing filters until analysis succeeds, then applies the generated filters. Network and AI behavior depends on your settings; see [Settings And Privacy](settings-and-privacy.md).
+When AI Search is enabled from the search bar, the placeholder changes to an assistant-style prompt and the workspace is dimmed to emphasize the mode change. AI Search waits for Enter instead of applying the natural-language draft as an ordinary prompt search. It keeps the existing filters until analysis succeeds, then applies the generated filters. Network and AI behavior depends on your settings; see [Settings And Privacy](settings-and-privacy.md).
 
 Examples:
 
@@ -62,7 +62,7 @@ Supported operators include:
 - `w:>1024`, `width:1024`, `h:<768`, or `height:768` filter dimensions.
 - `upscaled:true` shows upscaled images; `upscaled:false` shows images marked not upscaled.
 
-Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity. If a `date:`, `after:`, or `before:` token is still partial, Ambit waits instead of applying the search.
+Use ISO dates such as `2026-04-15` to avoid country-specific date ambiguity. While structured syntax is unfinished or malformed, Ambit keeps the last applied results visible and does not run the draft. Complete quotes and operator values, use whole numbers for steps and dimensions, a decimal number for CFG, digits for seeds, `true` or `false` for `upscaled:`, and put `OR` between two positive-prompt terms. Correcting the draft restarts the normal half-second update.
 
 ## Date Filters
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -351,7 +351,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
             >
                 <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(circle_at_50%_0%,rgba(139,174,124,0.08),transparent_70%)] dark:bg-[radial-gradient(circle_at_50%_0%,rgba(139,174,124,0.15),transparent_60%)] z-10" />
 
-                {isSearchFocused && (
+                {isSearchFocused && searchProps.isAiSearchEnabled && (
                     <div
                         className="absolute inset-0 z-40 bg-black/60 backdrop-blur-sm animate-in fade-in duration-300"
                         onClick={() => {

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -450,7 +450,20 @@ describe('AppLayout', () => {
         expect(clearAllFilters).toHaveBeenCalled();
     });
 
-    it('dismisses the search-focus overlay', () => {
+    it('keeps standard search results unobscured while focused', () => {
+        const { container } = render(
+            <AppLayout
+                {...defaultProps}
+                isSearchFocused
+                searchProps={{ ...defaultProps.searchProps, isAiSearchEnabled: false }}
+            />
+        );
+
+        expect(container.querySelector('.absolute.inset-0.z-40.bg-black\\/60')).toBeNull();
+        expect(screen.getByTestId('virtual-grid')).toBeTruthy();
+    });
+
+    it('dims the workspace for focused AI search and dismisses the overlay', () => {
         const setIsSearchFocused = vi.fn();
         const blur = vi.fn();
         const { container } = render(
@@ -458,11 +471,15 @@ describe('AppLayout', () => {
                 {...defaultProps}
                 isSearchFocused
                 setIsSearchFocused={setIsSearchFocused}
-                searchProps={{ inputRef: { current: { blur } } } as any}
+                searchProps={{
+                    ...defaultProps.searchProps,
+                    inputRef: { current: { blur } },
+                    isAiSearchEnabled: true,
+                }}
             />
         );
 
-        const overlay = container.querySelector('.bg-black\\/60');
+        const overlay = container.querySelector('.absolute.inset-0.z-40.bg-black\\/60');
         expect(overlay).toBeTruthy();
         fireEvent.click(overlay as Element);
         expect(blur).toHaveBeenCalledOnce();

--- a/src/components/ui/AppHeader.tsx
+++ b/src/components/ui/AppHeader.tsx
@@ -3,12 +3,17 @@ import { Import } from 'lucide-react';
 import { AppSettings, FilterState, LayoutMode, SortOption, ViewMode } from '../../types';
 import { useLibraryContext } from '../../hooks/useLibraryContext';
 import { useLibraryStore } from '../../stores/libraryStore';
-import { SearchBar } from '../../features/filters/components/SearchBar';
 import { ViewControls } from '../../features/library/components/ViewControls';
 import { ActiveFilters } from '../../features/filters/components/ActiveFilters';
 import { isBrowserMockMode } from '../../services/runtime';
 import { ToastContext } from '../../contexts/ToastContext';
 import { TooltipButton } from './InfoTooltip';
+
+const SearchBar = React.lazy(() => import('../../features/filters/components/SearchBar').then(module => ({ default: module.SearchBar })));
+
+const SearchBarFallback = () => (
+    <div aria-hidden className="h-10 w-full max-w-lg rounded-xl bg-gray-100 dark:bg-zinc-800/50 animate-pulse" />
+);
 
 interface AppHeaderProps {
     viewMode: ViewMode;
@@ -123,18 +128,20 @@ export const AppHeader = React.memo(({
                 </div>
 
                 <div className="flex items-center gap-4 flex-1">
-                    <SearchBar
-                        filters={filters}
-                        setFilters={setFilters}
-                        searchProps={searchProps}
-                        recentSearches={recentSearches}
-                        setRecentSearches={setRecentSearches}
-                        scopeName={scopeName}
-                        displayedCount={displayedCount}
-                        isFiltering={isFiltering ?? false}
-                        submitNavigatesToGrid={viewMode === 'dashboard' || viewMode === 'maintenance'}
-                        onDraftPendingChange={onSearchDraftPendingChange}
-                    />
+                    <React.Suspense fallback={<SearchBarFallback />}>
+                        <SearchBar
+                            filters={filters}
+                            setFilters={setFilters}
+                            searchProps={searchProps}
+                            recentSearches={recentSearches}
+                            setRecentSearches={setRecentSearches}
+                            scopeName={scopeName}
+                            displayedCount={displayedCount}
+                            isFiltering={isFiltering ?? false}
+                            submitNavigatesToGrid={viewMode === 'dashboard' || viewMode === 'maintenance'}
+                            onDraftPendingChange={onSearchDraftPendingChange}
+                        />
+                    </React.Suspense>
                     {browserMockMode && (
                         <span className="shrink-0 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] font-semibold text-amber-700 dark:text-amber-300">
                             Browser Mock

--- a/src/features/filters/components/SearchBar.tsx
+++ b/src/features/filters/components/SearchBar.tsx
@@ -3,11 +3,12 @@ import { LoaderCircle, Search, Sparkles, X } from 'lucide-react';
 import { FilterState } from '../../../types';
 import { APP_NAME } from '../../../constants/app';
 import { useSearch } from '../../../contexts/SearchContext';
-import { getAdvancedDateSearchReadiness } from '../../../utils/dateFilters';
 import { TooltipButton } from '../../../components/ui/InfoTooltip';
 import type { SearchBarOption } from './SearchBarPopover';
 
 const SearchBarPopover = React.lazy(() => import('./SearchBarPopover').then(module => ({ default: module.SearchBarPopover })));
+
+type SearchReadinessApi = typeof import('../../../utils/searchQueryReadiness');
 
 interface SearchBarProps {
     filters: FilterState;
@@ -47,20 +48,40 @@ export const SearchBar = React.memo(({
     const [activeOptionIndex, setActiveOptionIndex] = React.useState(-1);
     const [areOptionsDismissed, setAreOptionsDismissed] = React.useState(false);
     const [operatorSuggestions, setOperatorSuggestions] = React.useState<readonly { value: string; description: string }[]>([]);
+    const [searchReadinessApi, setSearchReadinessApi] = React.useState<SearchReadinessApi | null>(null);
     const listboxId = React.useId();
     const statusId = React.useId();
+    const helperId = React.useId();
     const trimmedValue = localValue.trim();
-    const dateSearchReadiness = React.useMemo(
-        () => getAdvancedDateSearchReadiness(localValue),
-        [localValue]
+    const queryReadiness = React.useMemo(
+        () => searchProps.isAiSearchEnabled
+            ? { isReady: true as const, issue: null }
+            : searchReadinessApi
+                ? searchReadinessApi.getSearchQueryReadiness(localValue)
+                : localValue === filters.searchQuery
+                    ? { isReady: true as const, issue: null }
+                    : {
+                        isReady: false as const,
+                        issue: { kind: 'pending' as const, message: 'Checking syntax...' },
+                    },
+        [filters.searchQuery, localValue, searchProps.isAiSearchEnabled, searchReadinessApi]
     );
-    const dateSearchHint = dateSearchReadiness.isReady
-        ? null
-        : 'Use ISO dates like date:2026-04 or before:2025';
+    const queryIssue = queryReadiness.issue;
     const liveSearchEnabled = !searchProps.isAiSearchEnabled && !submitNavigatesToGrid;
     const isDraftPending = liveSearchEnabled
-        && dateSearchReadiness.isReady
+        && queryReadiness.isReady
         && localValue !== filters.searchQuery;
+
+    React.useEffect(() => {
+        let isCurrent = true;
+        void import('../../../utils/searchQueryReadiness').then(module => {
+            if (isCurrent) setSearchReadinessApi(module);
+        });
+
+        return () => {
+            isCurrent = false;
+        };
+    }, []);
 
     React.useEffect(() => {
         if (!searchProps.isFocused || searchProps.isAiSearchEnabled || operatorSuggestions.length > 0) return;
@@ -77,14 +98,17 @@ export const SearchBar = React.memo(({
 
     const matchingOperators = React.useMemo(() => {
         if (searchProps.isAiSearchEnabled) return [];
-        const lastToken = localValue.split(' ').pop()?.toLowerCase() || '';
+        const lastSpace = localValue.lastIndexOf(' ');
+        const lastToken = localValue.slice(lastSpace + 1).toLowerCase();
+        const prefix = lastSpace >= 0 ? localValue.slice(0, lastSpace).trimEnd() : '';
         if (!lastToken) return [];
 
         return operatorSuggestions.filter(operator => {
             const normalized = operator.value.toLowerCase();
+            if (operator.value === 'OR' && !searchReadinessApi?.canAppendPromptOr(prefix)) return false;
             return normalized.startsWith(lastToken) && normalized !== lastToken;
         });
-    }, [localValue, operatorSuggestions, searchProps.isAiSearchEnabled]);
+    }, [localValue, operatorSuggestions, searchProps.isAiSearchEnabled, searchReadinessApi]);
 
     const options = React.useMemo<SearchBarOption[]>(() => {
         if (areOptionsDismissed) return [];
@@ -135,17 +159,22 @@ export const SearchBar = React.memo(({
         onDraftPendingChange(false);
     }, [onDraftPendingChange]);
 
+    const triggerGuidance = searchProps.isAiSearchEnabled
+        ? 'Press Enter to analyze with AI.'
+        : submitNavigatesToGrid
+            ? 'Press Enter to show results in Grid.'
+            : 'Updates after you pause. Enter finishes.';
+
     const statusMessage = React.useMemo(() => {
-        if (dateSearchHint) return null;
+        if (queryIssue) return null;
         if (searchProps.isSearchingAi) return 'Analyzing with Gemini…';
         if (!trimmedValue) return null;
-        if (searchProps.isAiSearchEnabled) return 'Press Enter to analyze and apply filters.';
-        if (submitNavigatesToGrid) return 'Press Enter to view matching images in Grid.';
+        if (searchProps.isAiSearchEnabled || submitNavigatesToGrid) return triggerGuidance;
         if (isDraftPending || isFiltering) return `Searching ${scopeName}…`;
         if (displayedCount === 0) return `No matches in ${scopeName}.`;
         return `${displayedCount.toLocaleString()} ${displayedCount === 1 ? 'match' : 'matches'} in ${scopeName}.`;
     }, [
-        dateSearchHint,
+        queryIssue,
         displayedCount,
         filters.searchQuery,
         isFiltering,
@@ -155,6 +184,7 @@ export const SearchBar = React.memo(({
         searchProps.isAiSearchEnabled,
         searchProps.isSearchingAi,
         submitNavigatesToGrid,
+        triggerGuidance,
         trimmedValue,
     ]);
 
@@ -189,11 +219,12 @@ export const SearchBar = React.memo(({
     };
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === 'Escape' && options.length > 0) {
+        if (event.key === 'Escape') {
             event.preventDefault();
             event.stopPropagation();
             setActiveOptionIndex(-1);
             setAreOptionsDismissed(true);
+            searchProps.inputRef.current?.blur();
             return;
         }
 
@@ -221,7 +252,7 @@ export const SearchBar = React.memo(({
         }
 
         if (event.key === 'Enter') {
-            if (!dateSearchReadiness.isReady || searchProps.isSearchingAi) {
+            if (!queryReadiness.isReady || searchProps.isSearchingAi) {
                 event.preventDefault();
                 return;
             }
@@ -262,10 +293,13 @@ export const SearchBar = React.memo(({
     const accessibleName = searchProps.isAiSearchEnabled
         ? `Ask ${APP_NAME} with AI`
         : `Search in ${scopeName}`;
+    const describedBy = searchProps.isFocused
+        ? [queryIssue || statusMessage ? statusId : null, helperId].filter(Boolean).join(' ')
+        : undefined;
 
     return (
         <div
-            className={`relative w-full max-w-lg group flex items-center gap-2 transition-all duration-300 ${searchProps.isFocused ? 'z-[70] scale-105' : 'z-30'}`}
+            className={`group flex items-center gap-2 ${searchProps.isFocused ? 'absolute left-6 right-6 top-1/2 max-w-lg -translate-y-1/2 z-[70]' : 'relative w-full max-w-lg z-30'}`}
             onFocusCapture={handleFocusCapture}
             onBlurCapture={handleBlurCapture}
         >
@@ -284,7 +318,8 @@ export const SearchBar = React.memo(({
                     aria-expanded={searchProps.isFocused && options.length > 0}
                     aria-controls={searchProps.isFocused && options.length > 0 ? listboxId : undefined}
                     aria-activedescendant={searchProps.isFocused ? activeOption?.id : undefined}
-                    aria-describedby={searchProps.isFocused && (dateSearchHint || statusMessage) ? statusId : undefined}
+                    aria-describedby={describedBy || undefined}
+                    aria-invalid={queryIssue?.kind === 'invalid' ? true : undefined}
                     aria-busy={searchProps.isSearchingAi}
                     readOnly={searchProps.isSearchingAi}
                     placeholder={searchProps.isAiSearchEnabled ? `Ask ${APP_NAME}...` : `Search in ${scopeName}...`}
@@ -309,10 +344,12 @@ export const SearchBar = React.memo(({
                     <React.Suspense fallback={null}>
                         <SearchBarPopover
                             activeOptionIndex={activeOptionIndex}
-                            dateSearchHint={dateSearchHint}
+                            helperId={helperId}
+                            helperText={triggerGuidance}
                             listboxId={listboxId}
                             listLabel={listLabel}
                             options={options}
+                            queryIssue={queryIssue}
                             statusId={statusId}
                             statusMessage={statusMessage}
                             onClearRecentSearches={clearRecentSearches}

--- a/src/features/filters/components/SearchBarPopover.tsx
+++ b/src/features/filters/components/SearchBarPopover.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { BookOpen, History } from 'lucide-react';
+import type { SearchQueryIssue } from '../../../utils/searchQueryReadiness';
 
 export interface SearchBarOption {
     id: string;
@@ -10,10 +11,12 @@ export interface SearchBarOption {
 
 interface SearchBarPopoverProps {
     activeOptionIndex: number;
-    dateSearchHint: string | null;
+    helperId: string;
+    helperText: string;
     listboxId: string;
     listLabel: string;
     options: readonly SearchBarOption[];
+    queryIssue: SearchQueryIssue | null;
     statusId: string;
     statusMessage: string | null;
     onClearRecentSearches: () => void;
@@ -23,10 +26,12 @@ interface SearchBarPopoverProps {
 
 export const SearchBarPopover = React.memo(({
     activeOptionIndex,
-    dateSearchHint,
+    helperId,
+    helperText,
     listboxId,
     listLabel,
     options,
+    queryIssue,
     statusId,
     statusMessage,
     onClearRecentSearches,
@@ -34,9 +39,14 @@ export const SearchBarPopover = React.memo(({
     onSelectOption,
 }: SearchBarPopoverProps) => (
     <div className="absolute top-full left-0 right-0 mt-2 bg-white dark:bg-zinc-900 border border-gray-200 dark:border-white/10 rounded-xl shadow-2xl z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
-        {dateSearchHint ? (
-            <div id={statusId} role="status" className="px-4 py-2 text-xs text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border-b border-amber-100 dark:border-amber-900/40">
-                {dateSearchHint}
+        {queryIssue ? (
+            <div
+                id={statusId}
+                role="status"
+                aria-live="polite"
+                className={`px-4 py-2 text-xs border-b ${queryIssue.kind === 'invalid' ? 'text-red-700 dark:text-red-300 bg-red-50 dark:bg-red-950/30 border-red-100 dark:border-red-900/40' : 'text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-950/30 border-amber-100 dark:border-amber-900/40'}`}
+            >
+                {queryIssue.message}
             </div>
         ) : statusMessage ? (
             <div id={statusId} role="status" aria-live="polite" className="px-4 py-2 text-xs text-gray-600 dark:text-gray-300 bg-gray-50 dark:bg-black/20 border-b border-gray-100 dark:border-white/5">
@@ -81,7 +91,9 @@ export const SearchBarPopover = React.memo(({
         ) : null}
 
         <div className="border-t border-gray-100 dark:border-white/5 px-3 py-2 flex items-center justify-between gap-3">
-            <span className="text-[10px] text-gray-400">Plain text searches positive prompts.</span>
+            <span id={helperId} className="text-[10px] text-gray-400">
+                {statusMessage === helperText ? 'Search syntax opens standard query operators.' : helperText}
+            </span>
             <button
                 type="button"
                 onClick={onOpenSearchHelp}

--- a/src/features/filters/components/__tests__/SearchBar.accessibility.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.accessibility.test.tsx
@@ -67,7 +67,7 @@ const renderSearchBar = (
     };
 };
 
-describe('SearchBar advanced date syntax guard', () => {
+describe('SearchBar accessibility', () => {
     it('exposes AI search as a dynamic pressed action with accessible help', () => {
         const harness = renderSearchBar();
         const aiButton = screen.getByRole('button', { name: 'Enable AI Search' });
@@ -95,16 +95,48 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('sunset');
     });
 
-    it('dismisses deferred suggestions with Escape and opens search syntax help directly', async () => {
+    it('dismisses deferred suggestions and blurs the search with Escape', async () => {
         const harness = renderSearchBar();
         const input = screen.getByRole('combobox', { name: 'Search in Library' });
+        act(() => input.focus());
         fireEvent.change(input, { target: { value: 'cn' } });
         expect(await screen.findByRole('listbox', { name: 'Search operator suggestions' })).toBeTruthy();
 
         fireEvent.keyDown(input, { key: 'Escape' });
         expect(screen.queryByRole('listbox')).toBeNull();
+        expect(harness.searchProps.onBlur).toHaveBeenCalledOnce();
+    });
 
+    it('opens search syntax help directly', async () => {
+        const harness = renderSearchBar();
+        expect(await screen.findByRole('button', { name: 'Search syntax' })).toBeTruthy();
         fireEvent.click(screen.getByRole('button', { name: 'Search syntax' }));
         expect(harness.searchProps.onOpenSearchHelp).toHaveBeenCalledOnce();
+    });
+
+    it('describes each trigger mode with its visible helper text', async () => {
+        const standard = renderSearchBar();
+        const standardInput = screen.getByRole('combobox', { name: 'Search in Library' });
+        const standardHelper = await screen.findByText('Updates after you pause. Enter finishes.');
+        expect(standardInput.getAttribute('aria-describedby')).toContain(standardHelper.id);
+
+        standard.unmount();
+        renderSearchBar(createDefaultFilters(), { isAiSearchEnabled: true });
+        const aiInput = screen.getByRole('combobox', { name: 'Ask Ambit with AI' });
+        const aiHelper = await screen.findByText('Press Enter to analyze with AI.');
+        expect(aiInput.getAttribute('aria-describedby')).toContain(aiHelper.id);
+    });
+
+    it('does not duplicate Enter-only guidance after a prompt is entered', async () => {
+        renderSearchBar(
+            createDefaultFilters({ searchQuery: 'existing prompt' }),
+            { isAiSearchEnabled: true }
+        );
+        const guidance = await screen.findAllByText('Press Enter to analyze with AI.');
+        const helper = screen.getByText('Search syntax opens standard query operators.');
+        const input = screen.getByRole('combobox', { name: 'Ask Ambit with AI' });
+
+        expect(guidance).toHaveLength(1);
+        expect(input.getAttribute('aria-describedby')).toContain(helper.id);
     });
 });

--- a/src/features/filters/components/__tests__/SearchBar.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.test.tsx
@@ -107,6 +107,7 @@ describe('SearchBar query readiness and trigger behavior', () => {
     it('keeps incomplete date syntax local and shows a hint', async () => {
         const harness = renderSearchBar();
         await flushSearchPopover();
+        await flushSearchReadiness();
         const input = screen.getByRole('combobox', { name: 'Search in Library' });
 
         fireEvent.change(input, {

--- a/src/features/filters/components/__tests__/SearchBar.test.tsx
+++ b/src/features/filters/components/__tests__/SearchBar.test.tsx
@@ -88,7 +88,13 @@ const flushSearchPopover = async () => {
     });
 };
 
-describe('SearchBar advanced date syntax guard', () => {
+const flushSearchReadiness = async () => {
+    await act(async () => {
+        await import('../../../../utils/searchQueryReadiness');
+    });
+};
+
+describe('SearchBar query readiness and trigger behavior', () => {
     beforeEach(() => {
         vi.useFakeTimers();
         vi.clearAllMocks();
@@ -101,8 +107,9 @@ describe('SearchBar advanced date syntax guard', () => {
     it('keeps incomplete date syntax local and shows a hint', async () => {
         const harness = renderSearchBar();
         await flushSearchPopover();
+        const input = screen.getByRole('combobox', { name: 'Search in Library' });
 
-        fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
+        fireEvent.change(input, {
             target: { value: 'date:2026-' },
         });
 
@@ -111,11 +118,14 @@ describe('SearchBar advanced date syntax guard', () => {
         });
 
         expect(harness.setFilters).not.toHaveBeenCalled();
-        expect(screen.getByRole('status').textContent).toBe('Use ISO dates like date:2026-04 or before:2025');
+        expect(screen.getByRole('status').textContent).toBe('Use ISO dates like date:2026-04 or before:2025.');
+        expect(input.getAttribute('aria-invalid')).toBeNull();
+        expect(input.getAttribute('aria-describedby')?.split(' ')).toHaveLength(2);
     });
 
-    it('commits valid date syntax after the main debounce', () => {
+    it('commits valid date syntax after the main debounce', async () => {
         const harness = renderSearchBar();
+        await flushSearchReadiness();
 
         fireEvent.change(screen.getByRole('combobox', { name: 'Search in Library' }), {
             target: { value: 'date:2026-04' },
@@ -129,8 +139,9 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.getCurrentFilters().searchQuery).toBe('date:2026-04');
     });
 
-    it('does not submit invalid date syntax on Enter', () => {
+    it('does not submit invalid date syntax on Enter', async () => {
         const harness = renderSearchBar();
+        await flushSearchReadiness();
         const input = screen.getByRole('combobox', { name: 'Search in Library' });
 
         fireEvent.change(input, {
@@ -140,6 +151,27 @@ describe('SearchBar advanced date syntax guard', () => {
 
         expect(harness.setFilters).not.toHaveBeenCalled();
         expect(harness.searchProps.submitSearch).not.toHaveBeenCalled();
+        expect(input.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('preserves the applied query until an invalid draft is corrected', async () => {
+        const harness = renderSearchBar(createDefaultFilters({ searchQuery: 'portrait' }));
+        await flushSearchReadiness();
+        const input = screen.getByRole('combobox', { name: 'Search in Library' });
+
+        fireEvent.change(input, { target: { value: 'steps:many' } });
+        act(() => vi.advanceTimersByTime(600));
+
+        expect(harness.setFilters).not.toHaveBeenCalled();
+        expect(harness.getCurrentFilters().searchQuery).toBe('portrait');
+        expect(input.getAttribute('aria-invalid')).toBe('true');
+
+        fireEvent.change(input, { target: { value: 'steps:30' } });
+        expect(input.getAttribute('aria-invalid')).toBeNull();
+        act(() => vi.advanceTimersByTime(499));
+        expect(harness.setFilters).not.toHaveBeenCalled();
+        act(() => vi.advanceTimersByTime(1));
+        expect(harness.getCurrentFilters().searchQuery).toBe('steps:30');
     });
 
     it('does not commit a date operator suggestion before a value exists', async () => {
@@ -173,8 +205,9 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.getCurrentFilters().searchQuery).toBe('after:2026');
     });
 
-    it('replaces a pending debounce and commits only the latest query', () => {
+    it('replaces a pending debounce and commits only the latest query', async () => {
         const harness = renderSearchBar();
+        await flushSearchReadiness();
         const input = screen.getByRole('combobox', { name: 'Search in Library' });
         fireEvent.change(input, { target: { value: 'first' } });
         fireEvent.change(input, { target: { value: 'second' } });
@@ -236,7 +269,7 @@ describe('SearchBar advanced date syntax guard', () => {
         expect(harness.searchProps.submitSearch).toHaveBeenCalledTimes(1);
     });
 
-    it('selects suggestions with the pointer and clears suggestions for blank tokens', async () => {
+    it('suggests OR only after a valid positive-prompt operand', async () => {
         renderSearchBar();
         await flushSearchPopover();
         const input = screen.getByRole('combobox');
@@ -244,19 +277,36 @@ describe('SearchBar advanced date syntax guard', () => {
         fireEvent.click(screen.getByRole('option', { name: /lora:/ }));
         expect((input as HTMLInputElement).value).toBe('lora:');
         fireEvent.change(input, { target: { value: 'o' } });
+        expect(screen.queryByRole('option', { name: /OR/ })).toBeNull();
+        fireEvent.change(input, { target: { value: 'forest o' } });
         fireEvent.click(screen.getByRole('option', { name: /OR/ }));
-        expect((input as HTMLInputElement).value).toBe('OR ');
+        expect((input as HTMLInputElement).value).toBe('forest OR ');
         fireEvent.change(input, { target: { value: ' ' } });
         expect(screen.queryByText('Suggestions')).toBeNull();
     });
 
-    it('submits ordinary searches on Enter', () => {
+    it('submits ordinary searches on Enter', async () => {
         const harness = renderSearchBar();
+        await flushSearchReadiness();
         const input = screen.getByRole('combobox');
         fireEvent.change(input, { target: { value: 'portrait' } });
         fireEvent.keyDown(input, { key: 'Enter' });
         expect(harness.setFilters).not.toHaveBeenCalled();
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('portrait');
+    });
+
+    it('expands over the toolbar without scaling and collapses on Escape', () => {
+        const harness = renderSearchBar();
+        const root = harness.container.firstElementChild;
+        const input = screen.getByRole('combobox');
+
+        expect(root?.className).toContain('absolute left-6 right-6');
+        expect(root?.className).toContain('max-w-lg');
+        expect(root?.className).not.toContain('scale-105');
+
+        act(() => input.focus());
+        fireEvent.keyDown(input, { key: 'Escape' });
+        expect(harness.searchProps.onBlur).toHaveBeenCalled();
     });
 
     it('clears the query, suggestions, and focuses the input', () => {
@@ -312,7 +362,7 @@ describe('SearchBar advanced date syntax guard', () => {
 
         expect(harness.setFilters).not.toHaveBeenCalled();
         expect(harness.onDraftPendingChange).toHaveBeenLastCalledWith(false);
-        expect(screen.getByRole('status').textContent).toBe('Press Enter to view matching images in Grid.');
+        expect(screen.getByRole('status').textContent).toBe('Press Enter to show results in Grid.');
 
         fireEvent.keyDown(input, { key: 'Enter' });
         expect(harness.searchProps.submitSearch).toHaveBeenCalledWith('portrait');

--- a/src/utils/__tests__/searchQueryReadiness.test.ts
+++ b/src/utils/__tests__/searchQueryReadiness.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { canAppendPromptOr, getSearchQueryReadiness } from '../searchQueryReadiness';
+
+describe('getSearchQueryReadiness', () => {
+    it.each([
+        '',
+        'forest portrait',
+        '"dark elf"',
+        'steps:30 cfg:7.5 width:1024 height:>512',
+        'seed:123 upscaled:false',
+        'date:2026-04 before:2025',
+        'forest OR ocean OR sky',
+        'unknown:value',
+        '"artist:name"',
+    ])('allows ready query %s', query => {
+        expect(getSearchQueryReadiness(query)).toEqual({ isReady: true, issue: null });
+    });
+
+    it.each([
+        ['"unfinished', 'Finish the quoted phrase before searching.'],
+        ['model:', 'Add a value after model:'],
+        ['date:2026-', 'Use ISO dates like date:2026-04 or before:2025.'],
+        ['steps:>', 'Use steps:30, steps:>30, or steps:<30.'],
+        ['cfg:7.', 'Use cfg:7, cfg:>7, or cfg:<7.'],
+        ['upscaled:t', 'Use upscaled:true or upscaled:false.'],
+        ['forest OR', 'Add a positive prompt term after OR.'],
+    ])('marks incomplete query %s as pending', (query, message) => {
+        const result = getSearchQueryReadiness(query);
+        expect(result.issue).toMatchObject({ kind: 'pending', message });
+    });
+
+    it.each([
+        ['before:june-2024', 'Use ISO dates like date:2026-04 or before:2025.'],
+        ['steps:3.5', 'Use steps:30, steps:>30, or steps:<30.'],
+        ['width:large', 'Use width:30, width:>30, or width:<30.'],
+        ['cfg:high', 'Use cfg:7, cfg:>7, or cfg:<7.'],
+        ['seed:-42', 'Use seed: followed by digits.'],
+        ['upscaled:yes', 'Use upscaled:true or upscaled:false.'],
+        ['OR forest', 'Use OR between two positive prompt terms.'],
+        ['forest OR OR ocean', 'Use OR between two positive prompt terms.'],
+        ['forest OR model:flux', 'Use OR between two positive prompt terms.'],
+    ])('marks malformed query %s as invalid', (query, message) => {
+        const result = getSearchQueryReadiness(query);
+        expect(result.issue).toMatchObject({ kind: 'invalid', message });
+    });
+
+    it.each([
+        `steps:${'9'.repeat(400)}`,
+        `cfg:${'9'.repeat(400)}`,
+        `width:>${'9'.repeat(400)}`,
+    ])('rejects non-finite numeric query %s', query => {
+        expect(getSearchQueryReadiness(query).issue?.kind).toBe('invalid');
+    });
+
+    it.each([
+        'steps:9007199254740993',
+        'height:>9007199254740993',
+    ])('rejects integer query %s when parsing would lose precision', query => {
+        expect(getSearchQueryReadiness(query).issue?.kind).toBe('invalid');
+    });
+
+    it('suggests OR only after a positive prompt operand', () => {
+        expect(canAppendPromptOr('forest')).toBe(true);
+        expect(canAppendPromptOr('forest OR ocean')).toBe(true);
+        expect(canAppendPromptOr('model:flux')).toBe(false);
+        expect(canAppendPromptOr('-forest')).toBe(false);
+        expect(canAppendPromptOr('forest OR')).toBe(false);
+        expect(canAppendPromptOr('')).toBe(false);
+    });
+});

--- a/src/utils/searchQueryReadiness.ts
+++ b/src/utils/searchQueryReadiness.ts
@@ -1,0 +1,179 @@
+import { getAdvancedDateSearchReadiness } from './dateFilters';
+
+export type SearchQueryIssueKind = 'pending' | 'invalid';
+
+export interface SearchQueryIssue {
+    kind: SearchQueryIssueKind;
+    message: string;
+    token?: string;
+}
+
+export interface SearchQueryReadiness {
+    isReady: boolean;
+    issue: SearchQueryIssue | null;
+}
+
+interface SearchQueryToken {
+    term: string;
+    isNegative: boolean;
+    isQuoted: boolean;
+    isOrOperator: boolean;
+}
+
+const INTEGER_COMPARISON_KEYS = new Set(['steps', 'w', 'width', 'h', 'height']);
+const DECIMAL_COMPARISON_KEYS = new Set(['cfg']);
+const DATE_KEYS = new Set(['date', 'after', 'before']);
+const INTEGER_COMPARISON_PATTERN = /^[<>]?\d+$/;
+const DECIMAL_COMPARISON_PATTERN = /^[<>]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const PENDING_DECIMAL_COMPARISON_PATTERN = /^[<>]?(?:\d+\.?|\.?)$/;
+const DIGITS_PATTERN = /^\d+$/;
+
+const isFiniteComparisonValue = (value: string): boolean => (
+    Number.isFinite(Number(value.replace(/^[<>]/, '')))
+);
+
+const isSafeIntegerComparisonValue = (value: string): boolean => (
+    Number.isSafeInteger(Number(value.replace(/^[<>]/, '')))
+);
+
+const hasUnfinishedQuote = (query: string): boolean => {
+    let isEscaped = false;
+    let isOpen = false;
+
+    for (const character of query) {
+        if (isEscaped) {
+            isEscaped = false;
+            continue;
+        }
+        if (character === '\\') {
+            isEscaped = true;
+            continue;
+        }
+        if (character === '"') isOpen = !isOpen;
+    }
+
+    return isOpen;
+};
+
+const tokenizeSearchQuery = (query: string): SearchQueryToken[] => {
+    const tokens: SearchQueryToken[] = [];
+    const termPattern = /(-|!)?("(?:[^"\\]|\\.)*"|\S+)/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = termPattern.exec(query)) !== null) {
+        const rawTerm = match[2];
+        const isQuoted = rawTerm.startsWith('"') && rawTerm.endsWith('"');
+        const term = isQuoted ? rawTerm.slice(1, -1) : rawTerm;
+        tokens.push({
+            term,
+            isNegative: Boolean(match[1]),
+            isQuoted,
+            isOrOperator: !match[1] && !isQuoted && term.toUpperCase() === 'OR',
+        });
+    }
+
+    return tokens;
+};
+
+const createIssue = (
+    kind: SearchQueryIssueKind,
+    message: string,
+    token?: string
+): SearchQueryReadiness => ({
+    isReady: false,
+    issue: { kind, message, token },
+});
+
+const isPositivePromptOperand = (token: SearchQueryToken | undefined): boolean => Boolean(
+    token
+    && !token.isNegative
+    && !token.isOrOperator
+    && (token.isQuoted || !token.term.includes(':'))
+    && token.term.length > 0
+);
+
+export const canAppendPromptOr = (query: string): boolean => {
+    if (hasUnfinishedQuote(query)) return false;
+    const tokens = tokenizeSearchQuery(query);
+    return isPositivePromptOperand(tokens.at(-1));
+};
+
+export const getSearchQueryReadiness = (query: string): SearchQueryReadiness => {
+    if (hasUnfinishedQuote(query)) {
+        return createIssue('pending', 'Finish the quoted phrase before searching.');
+    }
+
+    const dateReadiness = getAdvancedDateSearchReadiness(query);
+    if (!dateReadiness.isReady) {
+        return createIssue(
+            dateReadiness.issue ?? 'invalid',
+            'Use ISO dates like date:2026-04 or before:2025.',
+            dateReadiness.token
+        );
+    }
+
+    const tokens = tokenizeSearchQuery(query);
+
+    for (const token of tokens) {
+        if (token.isQuoted || token.isOrOperator || token.term.startsWith(':') || !token.term.includes(':')) {
+            continue;
+        }
+
+        const separatorIndex = token.term.indexOf(':');
+        const key = token.term.slice(0, separatorIndex).toLowerCase();
+        const value = token.term.slice(separatorIndex + 1);
+
+        if (!value) {
+            return createIssue('pending', `Add a value after ${key}:`, token.term);
+        }
+        if (DATE_KEYS.has(key)) continue;
+
+        if (
+            INTEGER_COMPARISON_KEYS.has(key)
+            && (!INTEGER_COMPARISON_PATTERN.test(value) || !isSafeIntegerComparisonValue(value))
+        ) {
+            return createIssue(
+                value === '<' || value === '>' ? 'pending' : 'invalid',
+                `Use ${key}:30, ${key}:>30, or ${key}:<30.`,
+                token.term
+            );
+        }
+        if (
+            DECIMAL_COMPARISON_KEYS.has(key)
+            && (!DECIMAL_COMPARISON_PATTERN.test(value) || !isFiniteComparisonValue(value))
+        ) {
+            const isPendingDecimal = !DECIMAL_COMPARISON_PATTERN.test(value)
+                && PENDING_DECIMAL_COMPARISON_PATTERN.test(value);
+            return createIssue(
+                isPendingDecimal ? 'pending' : 'invalid',
+                `Use ${key}:7, ${key}:>7, or ${key}:<7.`,
+                token.term
+            );
+        }
+        if (key === 'seed' && !DIGITS_PATTERN.test(value)) {
+            return createIssue('invalid', 'Use seed: followed by digits.', token.term);
+        }
+        if (key === 'upscaled' && value.toLowerCase() !== 'true' && value.toLowerCase() !== 'false') {
+            const normalizedValue = value.toLowerCase();
+            const isPendingBoolean = 'true'.startsWith(normalizedValue) || 'false'.startsWith(normalizedValue);
+            return createIssue(
+                isPendingBoolean ? 'pending' : 'invalid',
+                'Use upscaled:true or upscaled:false.',
+                token.term
+            );
+        }
+    }
+
+    for (let index = 0; index < tokens.length; index += 1) {
+        if (!tokens[index].isOrOperator) continue;
+
+        if (index === tokens.length - 1 && isPositivePromptOperand(tokens[index - 1])) {
+            return createIssue('pending', 'Add a positive prompt term after OR.', tokens[index].term);
+        }
+        if (!isPositivePromptOperand(tokens[index - 1]) || !isPositivePromptOperand(tokens[index + 1])) {
+            return createIssue('invalid', 'Use OR between two positive prompt terms.', tokens[index].term);
+        }
+    }
+
+    return { isReady: true, issue: null };
+};


### PR DESCRIPTION
## Summary

- auto-search standard queries after a 500 ms pause in Grid and Timeline
- keep AI Search, Statistics, and Maintenance explicitly Enter-triggered
- prevent incomplete structured syntax from committing while the user is still typing
- clarify keyboard guidance, focus treatment, and accessible status messaging
- document the hybrid trigger behavior

## Why

Immediate search is the fastest interaction for normal local filtering, but expensive AI analysis and cross-view navigation should remain deliberate. Structured operators also need a readiness guard so partial values do not temporarily replace valid results.

## User impact

Users get responsive standard search without having to press Enter, while Enter remains the predictable confirmation action. AI requests cannot fire accidentally, incomplete operators preserve the prior result set, and standard search no longer dims the workspace.

## Validation

- focused search/layout/virtual-grid tests: 98 passed
- full frontend suite: 2,823 passed, 1 existing skip
- ESLint
- TypeScript typecheck
- production build
- build output guard
- rendered browser interaction and accessibility QA
- git diff whitespace check
