### PR TITLE
fix: extract comfyui dual model guider metadata

### DIFF
--- a/docs/plans/milestone-25.md
+++ b/docs/plans/milestone-25.md
@@ -119,6 +119,8 @@ Verification evidence:
 
 ## Work Package 3: Dual-Model Guider Policy
 
+Status: Complete (`fix/comfyui-dual-model-guider-policy`, `2026-07-22`)
+
 Depends on: Work Packages 1 and 2.
 
 Primary invariant: only the guider's selected primary branch supplies primary
@@ -145,6 +147,26 @@ Completion criteria:
 - stale widgets, unconditional models, and disconnected branches cannot
   contribute primary metadata;
 - the package is independently review-clean.
+
+Verification evidence:
+
+- the pinned Ideogram workflow resolves primary model
+  `ideogram4_fp8_scaled`, seed `885894517601261`, base CFG 7, sampler
+  `euler`, and its exact 3,598-byte positive prompt through
+  `SamplerTraversal`;
+- the auxiliary unconditional model and scheduled CFG 3 override do not
+  become primary metadata, while authoritative empty negative conditioning
+  blocks disconnected prompt fallback;
+- steps intentionally remain unavailable until Work Package 4 adds the
+  connected `Ideogram4Scheduler` policy;
+- dual-model-guider tests pass with 5 tests, deterministic-value tests with 9,
+  multi-stage tests with 55, official-catalog tests with 27, catalog-intake
+  tests with 5, template-coverage tests with 3, workflow-subgraph tests with
+  14, and output-selection tests with 15;
+- the full ComfyUI suite passes with 255 tests and the existing Ollama test
+  ignored; all 10 reparse tests pass;
+- parser version is 30, Ideogram remains `unassessed`, and manifest totals
+  remain unchanged.
 
 ## Work Package 4: Ideogram Scheduler and Golden Coverage
 

