### PR TITLE
fix: resolve deterministic ComfyUI JSON numbers

### DIFF
--- a/docs/plans/milestone-25.md
+++ b/docs/plans/milestone-25.md
@@ -76,6 +76,8 @@ Verification evidence:
 
 ## Work Package 2: Deterministic JSON and Number Resolution
 
+Status: Complete (`fix/comfyui-deterministic-json-number-resolution`, `2026-07-21`)
+
 Depends on: Work Package 1.
 
 Primary invariant: connected profile values are exact or unavailable.
@@ -102,6 +104,18 @@ Completion criteria:
   numeric scheduler parameters;
 - malformed, oversized, cyclic, or unresolved paths fail closed;
 - the package is independently review-clean.
+
+Verification evidence:
+
+- the pinned `Default` profile resolves 20 steps, `mu = 0.0`, and
+  `std = 1.75` through the connected JSON and converter path;
+- deterministic-value tests pass with 9 tests, prompt tests with 50,
+  graph-source tests with 4, and catalog-intake tests with 5;
+- the full ComfyUI suite passes with 250 tests and the existing Ollama test
+  ignored; all 10 reparse tests pass;
+- parser version is 29, Ideogram remains `unassessed`, and manifest totals
+  remain unchanged;
+- `cargo fmt --check` and `git diff --check` pass with no `Cargo.lock` churn.
 
 ## Work Package 3: Dual-Model Guider Policy
 

--- a/src-tauri/src/metadata/comfyui/conditioning.rs
+++ b/src-tauri/src/metadata/comfyui/conditioning.rs
@@ -638,6 +638,22 @@ pub(crate) fn evaluate_string_node_strict(
     )
 }
 
