### PR TITLE
fix: preserve ComfyUI source output slots

### DIFF
--- a/docs/plans/milestone-24.md
+++ b/docs/plans/milestone-24.md
@@ -1,0 +1,187 @@
+# Milestone 24: ComfyUI Output-Slot and Sigma-Lineage Fidelity
+
+Status: In Progress
+Catalog commit: `c3bf8342318a3c2bfcbf6d0ac020155745417f29`
+
+## Reconciliation
+
+- Rust remains the authoritative ComfyUI metadata parser.
+- Official catalog fixtures remain workflow-only, pinned, and offline.
+- Deterministic graph values must be exact or unavailable; stale widgets and
+  disconnected fallback values must not reopen failed connected paths.
+- No frontend, database, Tauri command, Specta binding, diagnostics DTO, or
+  `ImageMetadata` shape changes are planned.
+
+The milestone starts with parser version 26 and 22 `golden`, 9
+`pattern_covered`, 4 `partial`, 40 `unassessed`, and 474 `excluded` catalog
+entries.
+
+## Objective
+
+Preserve connected source output slots, resolve the deterministic
+`CustomCombo.INDEX` path used by Bernini, and trace `SplitSigmas` back to its
+real scheduler without treating the split position as total steps.
+
+The milestone is accepted when Bernini has exact golden metadata and
+provenance, parser version 28 is live, and the catalog reaches 23 `golden` and
+3 `partial` entries.
+
+## Work Package 1: Source Output-Slot Fidelity
+
+Status: Complete (`fix/comfyui-output-slot-fidelity`, 2026-07-18)
+
+Primary invariant: graph normalization never discards a connected source's
+output slot.
+
+Scope:
+
+- Add an internal source reference containing node ID and optional output slot.
+- Preserve slots from API links and normalized workflow array/object edges,
+  including expanded nested subgraphs.
+- Keep existing ID-only connection helpers behaviorally unchanged; only new
+  slot-aware evaluators consume the richer reference.
+- Add API, workflow, unresolved-link, and subgraph-boundary regressions.
+
+Non-goals:
+
+- No `CustomCombo` evaluation, `SplitSigmas` traversal, metadata changes, or
+  manifest changes.
+- No parser-version increment; any metadata output change is a regression.
+
+Targeted verification:
+
+- workflow-subgraph and graph-focused tests;
+- full ComfyUI and reparse tests;
+- `cargo fmt --check` and `git diff --check`.
+
+Completion criteria:
+
+- source node IDs and output slots are exact for API and workflow graphs;
+- existing ID-only parsing produces unchanged metadata;
+- the package is independently review-clean.
+
+Verification evidence:
+
+- `cargo test metadata::comfyui::tests::graph_sources`: 4 passed;
+- `cargo test metadata::comfyui::tests::workflow_subgraphs`: 14 passed;
+- `cargo test metadata::comfyui`: 230 passed, 1 ignored;
+- `cargo test metadata::reparse`: 10 passed;
+- `cargo fmt --check` and `git diff --check`: passed.
+
+## Work Package 2: Deterministic CustomCombo Resolution
+
+Depends on: Work Package 1.
+
+Status: Pending (`fix/comfyui-custom-combo-resolution`)
+
+Primary invariant: an output-slot-specific deterministic value is exact or
+unavailable, never guessed.
+
+Scope:
+
+- Resolve `CustomCombo` output slot 0 as the selected string and serialized
+  output slot 1 as its validated option index.
+- Give connected `choice` values authority over direct or workflow widgets.
+- Require unlinked workflow selected value, stored index, and option list to
+  agree before returning an index.
+- Reject unsupported slots, unresolved links, inconsistent widgets, cycles,
+  and values beyond existing string limits.
+- Update Bernini to assert the exact positive prompt while it remains partial
+  for missing schedule metadata.
+- Increment parser version from 26 to 27.
+
+Non-goals:
+
+- No arbitrary combo execution, generated-text execution, or scheduler work.
+- No manifest promotion.
+
+Targeted verification:
+
+- prompt and workflow-subgraph tests;
+- Bernini official-catalog regression;
+- full ComfyUI and reparse tests.
+
+Completion criteria:
+
+- Bernini resolves `You are a helpful assistant.make it night` from the
+  selected output path;
+- stale or malformed combo state cannot fabricate an index or prompt;
+- parser version 27 reparses affected rows.
+
+## Work Package 3: SplitSigmas Scheduler Ancestry
+
+Depends on: Work Packages 1 and 2.
+
+Status: Pending (`fix/comfyui-split-sigmas-scheduler`)
+
+Primary invariant: a sigma split position controls staging but never
+masquerades as the generation step count.
+
+Scope:
+
+- Follow a selected sampler's connected `SplitSigmas.sigmas` input through
+  reroutes to the originating scheduler.
+- Extract total steps and scheduler only from that upstream scheduler using
+  link-first authority, cycle detection, and a depth limit of 16.
+- Preserve root/base-first model selection and direct sampler precedence.
+- Promote `video_bernini_r_image_editing` to exact golden coverage with 6
+  steps, `res_multistep (simple)`, its deterministic positive prompt, existing
+  negative prompt, model, seed, CFG, and LoRA.
+- Increment parser version from 27 to 28 and update manifest totals to 23
+  `golden`, 9 `pattern_covered`, 3 `partial`, 40 `unassessed`, and 474
+  `excluded`.
+
+Non-goals:
+
+- No use of `SplitSigmas.step` as total steps.
+- No generated-text, JSON-expression, Ideogram, or unrelated scheduler work.
+
+Targeted verification:
+
+- multi-stage and official-catalog tests;
+- template coverage, workflow-subgraph, and output-selection tests;
+- full ComfyUI and reparse tests.
+
+Completion criteria:
+
+- Bernini metadata and provenance are exact;
+- unresolved, cyclic, and disconnected schedule paths fail closed;
+- parser version and manifest totals are correct.
+
+## Work Package 4: Integration Review and Closure
+
+Depends on: Work Packages 1-3.
+
+Status: Pending (`docs/comfyui-milestone-24-integration`)
+
+Primary invariant: the merged packages preserve the last completed milestone
+while closing the Bernini gap without public interface changes.
+
+Scope:
+
+- Review all merged packages together on fresh `main`.
+- Run the full milestone acceptance gate and record observed counts.
+- Confirm parser version 28, final manifest totals, and no `Cargo.lock` churn.
+- Publish a docs-only closure PR and stop before Milestone 25.
+
+Non-goals:
+
+- No parser behavior, fixture, or coverage changes.
+
+## Milestone Acceptance Gate
+
+After all behavior packages merge:
+
+1. Run prompt, multi-stage, official-catalog, template-coverage,
+   workflow-subgraph, output-selection, full ComfyUI, and reparse tests.
+2. Run `cargo fmt --check` and `git diff --check`.
+3. Confirm parser version 28, final manifest totals, no `Cargo.lock` churn, and
+   no public interface changes.
+4. Mark this plan complete with merged PRs and observed verification evidence.
+
+## Deferred
+
+- ERNIE and Florence workflows remain partial because generated text is not
+  embedded in their workflow metadata.
+- Ideogram remains unassessed because its JSON extraction, math-expression,
+  dual-model guider, and custom scheduler policy require a separate milestone.