--- a/src-tauri/src/metadata/comfyui/eval_core.rs
+++ b/src-tauri/src/metadata/comfyui/eval_core.rs
@@ -173,7 +173,8 @@ pub fn extract_from_sampler(
     } else if !is_sampler_custom {
         if let Some(guider_id) = get_source_id(graph, node, "guider") {
             if let Some(guider_node) = graph.get_node(&guider_id) {
-                if let Some(model_name) = trace_model_chain(
+                let strict_connections = cfg_guider_requires_strict_inputs(guider_node);
+                if let Some(model_name) = trace_model_chain_with_mode(
                     graph,
                     guider_node,
                     "model",
@@ -181,6 +182,7 @@ pub fn extract_from_sampler(
                     ip_adapters,
                     hypernetworks,
                     &mut model_control_nets,
+                    strict_connections,
                 ) {
                     meta.model = model_name;
                 }
@@ -192,9 +194,11 @@ pub fn extract_from_sampler(
     let (pos, neg) = if let Some((guider_id, guider_node)) = cfg_guider.as_ref() {
         let (_, positive_input, negative_input) =
             cfg_guider_params(guider_node).expect("connected guider should be supported");
+        let strict_connections =
+            is_sampler_custom || cfg_guider_requires_strict_inputs(guider_node);
         let prompt = |input_name| {
             get_node_input_link(guider_node, input_name)
-                .map(|_| find_reachable_prompts(graph, &guider_id, input_name, is_sampler_custom))
+                .map(|_| find_reachable_prompts(graph, &guider_id, input_name, strict_connections))
                 .unwrap_or_default()
         };
         (prompt(positive_input), prompt(negative_input))
@@ -360,7 +364,11 @@ fn connected_cfg_guider<'a>(
 fn extract_connected_cfg_guider(graph: &ComfyGraph, sampler_node: &Value) -> Option<f64> {
     let (_, guider_node) = connected_cfg_guider(graph, sampler_node)?;
     let (cfg_input, _, _) = cfg_guider_params(guider_node)?;
-    evaluate_float(graph, guider_node, cfg_input, 200.0)
+    if cfg_guider_requires_strict_inputs(guider_node) {
+        evaluate_float_link_first(graph, guider_node, cfg_input, 200.0)
+    } else {
+        evaluate_float(graph, guider_node, cfg_input, 200.0)
+    }
 }
 
 pub(crate) fn cfg_guider_params(
@@ -369,8 +377,13 @@ pub(crate) fn cfg_guider_params(
     match get_node_type(guider_node) {
         "CFGGuider" => Some(("cfg", "positive", "negative")),
         "DualCFGGuider" => Some(("cfg_conds", "cond1", "negative")),
+        "DualModelGuider" => Some(("cfg", "positive", "negative")),
         _ => None,
     }
+}
+
+pub(crate) fn cfg_guider_requires_strict_inputs(guider_node: &Value) -> bool {
+    get_node_type(guider_node) == "DualModelGuider"
 }
 
 fn extract_connected_flux_guidance(graph: &ComfyGraph, sampler_node: &Value) -> Option<f64> {
@@ -500,6 +513,12 @@ fn trace_model_chain_with_mode(
                 continue;
             }
             break;
+        } else if t == "CFGOverride" {
+            if let Some(next) = get_strict_source_id(node, "model") {
+                current_id = next;
+                continue;
+            }
+            return None;
         } else if t == "LoraLoader" || t == "LoraLoaderModelOnly" {
             if let Some(name) = get_node_param(node, "lora_name").and_then(|v| v.as_str()) {
                 let name = crate::metadata::guidance::GuidanceClassifier::clean_name(name);

--- a/src-tauri/src/metadata/comfyui/evaluator.rs
+++ b/src-tauri/src/metadata/comfyui/evaluator.rs
@@ -22,6 +22,8 @@ pub(crate) struct OutputTraversalDiagnostics {
     pub(crate) unique_root_sampler_count: usize,
     pub(crate) ambiguous: bool,
     pub(crate) authoritative_sampler_custom_path: bool,
+    pub(crate) authoritative_model: bool,
+    pub(crate) authoritative_cfg: bool,
     pub(crate) authoritative_positive_prompt: bool,
     pub(crate) authoritative_negative_prompt: bool,
 }
@@ -85,6 +87,10 @@ impl<'a> ComfyEvaluator<'a> {
                 if let Some((_, positive_input, negative_input)) =
                     super::eval_core::cfg_guider_params(guider_node)
                 {
+                    if super::eval_core::cfg_guider_requires_strict_inputs(guider_node) {
+                        diagnostics.authoritative_model = true;
+                        diagnostics.authoritative_cfg = true;
+                    }
                     diagnostics.authoritative_positive_prompt =
                         get_node_input_link(guider_node, positive_input).is_some();
                     diagnostics.authoritative_negative_prompt =

--- a/src-tauri/src/metadata/comfyui/graph.rs
+++ b/src-tauri/src/metadata/comfyui/graph.rs
@@ -833,6 +833,10 @@ pub fn get_node_param<'a>(node: &'a Value, key: &str) -> Option<&'a Value> {
             return arr.first();
         }
 
+        if t == "DualModelGuider" && key == "cfg" {
+            return arr.first();
+        }
+
         if t == "BasicScheduler" {
             match key {
                 "scheduler" => return arr.first(),

--- a/src-tauri/src/metadata/comfyui/mod.rs
+++ b/src-tauri/src/metadata/comfyui/mod.rs
@@ -676,6 +676,13 @@ fn extract_comfyui_graph_with_diagnostics(
     if meta.is_incomplete() {
         diagnostics.attempt(ComfyParseLayer::SamplerFallback);
         let mut sampler_meta = evaluator.extract_from_all_samplers();
+        if output_diagnostics.authoritative_model {
+            sampler_meta.model = "Unknown".to_string();
+            sampler_meta.model_hash = None;
+        }
+        if output_diagnostics.authoritative_cfg {
+            sampler_meta.cfg = 0.0;
+        }
         if output_diagnostics.authoritative_positive_prompt {
             sampler_meta.positive_prompt.clear();
         }
@@ -695,6 +702,13 @@ fn extract_comfyui_graph_with_diagnostics(
     if meta.is_incomplete() {
         diagnostics.attempt(ComfyParseLayer::GlobalScan);
         let mut scan_meta = global_scan(&graph);
+        if output_diagnostics.authoritative_model {
+            scan_meta.model = "Unknown".to_string();
+            scan_meta.model_hash = None;
+        }
+        if output_diagnostics.authoritative_cfg {
+            scan_meta.cfg = 0.0;
+        }
         if output_diagnostics.authoritative_positive_prompt {
             scan_meta.positive_prompt.clear();
         }

--- a/src-tauri/src/metadata/comfyui/tests/dual_model_guider.rs
+++ b/src-tauri/src/metadata/comfyui/tests/dual_model_guider.rs
@@ -1,0 +1,297 @@
+use super::super::diagnostics::{ComfyMetadataField, ComfyParseDiagnostics, ComfyParseLayer};
+use super::super::extract_comfyui_metadata_with_diagnostics;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+const IDEOGRAM_EXPECTED_POSITIVE: &str =
+    include_str!("fixtures/official_catalog/image_ideogram4_t2i.expected-positive.txt");
+
+fn extract_prompt_graph(nodes: Value) -> (crate::metadata::ImageMetadata, ComfyParseDiagnostics) {
+    let chunks = HashMap::from([("prompt".to_string(), nodes.to_string())]);
+    extract_comfyui_metadata_with_diagnostics(&chunks)
+}
+
+fn connected_api_graph() -> Value {
+    json!({
+        "1": {
+            "class_type": "UNETLoader",
+            "inputs": { "unet_name": "unconditional-model.safetensors" }
+        },
+        "2": {
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": "selected positive" }
+        },
+        "3": {
+            "class_type": "CLIPTextEncode",
+            "inputs": { "text": "selected negative" }
+        },
+        "4": {
+            "class_type": "UNETLoader",
+            "inputs": { "unet_name": "primary-model.safetensors" }
+        },
+        "5": {
+            "class_type": "CFGOverride",
+            "inputs": { "model": ["4", 0] },
+            "widgets_values": [3.0, 0.7, 1.0]
+        },
+        "6": {
+            "class_type": "DualModelGuider",
+            "inputs": {
+                "model": ["5", 0],
+                "positive": ["2", 0],
+                "model_negative": ["1", 0],
+                "negative": ["3", 0],
+                "cfg": 7.0
+            }
+        },
+        "7": { "class_type": "RandomNoise", "inputs": { "noise_seed": 12345 } },
+        "8": { "class_type": "KSamplerSelect", "inputs": { "sampler_name": "euler" } },
+        "9": {
+            "class_type": "BasicScheduler",
+            "inputs": { "scheduler": "simple", "steps": 20, "denoise": 1.0 }
+        },
+        "10": { "class_type": "EmptyLatentImage", "inputs": {} },
+        "11": {
+            "class_type": "SamplerCustomAdvanced",
+            "inputs": {
+                "noise": ["7", 0],
+                "guider": ["6", 0],
+                "sampler": ["8", 0],
+                "sigmas": ["9", 0],
+                "latent_image": ["10", 0]
+            }
+        },
+        "12": { "class_type": "VAEDecode", "inputs": { "samples": ["11", 0] } },
+        "13": { "class_type": "SaveImage", "inputs": { "images": ["12", 0] } }
+    })
+}
+
+fn assert_traversal_source(diagnostics: &ComfyParseDiagnostics, field: ComfyMetadataField) {
+    assert_eq!(
+        diagnostics.field_sources.get(&field),
+        Some(&ComfyParseLayer::SamplerTraversal),
+        "field {field:?}"
+    );
+}
+
+#[test]
+fn connected_dual_model_guider_uses_only_primary_metadata() {
+    let (meta, diagnostics) = extract_prompt_graph(connected_api_graph());
+
+    assert_eq!(meta.model, "primary_model");
+    assert!(!meta.model.contains("unconditional"));
+    assert_eq!(meta.seed, Some(12345));
+    assert_eq!(meta.steps, 20);
+    assert_eq!(meta.cfg, 7.0);
+    assert_ne!(meta.cfg, 3.0, "CFGOverride is not the base CFG value");
+    assert_eq!(meta.sampler, "euler (simple)");
+    assert_eq!(meta.positive_prompt, "selected positive");
+    assert_eq!(meta.negative_prompt, "selected negative");
+
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Seed,
+        ComfyMetadataField::Steps,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+        ComfyMetadataField::PositivePrompt,
+        ComfyMetadataField::NegativePrompt,
+    ] {
+        assert_traversal_source(&diagnostics, field);
+    }
+}
+
+#[test]
+fn workflow_linked_dual_model_cfg_overrides_stale_widget() {
+    let workflow = json!({
+        "nodes": [
+            { "id": 1, "type": "UNETLoader", "widgets_values": ["workflow-primary.safetensors", "default"] },
+            { "id": 2, "type": "CLIPTextEncode", "widgets_values": ["workflow positive"] },
+            { "id": 3, "type": "CLIPTextEncode", "widgets_values": ["workflow negative"] },
+            { "id": 4, "type": "PrimitiveFloat", "widgets_values": [6.25] },
+            { "id": 5, "type": "CFGOverride", "inputs": [{ "name": "model", "link": 1 }], "widgets_values": [3.0, 0.7, 1.0] },
+            {
+                "id": 6,
+                "type": "DualModelGuider",
+                "inputs": [
+                    { "name": "model", "link": 2 },
+                    { "name": "positive", "link": 3 },
+                    { "name": "model_negative", "link": null },
+                    { "name": "negative", "link": 4 },
+                    { "name": "cfg", "link": 5 }
+                ],
+                "widgets_values": [1.0]
+            },
+            { "id": 7, "type": "RandomNoise", "widgets_values": [23456] },
+            { "id": 8, "type": "KSamplerSelect", "widgets_values": ["euler"] },
+            { "id": 9, "type": "BasicScheduler", "widgets_values": ["simple", 18, 1.0] },
+            { "id": 10, "type": "EmptyLatentImage", "widgets_values": [1024, 1024, 1] },
+            {
+                "id": 11,
+                "type": "SamplerCustomAdvanced",
+                "inputs": [
+                    { "name": "noise", "link": 6 },
+                    { "name": "guider", "link": 7 },
+                    { "name": "sampler", "link": 8 },
+                    { "name": "sigmas", "link": 9 },
+                    { "name": "latent_image", "link": 10 }
+                ]
+            },
+            { "id": 12, "type": "VAEDecode", "inputs": [{ "name": "samples", "link": 11 }] },
+            { "id": 13, "type": "SaveImage", "inputs": [{ "name": "images", "link": 12 }] }
+        ],
+        "links": [
+            [1, 1, 0, 5, 0, "MODEL"],
+            [2, 5, 0, 6, 0, "MODEL"],
+            [3, 2, 0, 6, 1, "CONDITIONING"],
+            [4, 3, 0, 6, 3, "CONDITIONING"],
+            [5, 4, 0, 6, 4, "FLOAT"],
+            [6, 7, 0, 11, 0, "NOISE"],
+            [7, 6, 0, 11, 1, "GUIDER"],
+            [8, 8, 0, 11, 2, "SAMPLER"],
+            [9, 9, 0, 11, 3, "SIGMAS"],
+            [10, 10, 0, 11, 4, "LATENT"],
+            [11, 11, 0, 12, 0, "LATENT"],
+            [12, 12, 0, 13, 0, "IMAGE"]
+        ]
+    });
+    let chunks = HashMap::from([("workflow".to_string(), workflow.to_string())]);
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "workflow_primary");
+    assert_eq!(meta.cfg, 6.25);
+    assert_ne!(meta.cfg, 1.0);
+    assert_eq!(meta.positive_prompt, "workflow positive");
+    assert_eq!(meta.negative_prompt, "workflow negative");
+    assert_traversal_source(&diagnostics, ComfyMetadataField::Cfg);
+}
+
+#[test]
+fn direct_sampler_cfg_wins_over_dual_model_guider_cfg() {
+    let mut nodes = connected_api_graph();
+    nodes["11"]["inputs"]["cfg"] = json!(9.0);
+
+    let (meta, diagnostics) = extract_prompt_graph(nodes);
+
+    assert_eq!(meta.cfg, 9.0);
+    assert_traversal_source(&diagnostics, ComfyMetadataField::Cfg);
+}
+
+#[test]
+fn unresolved_selected_guider_inputs_do_not_reopen_disconnected_fallbacks() {
+    let mut nodes = connected_api_graph();
+    nodes["6"]["inputs"]["model"] = json!(["missing-model", 0]);
+    nodes["6"]["inputs"]["positive"] = json!(["missing-positive", 0]);
+    nodes["6"]["inputs"]["cfg"] = json!(["missing-cfg", 0]);
+    nodes["6"]["inputs"]["negative"] = json!(["23", 0]);
+    nodes["20"] = json!({
+        "class_type": "KSampler",
+        "inputs": {
+            "model": ["21", 0],
+            "positive": ["22", 0],
+            "negative": ["22", 0],
+            "seed": 999,
+            "steps": 99,
+            "cfg": 19.0,
+            "sampler_name": "dpmpp_2m",
+            "scheduler": "normal"
+        }
+    });
+    nodes["21"] = json!({
+        "class_type": "UNETLoader",
+        "inputs": { "unet_name": "disconnected-model.safetensors" }
+    });
+    nodes["22"] = json!({
+        "class_type": "CLIPTextEncode",
+        "inputs": { "text": "disconnected prompt" }
+    });
+    nodes["23"] = json!({
+        "class_type": "ConditioningZeroOut",
+        "inputs": { "conditioning": ["3", 0] }
+    });
+
+    let (meta, diagnostics) = extract_prompt_graph(nodes);
+
+    assert_eq!(meta.model, "Unknown");
+    assert_eq!(meta.cfg, 0.0);
+    assert!(meta.positive_prompt.is_empty());
+    assert!(meta.negative_prompt.is_empty());
+    assert!(!diagnostics
+        .field_sources
+        .contains_key(&ComfyMetadataField::Model));
+    assert!(!diagnostics
+        .field_sources
+        .contains_key(&ComfyMetadataField::Cfg));
+    assert!(!diagnostics
+        .field_sources
+        .contains_key(&ComfyMetadataField::PositivePrompt));
+    assert!(!diagnostics
+        .field_sources
+        .contains_key(&ComfyMetadataField::NegativePrompt));
+}
+
+#[test]
+fn pinned_ideogram_dual_model_guider_uses_primary_branch() {
+    let chunks: HashMap<String, String> = serde_json::from_str(include_str!(
+        "fixtures/official_catalog/image_ideogram4_t2i.chunks.json"
+    ))
+    .expect("Ideogram chunks should be valid JSON");
+    let expected_workflow = chunks
+        .get("workflow")
+        .expect("Ideogram fixture should include workflow");
+
+    let (meta, diagnostics) = extract_comfyui_metadata_with_diagnostics(&chunks);
+
+    assert_eq!(meta.model, "ideogram4_fp8_scaled");
+    assert!(!meta.model.contains("unconditional"));
+    assert_eq!(meta.seed, Some(885_894_517_601_261));
+    assert_eq!(meta.steps, 0);
+    assert_eq!(meta.cfg, 7.0);
+    assert_ne!(meta.cfg, 3.0);
+    assert_eq!(meta.sampler, "euler");
+    assert_eq!(meta.positive_prompt, IDEOGRAM_EXPECTED_POSITIVE);
+    assert!(meta.negative_prompt.is_empty());
+    assert!(meta.loras.is_empty());
+    assert!(meta.control_nets.is_empty());
+    assert!(meta.ip_adapters.is_empty());
+    assert!(meta.embeddings.is_empty());
+    assert!(meta.hypernetworks.is_empty());
+    assert_eq!(
+        meta.workflow_json.as_deref(),
+        Some(expected_workflow.as_str())
+    );
+    assert!(meta.has_workflow_hint);
+
+    assert_eq!(diagnostics.graph_node_count, 42);
+    assert_eq!(diagnostics.selected_output_candidate_count, 1);
+    assert_eq!(diagnostics.unique_output_root_sampler_count, 1);
+    assert!(!diagnostics.output_ambiguous);
+    for field in [
+        ComfyMetadataField::Model,
+        ComfyMetadataField::Seed,
+        ComfyMetadataField::Cfg,
+        ComfyMetadataField::Sampler,
+        ComfyMetadataField::PositivePrompt,
+    ] {
+        assert_traversal_source(&diagnostics, field);
+    }
+    assert!(!diagnostics
+        .field_sources
+        .contains_key(&ComfyMetadataField::NegativePrompt));
+    assert!(!diagnostics
+        .field_sources
+        .contains_key(&ComfyMetadataField::Steps));
+    assert_eq!(
+        diagnostics
+            .field_sources
+            .get(&ComfyMetadataField::WorkflowJson),
+        Some(&ComfyParseLayer::WorkflowChunk)
+    );
+    assert_eq!(
+        diagnostics
+            .field_sources
+            .get(&ComfyMetadataField::WorkflowHint),
+        Some(&ComfyParseLayer::WorkflowChunk)
+    );
+}

--- a/src-tauri/src/metadata/comfyui/tests/mod.rs
+++ b/src-tauri/src/metadata/comfyui/tests/mod.rs
@@ -3,6 +3,7 @@ pub mod catalog_patterns;
 pub mod complex_workflows;
 pub mod deterministic_values;
 pub mod diagnostics;
+pub mod dual_model_guider;
 pub mod false_positive_models;
 pub mod general;
 pub mod graph_sources;

--- a/src-tauri/src/metadata/mod.rs
+++ b/src-tauri/src/metadata/mod.rs
@@ -18,7 +18,7 @@ pub use parsers::{extract_png_chunks, scan_jpeg_metadata, scan_webp_metadata};
 /// Current parser version. Increment when any parser logic changes.
 /// Images with parser_version < CURRENT_PARSER_VERSION will be queued
 /// for background re-parsing from their stored original_metadata_json.
-pub const CURRENT_PARSER_VERSION: u32 = 29;
+pub const CURRENT_PARSER_VERSION: u32 = 30;
 
 pub(crate) fn is_missing_prompt_value(value: &str) -> bool {
     value.trim().is_empty() || is_placeholder_prompt_value(value)


### PR DESCRIPTION
## Summary
- add strict connected `DualModelGuider` extraction for primary model, base CFG, and prompt conditioning
- treat `CFGOverride` as a transparent model wrapper without exposing its scheduled CFG as the primary scalar
- prevent disconnected sampler/global fallback from reopening authoritative unresolved or empty guider fields
- add focused API, workflow, fallback-authority, and pinned Ideogram regressions
- increment the metadata parser version from 29 to 30

## Why
The official Ideogram v4 workflow uses a dual-model guider with a separate unconditional model and a range-limited CFG override. Without an explicit policy, fallback traversal could select the auxiliary model or stale/disconnected values as primary metadata.

## Verification
- `cargo test metadata::comfyui::tests::dual_model_guider` (5 passed)
- deterministic values (9 passed)
- multi-stage (55 passed)
- official catalog (27 passed)
- catalog intake (5 passed)
- template coverage (3 passed)
- workflow subgraphs (14 passed)
- output selection (15 passed)
- full ComfyUI suite (255 passed, 1 existing ignored)
- reparse suite (10 passed)
- `cargo fmt --check`
- `git diff --check`

## Scope
No frontend, public API, schema, binding, fixture, or manifest changes. `Ideogram4Scheduler` steps and scheduler identity remain intentionally deferred to Milestone 25 Work Package 4.