+pub(crate) fn evaluate_string_source_strict(
+    graph: &ComfyGraph,
+    source: &InputSource,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) -> Option<String> {
+    evaluate_string_source_with_mode(
+        graph,
+        source,
+        visited,
+        depth,
+        StringEvaluationMode::TransformOperand,
+        true,
+    )
+}
+
 fn evaluate_string_node_with_mode(
     graph: &ComfyGraph,
     node_id: &str,
@@ -946,6 +962,40 @@ fn evaluate_string_node_with_mode(
             strict_connections,
         )?;
         return replace_string_bounded(&source, &find, &replacement);
+    }
+
+    if t == "JsonExtractString" {
+        if !matches!(output_slot, None | Some(0)) {
+            return None;
+        }
+        let json_string = evaluate_transform_input(
+            graph,
+            node,
+            "json_string",
+            visited,
+            depth,
+            MAX_TRANSFORM_STRING_BYTES,
+            None,
+            strict_connections,
+        )?;
+        let key = evaluate_transform_input(
+            graph,
+            node,
+            "key",
+            visited,
+            depth,
+            MAX_TRANSFORM_PATTERN_BYTES,
+            None,
+            strict_connections,
+        )?;
+        let parsed: Value = serde_json::from_str(&json_string).ok()?;
+        let value = parsed.as_object()?.get(&key);
+        let result = match value {
+            None | Some(Value::Null) => String::new(),
+            Some(Value::String(value)) => value.clone(),
+            Some(value) => serde_json::to_string(value).ok()?,
+        };
+        return (result.len() <= MAX_TRANSFORM_STRING_BYTES).then_some(result);
     }
 
     if t == "RegexExtract" {

--- a/src-tauri/src/metadata/comfyui/eval_utils.rs
+++ b/src-tauri/src/metadata/comfyui/eval_utils.rs
@@ -1,6 +1,7 @@
 use super::graph::{
-    get_input_connection, get_node_id, get_node_param, get_node_type,
+    get_input_connection, get_input_source, get_node_id, get_node_param, get_node_type,
     get_switch_branch_input_strict, get_switch_branch_source, ComfyGraph, InputConnection,
+    InputSource, InputSourceConnection,
 };
 use serde_json::Value;
 use std::collections::HashSet;
@@ -130,52 +131,234 @@ fn first_declared_connection(node: &Value, keys: &[&str]) -> InputConnection {
     InputConnection::Unconnected
 }
 
+fn first_declared_source(node: &Value, keys: &[&str]) -> InputSourceConnection {
+    for key in keys {
+        match get_input_source(node, key) {
+            InputSourceConnection::Unconnected => {}
+            connection => return connection,
+        }
+    }
+    InputSourceConnection::Unconnected
+}
+
+enum NumericScalar {
+    Boolean(bool),
+    Integer(i64),
+    Unsigned(u64),
+    Float(f64),
+    String(String),
+}
+
+fn numeric_scalar_from_value(value: &Value) -> Option<NumericScalar> {
+    if let Some(value) = value.as_bool() {
+        return Some(NumericScalar::Boolean(value));
+    }
+    if let Some(value) = value.as_i64() {
+        return Some(NumericScalar::Integer(value));
+    }
+    if let Some(value) = value.as_u64() {
+        return Some(NumericScalar::Unsigned(value));
+    }
+    if let Some(value) = value.as_f64() {
+        return value.is_finite().then_some(NumericScalar::Float(value));
+    }
+    value
+        .as_str()
+        .map(|value| NumericScalar::String(value.to_string()))
+}
+
+fn numeric_scalar_as_i64(value: NumericScalar) -> Option<i64> {
+    match value {
+        NumericScalar::Boolean(value) => Some(i64::from(value)),
+        NumericScalar::Integer(value) => Some(value),
+        NumericScalar::Unsigned(value) => i64::try_from(value).ok(),
+        NumericScalar::Float(value) => finite_float_as_i64(value),
+        NumericScalar::String(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                return None;
+            }
+            value
+                .parse::<i64>()
+                .ok()
+                .or_else(|| {
+                    value
+                        .parse::<u64>()
+                        .ok()
+                        .and_then(|value| i64::try_from(value).ok())
+                })
+                .or_else(|| value.parse::<f64>().ok().and_then(finite_float_as_i64))
+        }
+    }
+}
+
+fn numeric_scalar_as_f64(value: NumericScalar) -> Option<f64> {
+    let value = match value {
+        NumericScalar::Boolean(value) => {
+            if value {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        NumericScalar::Integer(value) => value as f64,
+        NumericScalar::Unsigned(value) => value as f64,
+        NumericScalar::Float(value) => value,
+        NumericScalar::String(value) => value.trim().parse::<f64>().ok()?,
+    };
+    value.is_finite().then_some(value)
+}
+
+fn finite_float_as_i64(value: f64) -> Option<i64> {
+    const I64_UPPER_EXCLUSIVE: f64 = 9_223_372_036_854_775_808.0;
+
+    if !value.is_finite() {
+        return None;
+    }
+    let value = value.trunc();
+    if value < i64::MIN as f64 || value >= I64_UPPER_EXCLUSIVE {
+        return None;
+    }
+    Some(value as i64)
+}
+
+fn evaluate_numeric_scalar_source(
+    graph: &ComfyGraph,
+    source: &InputSource,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) -> Option<NumericScalar> {
+    if depth > 16 || !visited.insert(source.node_id.clone()) {
+        return None;
+    }
+    let node = graph.get_node(&source.node_id)?;
+    let node_type = get_node_type(node);
+
+    if node_type == "ComfySwitchNode" {
+        let branch = get_switch_branch_input_strict(graph, node)?;
+        return match get_input_source(node, branch) {
+            InputSourceConnection::Connected(source) => {
+                evaluate_numeric_scalar_source(graph, &source, visited, depth + 1)
+            }
+            InputSourceConnection::DeclaredUnresolved | InputSourceConnection::Unconnected => None,
+        };
+    }
+
+    if node_type == "Reroute" {
+        return match first_declared_source(node, &["", "value", "input", "any"]) {
+            InputSourceConnection::Connected(source) => {
+                evaluate_numeric_scalar_source(graph, &source, visited, depth + 1)
+            }
+            InputSourceConnection::DeclaredUnresolved | InputSourceConnection::Unconnected => None,
+        };
+    }
+
+    if node_type == "ComfyNumberConvert" {
+        return evaluate_comfy_number_convert(graph, node, source.output_slot, visited, depth);
+    }
+
+    match first_declared_source(node, &["value", "int", "float"]) {
+        InputSourceConnection::Connected(source) => {
+            return evaluate_numeric_scalar_source(graph, &source, visited, depth + 1);
+        }
+        InputSourceConnection::DeclaredUnresolved => return None,
+        InputSourceConnection::Unconnected => {}
+    }
+
+    for key in ["value", "int", "float"] {
+        if let Some(value) = get_node_param(node, key).and_then(numeric_scalar_from_value) {
+            return Some(value);
+        }
+    }
+
+    if let Some(value) =
+        super::conditioning::evaluate_string_source_strict(graph, source, &mut HashSet::new(), 0)
+    {
+        return Some(NumericScalar::String(value));
+    }
+
+    if let Some(value) = node
+        .get("widgets_values")
+        .and_then(Value::as_array)
+        .and_then(|values| values.first())
+        .and_then(numeric_scalar_from_value)
+    {
+        return Some(value);
+    }
+
+    None
+}
+
+fn evaluate_comfy_number_convert(
+    graph: &ComfyGraph,
+    node: &Value,
+    output_slot: Option<usize>,
+    visited: &mut HashSet<String>,
+    depth: usize,
+) -> Option<NumericScalar> {
+    let value = match get_input_source(node, "value") {
+        InputSourceConnection::Connected(source) => {
+            evaluate_numeric_scalar_source(graph, &source, visited, depth + 1)?
+        }
+        InputSourceConnection::DeclaredUnresolved => return None,
+        InputSourceConnection::Unconnected => {
+            get_node_param(node, "value").and_then(numeric_scalar_from_value)?
+        }
+    };
+
+    match output_slot {
+        Some(0) => numeric_scalar_as_f64(value).map(NumericScalar::Float),
+        Some(1) => numeric_scalar_as_i64(value).map(NumericScalar::Integer),
+        _ => None,
+    }
+}
+
 fn evaluate_linked_number_strict(
     graph: &ComfyGraph,
-    node_id: &str,
+    source: &InputSource,
     param: &str,
     max_limit: i64,
     visited: &mut HashSet<String>,
     depth: usize,
 ) -> Option<i64> {
-    if depth > 16 || !visited.insert(node_id.to_string()) {
+    if depth > 16 || !visited.insert(source.node_id.clone()) {
         return None;
     }
-    let node = graph.get_node(node_id)?;
-    if get_node_type(node) == "ComfySwitchNode" {
+    let node = graph.get_node(&source.node_id)?;
+    let node_type = get_node_type(node);
+    if node_type == "ComfyNumberConvert" {
+        let value = evaluate_comfy_number_convert(graph, node, source.output_slot, visited, depth)?;
+        return numeric_scalar_as_i64(value).filter(|value| *value < max_limit);
+    }
+    if node_type == "ComfySwitchNode" {
         let branch = get_switch_branch_input_strict(graph, node)?;
-        return match get_input_connection(node, branch) {
-            InputConnection::Connected(source_id) => evaluate_linked_number_strict(
-                graph,
-                &source_id,
-                param,
-                max_limit,
-                visited,
-                depth + 1,
-            ),
-            InputConnection::DeclaredUnresolved | InputConnection::Unconnected => None,
+        return match get_input_source(node, branch) {
+            InputSourceConnection::Connected(source) => {
+                evaluate_linked_number_strict(graph, &source, param, max_limit, visited, depth + 1)
+            }
+            InputSourceConnection::DeclaredUnresolved | InputSourceConnection::Unconnected => None,
         };
     }
 
-    let input_keys: &[&str] = if get_node_type(node) == "Reroute" {
+    let input_keys: &[&str] = if node_type == "Reroute" {
         &["", "value", "input", "any"]
     } else {
         &["value", "int", param]
     };
-    match first_declared_connection(node, input_keys) {
-        InputConnection::Connected(source_id) => {
+    match first_declared_source(node, input_keys) {
+        InputSourceConnection::Connected(source) => {
             return evaluate_linked_number_strict(
                 graph,
-                &source_id,
+                &source,
                 param,
                 max_limit,
                 visited,
                 depth + 1,
             );
         }
-        InputConnection::DeclaredUnresolved => return None,
-        InputConnection::Unconnected if get_node_type(node) == "Reroute" => return None,
-        InputConnection::Unconnected => {}
+        InputSourceConnection::DeclaredUnresolved => return None,
+        InputSourceConnection::Unconnected if node_type == "Reroute" => return None,
+        InputSourceConnection::Unconnected => {}
     }
 
     for key in ["value", "int", param] {
@@ -192,50 +375,50 @@ fn evaluate_linked_number_strict(
 
 fn evaluate_linked_float_strict(
     graph: &ComfyGraph,
-    node_id: &str,
+    source: &InputSource,
     param: &str,
     max_limit: f64,
     visited: &mut HashSet<String>,
     depth: usize,
 ) -> Option<f64> {
-    if depth > 16 || !visited.insert(node_id.to_string()) {
+    if depth > 16 || !visited.insert(source.node_id.clone()) {
         return None;
     }
-    let node = graph.get_node(node_id)?;
-    if get_node_type(node) == "ComfySwitchNode" {
+    let node = graph.get_node(&source.node_id)?;
+    let node_type = get_node_type(node);
+    if node_type == "ComfyNumberConvert" {
+        let value = evaluate_comfy_number_convert(graph, node, source.output_slot, visited, depth)?;
+        return numeric_scalar_as_f64(value).filter(|value| *value < max_limit);
+    }
+    if node_type == "ComfySwitchNode" {
         let branch = get_switch_branch_input_strict(graph, node)?;
-        return match get_input_connection(node, branch) {
-            InputConnection::Connected(source_id) => evaluate_linked_float_strict(
-                graph,
-                &source_id,
-                param,
-                max_limit,
-                visited,
-                depth + 1,
-            ),
-            InputConnection::DeclaredUnresolved | InputConnection::Unconnected => None,
+        return match get_input_source(node, branch) {
+            InputSourceConnection::Connected(source) => {
+                evaluate_linked_float_strict(graph, &source, param, max_limit, visited, depth + 1)
+            }
+            InputSourceConnection::DeclaredUnresolved | InputSourceConnection::Unconnected => None,
         };
     }
 
-    let input_keys: &[&str] = if get_node_type(node) == "Reroute" {
+    let input_keys: &[&str] = if node_type == "Reroute" {
         &["", "value", "input", "any"]
     } else {
         &["value", "float", param]
     };
-    match first_declared_connection(node, input_keys) {
-        InputConnection::Connected(source_id) => {
+    match first_declared_source(node, input_keys) {
+        InputSourceConnection::Connected(source) => {
             return evaluate_linked_float_strict(
                 graph,
-                &source_id,
+                &source,
                 param,
                 max_limit,
                 visited,
                 depth + 1,
             );
         }
-        InputConnection::DeclaredUnresolved => return None,
-        InputConnection::Unconnected if get_node_type(node) == "Reroute" => return None,
-        InputConnection::Unconnected => {}
+        InputSourceConnection::DeclaredUnresolved => return None,
+        InputSourceConnection::Unconnected if node_type == "Reroute" => return None,
+        InputSourceConnection::Unconnected => {}
     }
 
     for key in ["value", "float", param] {
@@ -323,17 +506,12 @@ pub(crate) fn evaluate_number_link_first(
     param: &str,
     max_limit: i64,
 ) -> Option<i64> {
-    match get_input_connection(node, param) {
-        InputConnection::Connected(source_id) => evaluate_linked_number_strict(
-            graph,
-            &source_id,
-            param,
-            max_limit,
-            &mut HashSet::new(),
-            0,
-        ),
-        InputConnection::DeclaredUnresolved => None,
-        InputConnection::Unconnected => get_node_param(node, param)
+    match get_input_source(node, param) {
+        InputSourceConnection::Connected(source) => {
+            evaluate_linked_number_strict(graph, &source, param, max_limit, &mut HashSet::new(), 0)
+        }
+        InputSourceConnection::DeclaredUnresolved => None,
+        InputSourceConnection::Unconnected => get_node_param(node, param)
             .and_then(value_as_i64)
             .filter(|value| *value < max_limit),
     }
@@ -345,17 +523,12 @@ pub(crate) fn evaluate_float_link_first(
     param: &str,
     max_limit: f64,
 ) -> Option<f64> {
-    match get_input_connection(node, param) {
-        InputConnection::Connected(source_id) => evaluate_linked_float_strict(
-            graph,
-            &source_id,
-            param,
-            max_limit,
-            &mut HashSet::new(),
-            0,
-        ),
-        InputConnection::DeclaredUnresolved => None,
-        InputConnection::Unconnected => get_node_param(node, param)
+    match get_input_source(node, param) {
+        InputSourceConnection::Connected(source) => {
+            evaluate_linked_float_strict(graph, &source, param, max_limit, &mut HashSet::new(), 0)
+        }
+        InputSourceConnection::DeclaredUnresolved => None,
+        InputSourceConnection::Unconnected => get_node_param(node, param)
             .and_then(value_as_f64)
             .filter(|value| *value < max_limit),
     }

--- a/src-tauri/src/metadata/comfyui/graph.rs
+++ b/src-tauri/src/metadata/comfyui/graph.rs
@@ -755,6 +755,14 @@ pub fn get_node_param<'a>(node: &'a Value, key: &str) -> Option<&'a Value> {
             }
         }
 
+        if t == "JsonExtractString" {
+            match key {
+                "json_string" => return arr.first(),
+                "key" => return arr.get(1),
+                _ => {}
+            }
+        }
+
         if t == "RegexExtract" {
             match key {
                 "string" => return arr.first(),

--- a/src-tauri/src/metadata/comfyui/tests/deterministic_values.rs
+++ b/src-tauri/src/metadata/comfyui/tests/deterministic_values.rs
@@ -1,0 +1,277 @@
+use super::super::conditioning::evaluate_string_node_strict;
+use super::super::eval_utils::{evaluate_float_link_first, evaluate_number_link_first};
+use super::super::graph::{get_node_type, ComfyGraph};
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+
+fn prompt_graph(nodes: Value) -> ComfyGraph {
+    let chunks = HashMap::from([("prompt".to_string(), nodes.to_string())]);
+    ComfyGraph::from_chunks(&chunks)
+}
+
+fn workflow_graph(nodes: Value, links: Value) -> ComfyGraph {
+    let workflow = json!({ "nodes": nodes, "links": links });
+    let chunks = HashMap::from([("workflow".to_string(), workflow.to_string())]);
+    ComfyGraph::from_chunks(&chunks)
+}
+
+fn evaluate_string_node(graph: &ComfyGraph, node_id: &str) -> Option<String> {
+    evaluate_string_node_strict(graph, node_id, &mut HashSet::new(), 0)
+}
+
+fn converter_graph(value: Value, output_slot: usize) -> ComfyGraph {
+    prompt_graph(json!({
+        "1": { "class_type": "ComfyNumberConvert", "inputs": { "value": value } },
+        "2": { "class_type": "Consumer", "inputs": { "number": ["1", output_slot] } }
+    }))
+}
+
+#[test]
+fn json_extract_uses_connected_inputs_and_compact_json_values() {
+    let graph = prompt_graph(json!({
+        "1": {
+            "class_type": "String",
+            "inputs": { "value": "{\"Default\":{\"steps\":20,\"enabled\":true}}" }
+        },
+        "2": { "class_type": "String", "inputs": { "value": "Default" } },
+        "3": {
+            "class_type": "JsonExtractString",
+            "inputs": { "json_string": ["1", 0], "key": ["2", 0] },
+            "widgets_values": ["{\"stale\":true}", "stale"]
+        }
+    }));
+
+    assert_eq!(
+        evaluate_string_node(&graph, "3").as_deref(),
+        Some("{\"enabled\":true,\"steps\":20}")
+    );
+}
+
+#[test]
+fn json_extract_supports_unlinked_workflow_widgets_and_authoritative_empty_values() {
+    let graph = workflow_graph(
+        json!([
+            {
+                "id": 1,
+                "type": "JsonExtractString",
+                "inputs": [],
+                "outputs": [{ "name": "STRING", "type": "STRING", "links": null }],
+                "widgets_values": ["{\"prompt\":\"literal\",\"empty\":null}", "prompt"]
+            },
+            {
+                "id": 2,
+                "type": "JsonExtractString",
+                "inputs": [],
+                "outputs": [{ "name": "STRING", "type": "STRING", "links": null }],
+                "widgets_values": ["{\"prompt\":\"literal\",\"empty\":null}", "empty"]
+            },
+            {
+                "id": 3,
+                "type": "JsonExtractString",
+                "inputs": [],
+                "outputs": [{ "name": "STRING", "type": "STRING", "links": null }],
+                "widgets_values": ["{\"prompt\":\"literal\"}", "missing"]
+            }
+        ]),
+        json!([]),
+    );
+
+    assert_eq!(
+        evaluate_string_node(&graph, "1").as_deref(),
+        Some("literal")
+    );
+    assert_eq!(evaluate_string_node(&graph, "2").as_deref(), Some(""));
+    assert_eq!(evaluate_string_node(&graph, "3").as_deref(), Some(""));
+}
+
+#[test]
+fn json_extract_failures_do_not_reopen_stale_widgets() {
+    let oversized_key = "k".repeat(4 * 1024 + 1);
+    let oversized_json = format!("{{\"key\":\"{}\"}}", "x".repeat(64 * 1024));
+    let graph = prompt_graph(json!({
+        "1": {
+            "class_type": "JsonExtractString",
+            "inputs": { "json_string": ["missing", 0], "key": "key" },
+            "widgets_values": ["{\"key\":\"stale\"}", "key"]
+        },
+        "2": { "class_type": "JsonExtractString", "inputs": { "json_string": "[]", "key": "key" } },
+        "3": { "class_type": "JsonExtractString", "inputs": { "json_string": "not json", "key": "key" } },
+        "4": { "class_type": "JsonExtractString", "inputs": { "json_string": "{}", "key": oversized_key } },
+        "5": { "class_type": "JsonExtractString", "inputs": { "json_string": oversized_json, "key": "key" } },
+        "6": { "class_type": "PreviewAny", "inputs": { "source": ["7", 1] } },
+        "7": { "class_type": "JsonExtractString", "inputs": { "json_string": "{\"key\":\"value\"}", "key": "key" } },
+        "8": { "class_type": "JsonExtractString", "inputs": { "json_string": ["9", 0], "key": "key" } },
+        "9": { "class_type": "StringConcatenate", "inputs": { "string_a": ["8", 0], "string_b": "", "delimiter": "" } }
+    }));
+
+    for node_id in ["1", "2", "3", "4", "5", "6", "8"] {
+        assert_eq!(
+            evaluate_string_node(&graph, node_id),
+            None,
+            "node {node_id}"
+        );
+    }
+}
+
+#[test]
+fn comfy_number_convert_honors_output_slots_and_scalar_types() {
+    let cases = [
+        (json!(true), 1, Some(1), None),
+        (json!(false), 0, None, Some(0.0)),
+        (json!(-7), 1, Some(-7), None),
+        (json!(3.9), 1, Some(3), None),
+        (json!(" 12.75 "), 0, None, Some(12.75)),
+        (json!(" -12.75 "), 1, Some(-12), None),
+        (
+            json!("9007199254740991"),
+            1,
+            Some(9_007_199_254_740_991),
+            None,
+        ),
+    ];
+
+    for (value, slot, expected_integer, expected_float) in cases {
+        let graph = converter_graph(value, slot);
+        let consumer = graph.get_node("2").expect("consumer node");
+        if let Some(expected) = expected_integer {
+            assert_eq!(
+                evaluate_number_link_first(&graph, consumer, "number", i64::MAX),
+                Some(expected)
+            );
+        }
+        if let Some(expected) = expected_float {
+            assert_eq!(
+                evaluate_float_link_first(&graph, consumer, "number", f64::MAX),
+                Some(expected)
+            );
+        }
+    }
+}
+
+#[test]
+fn comfy_number_convert_preserves_slots_through_reroutes() {
+    let graph = prompt_graph(json!({
+        "1": { "class_type": "String", "inputs": { "value": "20.9" } },
+        "2": { "class_type": "ComfyNumberConvert", "inputs": { "value": ["1", 0] } },
+        "3": { "class_type": "Reroute", "inputs": { "value": ["2", 1] } },
+        "4": { "class_type": "Consumer", "inputs": { "number": ["3", 0] } }
+    }));
+    let consumer = graph.get_node("4").expect("consumer node");
+
+    assert_eq!(
+        evaluate_number_link_first(&graph, consumer, "number", 100),
+        Some(20)
+    );
+}
+
+#[test]
+fn comfy_number_convert_preserves_string_source_output_slots() {
+    let graph = prompt_graph(json!({
+        "1": { "class_type": "CustomCombo", "widgets_values": ["B", 1, "A", "B"] },
+        "2": { "class_type": "ComfyNumberConvert", "inputs": { "value": ["1", 1] } },
+        "3": { "class_type": "Consumer", "inputs": { "number": ["2", 1] } }
+    }));
+    let consumer = graph.get_node("3").expect("consumer node");
+
+    assert_eq!(
+        evaluate_number_link_first(&graph, consumer, "number", 10),
+        Some(1)
+    );
+}
+
+#[test]
+fn comfy_number_convert_prefers_linked_numeric_values_over_stale_widgets() {
+    let graph = prompt_graph(json!({
+        "1": { "class_type": "PrimitiveNode", "inputs": { "value": 7 } },
+        "2": {
+            "class_type": "PrimitiveNode",
+            "_resolved_sources": { "value": { "node_id": "1", "output_slot": 0 } },
+            "widgets_values": [99]
+        },
+        "3": { "class_type": "ComfyNumberConvert", "inputs": { "value": ["2", 0] } },
+        "4": { "class_type": "Consumer", "inputs": { "number": ["3", 1] } }
+    }));
+    let consumer = graph.get_node("4").expect("consumer node");
+
+    assert_eq!(
+        evaluate_number_link_first(&graph, consumer, "number", 100),
+        Some(7)
+    );
+}
+
+#[test]
+fn comfy_number_convert_fails_closed_for_invalid_sources_and_slots() {
+    for value in [
+        json!(""),
+        json!("NaN"),
+        json!("Infinity"),
+        json!("9223372036854775808"),
+    ] {
+        let graph = converter_graph(value, 1);
+        let consumer = graph.get_node("2").expect("consumer node");
+        assert_eq!(
+            evaluate_number_link_first(&graph, consumer, "number", i64::MAX),
+            None
+        );
+    }
+
+    let graph = prompt_graph(json!({
+        "1": { "class_type": "ComfyNumberConvert", "inputs": { "value": ["missing", 0] }, "widgets_values": [42] },
+        "2": { "class_type": "Consumer", "inputs": { "number": ["1", 2] } },
+        "3": { "class_type": "Consumer", "_resolved_inputs": { "number": "1" } },
+        "4": { "class_type": "ComfyNumberConvert", "inputs": { "value": ["5", 1] } },
+        "5": { "class_type": "ComfyNumberConvert", "inputs": { "value": ["4", 1] } },
+        "6": { "class_type": "Consumer", "inputs": { "number": ["4", 1] } }
+    }));
+    for node_id in ["2", "3", "6"] {
+        let consumer = graph.get_node(node_id).expect("consumer node");
+        assert_eq!(
+            evaluate_number_link_first(&graph, consumer, "number", i64::MAX),
+            None
+        );
+    }
+}
+
+#[test]
+fn pinned_ideogram_profile_resolves_deterministic_scheduler_values() {
+    let chunks: HashMap<String, String> = serde_json::from_str(include_str!(
+        "fixtures/official_catalog/image_ideogram4_t2i.chunks.json"
+    ))
+    .expect("Ideogram chunks should be valid JSON");
+    let graph = ComfyGraph::from_chunks(&chunks);
+    let (combo_id, _) = graph
+        .nodes
+        .iter()
+        .find(|(_, node)| {
+            get_node_type(node) == "CustomCombo"
+                && node
+                    .get("widgets_values")
+                    .and_then(Value::as_array)
+                    .and_then(|values| values.first())
+                    .and_then(Value::as_str)
+                    == Some("Default")
+        })
+        .expect("selected Ideogram profile combo");
+    let scheduler = graph
+        .nodes
+        .values()
+        .find(|node| get_node_type(node) == "Ideogram4Scheduler")
+        .expect("Ideogram scheduler");
+
+    assert_eq!(
+        evaluate_string_node(&graph, combo_id).as_deref(),
+        Some("Default")
+    );
+    assert_eq!(
+        evaluate_number_link_first(&graph, scheduler, "steps", 1_000),
+        Some(20)
+    );
+    assert_eq!(
+        evaluate_float_link_first(&graph, scheduler, "mu", 100.0),
+        Some(0.0)
+    );
+    assert_eq!(
+        evaluate_float_link_first(&graph, scheduler, "std", 100.0),
+        Some(1.75)
+    );
+}

--- a/src-tauri/src/metadata/comfyui/tests/mod.rs
+++ b/src-tauri/src/metadata/comfyui/tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod catalog_intake;
 pub mod catalog_patterns;
 pub mod complex_workflows;
+pub mod deterministic_values;
 pub mod diagnostics;
 pub mod false_positive_models;
 pub mod general;

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -18,7 +18,7 @@ pub use parsers::{extract_png_chunks, scan_jpeg_metadata, scan_webp_metadata};
 /// Current parser version. Increment when any parser logic changes.
 /// Images with parser_version < CURRENT_PARSER_VERSION will be queued
 /// for background re-parsing from their stored original_metadata_json.
-pub const CURRENT_PARSER_VERSION: u32 = 28;
+pub const CURRENT_PARSER_VERSION: u32 = 29;
 
 pub(crate) fn is_missing_prompt_value(value: &str) -> bool {
     value.trim().is_empty() || is_placeholder_prompt_value(value)


### PR DESCRIPTION
## Summary
- add bounded exact-key JsonExtractString evaluation with connected-input authority
- preserve source output slots through strict numeric traversal and support ComfyNumberConvert float/int outputs
- resolve the pinned Ideogram Default profile deterministically and bump parser version to 29

## Verification
- cargo test metadata::comfyui::tests::deterministic_values (9 passed)
- cargo test metadata::comfyui::tests::prompts (50 passed)
- cargo test metadata::comfyui::tests::graph_sources (4 passed)
- cargo test metadata::comfyui::tests::catalog_intake (5 passed)
- cargo test metadata::comfyui (250 passed, 1 ignored)
- cargo test metadata::reparse (10 passed)
- cargo fmt --check
- git diff --check

No frontend, database, command, binding, diagnostics DTO, manifest-status, or ImageMetadata changes.