--- a/src-tauri/src/metadata/comfyui/graph.rs
+++ b/src-tauri/src/metadata/comfyui/graph.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{json, Value};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
@@ -13,6 +13,19 @@ pub struct ComfyGraph {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum InputConnection {
     Connected(String),
+    DeclaredUnresolved,
+    Unconnected,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct InputSource {
+    pub(crate) node_id: String,
+    pub(crate) output_slot: Option<usize>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum InputSourceConnection {
+    Connected(InputSource),
     DeclaredUnresolved,
     Unconnected,
 }
@@ -53,12 +66,20 @@ impl ComfyGraph {
                         for edge in &normalized.edges {
                             incoming.insert(
                                 (edge.target_id.clone(), edge.target_slot),
-                                (edge.source_id.clone(), edge.link_type.clone()),
+                                (
+                                    edge.source_id.clone(),
+                                    edge.source_slot,
+                                    edge.link_type.clone(),
+                                ),
                             );
                             if let Some(link_id) = &edge.link_id {
                                 incoming_by_link.insert(
                                     (edge.target_id.clone(), link_id.clone()),
-                                    (edge.source_id.clone(), edge.link_type.clone()),
+                                    (
+                                        edge.source_id.clone(),
+                                        edge.source_slot,
+                                        edge.link_type.clone(),
+                                    ),
                                 );
                             }
                         }
@@ -78,10 +99,12 @@ impl ComfyGraph {
                             else {
                                 continue;
                             };
-                            if let Some((source_id, link_type)) = incoming.get(&(id, 0)) {
+                            if let Some((source_id, source_slot, link_type)) =
+                                incoming.get(&(id, 0))
+                            {
                                 var_map.insert(
                                     var_name.to_string(),
-                                    (source_id.clone(), link_type.clone()),
+                                    (source_id.clone(), *source_slot, link_type.clone()),
                                 );
                             }
                         }
@@ -92,6 +115,7 @@ impl ComfyGraph {
                             };
                             let node_type = get_node_type(&node).to_string();
                             let mut resolved = serde_json::Map::new();
+                            let mut resolved_sources = serde_json::Map::new();
 
                             if let Some(inputs) = node.get("inputs").and_then(Value::as_array) {
                                 for (slot, input) in inputs.iter().enumerate() {
@@ -106,12 +130,21 @@ impl ComfyGraph {
                                             incoming_by_link.get(&(id.clone(), link_id))
                                         })
                                         .or_else(|| incoming.get(&(id.clone(), slot)));
-                                    if let Some((source_id, _)) = linked_source {
+                                    if let Some((source_id, source_slot, _)) = linked_source {
                                         let value = resolved
                                             .entry(name.to_string())
                                             .or_insert(Value::Array(Vec::new()));
                                         if let Some(values) = value.as_array_mut() {
                                             values.push(Value::String(source_id.clone()));
+                                        }
+                                        let value = resolved_sources
+                                            .entry(name.to_string())
+                                            .or_insert(Value::Array(Vec::new()));
+                                        if let Some(values) = value.as_array_mut() {
+                                            values.push(resolved_source_value(
+                                                source_id,
+                                                *source_slot,
+                                            ));
                                         }
                                     }
                                 }
@@ -123,7 +156,9 @@ impl ComfyGraph {
                                     .and_then(|value| value.get(0))
                                     .and_then(Value::as_str)
                                 {
-                                    if let Some((source_id, link_type)) = var_map.get(var_name) {
+                                    if let Some((source_id, source_slot, link_type)) =
+                                        var_map.get(var_name)
+                                    {
                                         resolved.insert(
                                             var_name.to_string(),
                                             Value::String(source_id.clone()),
@@ -138,6 +173,14 @@ impl ComfyGraph {
                                                 Value::String(source_id.clone()),
                                             );
                                         }
+                                        let source = resolved_source_value(source_id, *source_slot);
+                                        resolved_sources
+                                            .insert(var_name.to_string(), source.clone());
+                                        resolved_sources
+                                            .insert("source".to_string(), source.clone());
+                                        if !link_type.is_empty() && link_type != "*" {
+                                            resolved_sources.insert(link_type.clone(), source);
+                                        }
                                     }
                                 }
                             }
@@ -146,6 +189,10 @@ impl ComfyGraph {
                                 object.insert(
                                     "_resolved_inputs".to_string(),
                                     Value::Object(resolved),
+                                );
+                                object.insert(
+                                    "_resolved_sources".to_string(),
+                                    Value::Object(resolved_sources),
                                 );
                             }
                             nodes_map.insert(id, node);
@@ -195,21 +242,52 @@ pub fn get_node_input_link(node: &Value, key: &str) -> Option<String> {
 }
 
 pub(crate) fn get_input_connection(node: &Value, key: &str) -> InputConnection {
+    match get_input_source(node, key) {
+        InputSourceConnection::Connected(source) => InputConnection::Connected(source.node_id),
+        InputSourceConnection::DeclaredUnresolved => InputConnection::DeclaredUnresolved,
+        InputSourceConnection::Unconnected => InputConnection::Unconnected,
+    }
+}
+
+pub(crate) fn get_input_source(node: &Value, key: &str) -> InputSourceConnection {
+    if let Some(value) = node
+        .get("_resolved_sources")
+        .and_then(|inputs| inputs.get(key))
+    {
+        if let Some(source) = resolved_input_source(value) {
+            return InputSourceConnection::Connected(source);
+        }
+        if let Some(source) = value
+            .as_array()
+            .and_then(|sources| sources.first())
+            .and_then(resolved_input_source)
+        {
+            return InputSourceConnection::Connected(source);
+        }
+        return InputSourceConnection::DeclaredUnresolved;
+    }
+
     if let Some(value) = node
         .get("_resolved_inputs")
         .and_then(|inputs| inputs.get(key))
     {
         if let Some(source_id) = value.as_str() {
-            return InputConnection::Connected(source_id.to_string());
+            return InputSourceConnection::Connected(InputSource {
+                node_id: source_id.to_string(),
+                output_slot: None,
+            });
         }
         if let Some(source_id) = value
             .as_array()
             .and_then(|sources| sources.first())
             .and_then(Value::as_str)
         {
-            return InputConnection::Connected(source_id.to_string());
+            return InputSourceConnection::Connected(InputSource {
+                node_id: source_id.to_string(),
+                output_slot: None,
+            });
         }
-        return InputConnection::DeclaredUnresolved;
+        return InputSourceConnection::DeclaredUnresolved;
     }
 
     if let Some(value) = node
@@ -225,9 +303,12 @@ pub(crate) fn get_input_connection(node: &Value, key: &str) -> InputConnection {
                     .or_else(|| link[0].as_i64().map(|source_id| source_id.to_string()))
                     .or_else(|| link[0].as_u64().map(|source_id| source_id.to_string()))
                 {
-                    return InputConnection::Connected(source_id);
+                    return InputSourceConnection::Connected(InputSource {
+                        node_id: source_id,
+                        output_slot: value_as_usize(&link[1]),
+                    });
                 }
-                return InputConnection::DeclaredUnresolved;
+                return InputSourceConnection::DeclaredUnresolved;
             }
         }
     }
@@ -242,10 +323,32 @@ pub(crate) fn get_input_connection(node: &Value, key: &str) -> InputConnection {
                 && input.get("link").is_some_and(|link| !link.is_null())
         })
     {
-        return InputConnection::DeclaredUnresolved;
+        return InputSourceConnection::DeclaredUnresolved;
     }
 
-    InputConnection::Unconnected
+    InputSourceConnection::Unconnected
+}
+
+fn resolved_source_value(source_id: &str, source_slot: usize) -> Value {
+    json!({
+        "node_id": source_id,
+        "output_slot": source_slot,
+    })
+}
+
+fn resolved_input_source(value: &Value) -> Option<InputSource> {
+    let object = value.as_object()?;
+    Some(InputSource {
+        node_id: object.get("node_id").and_then(value_as_id)?,
+        output_slot: object.get("output_slot").and_then(value_as_usize),
+    })
+}
+
+fn value_as_usize(value: &Value) -> Option<usize> {
+    value
+        .as_u64()
+        .and_then(|value| usize::try_from(value).ok())
+        .or_else(|| value.as_i64().and_then(|value| usize::try_from(value).ok()))
 }
 
 pub(crate) fn get_strict_source_id(node: &Value, key: &str) -> Option<String> {

--- a/src-tauri/src/metadata/comfyui/tests/graph_sources.rs
+++ b/src-tauri/src/metadata/comfyui/tests/graph_sources.rs
@@ -1,0 +1,203 @@
+use super::super::graph::{
+    get_input_connection, get_input_source, ComfyGraph, InputConnection, InputSource,
+    InputSourceConnection,
+};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+fn graph_from_chunk(key: &str, value: Value) -> ComfyGraph {
+    ComfyGraph::from_chunks(&HashMap::from([(key.to_string(), value.to_string())]))
+}
+
+fn assert_source(
+    graph: &ComfyGraph,
+    node_id: &str,
+    input_name: &str,
+    expected_id: &str,
+    expected_slot: usize,
+) {
+    let node = graph.get_node(node_id).expect("connected target node");
+    assert_eq!(
+        get_input_source(node, input_name),
+        InputSourceConnection::Connected(InputSource {
+            node_id: expected_id.to_string(),
+            output_slot: Some(expected_slot),
+        })
+    );
+    assert_eq!(
+        get_input_connection(node, input_name),
+        InputConnection::Connected(expected_id.to_string()),
+        "the existing ID-only connection projection must remain unchanged"
+    );
+}
+
+#[test]
+fn api_connections_preserve_source_output_slots() {
+    let graph = graph_from_chunk(
+        "prompt",
+        json!({
+            "7": { "class_type": "Source", "inputs": {} },
+            "9": {
+                "class_type": "Target",
+                "inputs": { "value": ["7", 3] }
+            },
+            "10": {
+                "class_type": "LegacyTarget",
+                "inputs": { "value": ["7", -1] }
+            }
+        }),
+    );
+
+    assert_source(&graph, "9", "value", "7", 3);
+    let legacy_node = graph.get_node("10").expect("legacy target node");
+    assert_eq!(
+        get_input_source(legacy_node, "value"),
+        InputSourceConnection::Connected(InputSource {
+            node_id: "7".to_string(),
+            output_slot: None,
+        })
+    );
+    assert_eq!(
+        get_input_connection(legacy_node, "value"),
+        InputConnection::Connected("7".to_string()),
+        "invalid legacy slot values must not change ID-only connection behavior"
+    );
+}
+
+#[test]
+fn workflow_array_and_object_edges_preserve_source_output_slots() {
+    let graph = graph_from_chunk(
+        "workflow",
+        json!({
+            "nodes": [
+                {
+                    "id": 1,
+                    "type": "Source",
+                    "inputs": [],
+                    "outputs": [
+                        { "name": "A", "type": "STRING", "links": [] },
+                        { "name": "B", "type": "STRING", "links": [11] },
+                        { "name": "C", "type": "STRING", "links": [10] }
+                    ]
+                },
+                {
+                    "id": 2,
+                    "type": "Target",
+                    "inputs": [{ "name": "array_value", "type": "STRING", "link": 10 }],
+                    "outputs": []
+                },
+                {
+                    "id": 3,
+                    "type": "Target",
+                    "inputs": [{ "name": "object_value", "type": "STRING", "link": 11 }],
+                    "outputs": []
+                }
+            ],
+            "links": [
+                [10, 1, 2, 2, 0, "STRING"],
+                {
+                    "id": 11,
+                    "origin_id": 1,
+                    "origin_slot": 1,
+                    "target_id": 3,
+                    "target_slot": 0,
+                    "type": "STRING"
+                }
+            ],
+            "version": 0.4
+        }),
+    );
+
+    assert_source(&graph, "2", "array_value", "1", 2);
+    assert_source(&graph, "3", "object_value", "1", 1);
+}
+
+#[test]
+fn nested_subgraph_outputs_keep_the_internal_source_slot() {
+    let graph = graph_from_chunk(
+        "workflow",
+        json!({
+            "nodes": [
+                {
+                    "id": 30,
+                    "type": "outer_definition",
+                    "mode": 0,
+                    "inputs": [],
+                    "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [20] }]
+                },
+                {
+                    "id": 40,
+                    "type": "SaveImage",
+                    "mode": 0,
+                    "inputs": [{ "name": "images", "type": "IMAGE", "link": 20 }],
+                    "outputs": []
+                }
+            ],
+            "links": [[20, 30, 0, 40, 0, "IMAGE"]],
+            "definitions": {
+                "subgraphs": [{
+                    "id": "inner_definition",
+                    "inputNode": { "id": -10 },
+                    "outputNode": { "id": -20 },
+                    "inputs": [],
+                    "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+                    "nodes": [{
+                        "id": 7,
+                        "type": "MultiOutputSource",
+                        "inputs": [],
+                        "outputs": [
+                            { "name": "A", "type": "IMAGE", "links": [] },
+                            { "name": "B", "type": "IMAGE", "links": [] },
+                            { "name": "C", "type": "IMAGE", "links": [21] }
+                        ]
+                    }],
+                    "links": [[21, 7, 2, -20, 0, "IMAGE"]]
+                }, {
+                    "id": "outer_definition",
+                    "inputNode": { "id": -10 },
+                    "outputNode": { "id": -20 },
+                    "inputs": [],
+                    "outputs": [{ "name": "IMAGE", "type": "IMAGE" }],
+                    "nodes": [{
+                        "id": 8,
+                        "type": "inner_definition",
+                        "mode": 0,
+                        "inputs": [],
+                        "outputs": [{ "name": "IMAGE", "type": "IMAGE", "links": [22] }]
+                    }],
+                    "links": [[22, 8, 0, -20, 0, "IMAGE"]]
+                }]
+            },
+            "version": 0.4
+        }),
+    );
+
+    assert_source(&graph, "40", "images", "30:8:7", 2);
+}
+
+#[test]
+fn declared_unresolved_workflow_links_have_no_source_or_slot() {
+    let graph = graph_from_chunk(
+        "workflow",
+        json!({
+            "nodes": [{
+                "id": 2,
+                "type": "Target",
+                "inputs": [{ "name": "value", "type": "STRING", "link": 999 }],
+                "outputs": []
+            }],
+            "links": [],
+            "version": 0.4
+        }),
+    );
+    let node = graph.get_node("2").expect("unresolved target node");
+
+    assert_eq!(
+        get_input_source(node, "value"),
+        InputSourceConnection::DeclaredUnresolved
+    );
+    assert_eq!(
+        get_input_connection(node, "value"),
+        InputConnection::DeclaredUnresolved
+    );
+}

--- a/src-tauri/src/metadata/comfyui/tests/mod.rs
+++ b/src-tauri/src/metadata/comfyui/tests/mod.rs
@@ -4,6 +4,7 @@ pub mod complex_workflows;
 pub mod diagnostics;
 pub mod false_positive_models;
 pub mod general;
+pub mod graph_sources;
 pub mod merge_precedence;
 pub mod models;
 pub mod multi_stage;


### PR DESCRIPTION
## Summary
- preserve source output-slot identity for ComfyUI API prompt links and workflow edges
- carry slot identity through GetNode/SetNode and recursively normalized workflow subgraphs
- retain the existing ID-only connection API as a compatibility projection
- add the persisted Milestone 24 work-package plan and focused graph-source regressions

## Why
Work Package 2 needs to resolve `CustomCombo` output slots deterministically. The graph previously discarded source-slot identity during workflow normalization, making slot-specific string evaluation impossible without guessing.

## Compatibility
- parser output is unchanged
- parser version remains 26
- no public API, schema, binding, diagnostics DTO, or frontend changes

## Verification
- `cargo test metadata::comfyui::tests::graph_sources` (4 passed)
- `cargo test metadata::comfyui::tests::workflow_subgraphs` (14 passed)
- `cargo test metadata::comfyui` (230 passed, 1 ignored)
- `cargo test metadata::reparse` (10 passed)
- `cargo fmt --check`
- `git diff --check`