### PR TITLE
docs: refresh agent documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,10 @@
 # AGENTS.md
-Agent doc system: agent-doc-system v1.2.0
 
 ## Purpose
 Ambit is a local-first desktop image manager for large AI-generated image libraries. The repo is a Tauri v2 app with a React/TypeScript frontend and a Rust/SQLite backend. Most agent tasks here touch feature UI, Tauri commands, metadata parsing, or library/query performance.
+
+## Delivery Posture
+Use **Assure** by default. Ambit is public open-source desktop software distributed through signed installers and an auto-updater, and changes can affect existing local libraries, filesystem scope, migrations, privacy behavior, or release compatibility. Keep ceremony proportional for low-risk work, but use explicit regression coverage and release-aware verification for those boundaries.
 
 ## Priorities
 When working in this repository, optimize for:
@@ -27,7 +29,14 @@ Start here for common tasks:
 - App shell and cross-feature UI orchestration: `src/App.tsx`, `src/components/`, `src/features/`
 - Search, query, and persisted UI state: `src/contexts/`, `src/stores/`, `src/hooks/`, `src/services/`
 - Rust commands, DB migrations, and metadata extraction: `src-tauri/src/lib.rs`, `src-tauri/src/db/`, `src-tauri/src/metadata/`, `src-tauri/src/scanner/`
+- Thumbnail generation and background optimization: `src-tauri/src/thumb/`, `src/services/thumbnailService.ts`, `src/hooks/useThumbnailQueue.ts`, `src/hooks/useThumbnailOps.ts`
 - Release automation and versioning: `docs/WORKFLOW_SETUP.md`, `.github/workflows/`
+
+## Sources of Truth
+- Current version and toolchain facts come from `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/tauri.dev.json`, `src-tauri/Cargo.toml`, `.node-version`, and `rust-toolchain.toml`; the version files must agree.
+- Commands and release gates come from `package.json` and the workflow YAML. Documentation explains intent but does not override those executable sources.
+- Current architecture comes from the code and migrations, with `docs/architecture.md` as the routed explanation.
+- `docs/progress.md` owns moving repository state. A file under `docs/plans/` is active only when its own status says so; completed or superseded plans are historical evidence.
 
 ## Commands
 - Install dependencies: `pnpm install`
@@ -40,6 +49,9 @@ Start here for common tasks:
 - Frontend tests: `pnpm run test` for watch mode, `pnpm run test:run` for CI-style one-shot runs
 - Coverage: `pnpm run coverage`
 - Rust tests: `pnpm run test:rust`
+- Generate Specta bindings: `pnpm run bindings:generate`
+- Check generated binding drift: `pnpm run bindings:check`
+- Tauri compatibility build without packaging: `pnpm run tauri:check`
 - Release verification gate: `pnpm run verify:release`
 
 Production app builds run `verify:release` before `tauri build --ci`.
@@ -68,6 +80,7 @@ Production app builds run `verify:release` before `tauri build --ci`.
 - `src/stores/settingsStore.ts` and `src/services/TauriFsRepository.ts`: settings persistence, keyring migration, and path scope registration.
 - `src-tauri/src/db/`: migrations, PRAGMAs, and query behavior affect data integrity and large-library performance.
 - `src-tauri/src/metadata/comfyui/`: heuristic parsing with a broad regression-test surface.
+- `src-tauri/src/thumb/` and `src/hooks/useThumbnailQueue.ts`: cancellable background work, SQLite writes, cache recovery, and foreground-activity throttling interact.
 
 ## Doc Routing
 Use this file as the entry point. Do not bulk-read `docs/` unless one of the routes below is relevant.

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -32,11 +32,11 @@ Protect `main` with these required status checks:
 - Scheduled and manually dispatched runs execute both audits.
 - Unrelated PRs report that audits were skipped and pass the check.
 
-Do not require an always-green dependency-review placeholder. Enable the real `actions/dependency-review-action` only after the repository is public or GitHub Advanced Security makes it available.
+Do not require an always-green dependency-review placeholder. The public repository currently uses the direct npm and Rust audits above; adopting `actions/dependency-review-action` should be an intentional workflow change with its real check required only after it is enabled and validated.
 
 ## Repository Rules
 
-GitHub exposes branch protection and repository rulesets for private repositories only on a paid plan. If Ambit remains private on GitHub Free, upgrade the account before treating required checks as enforced policy.
+Branch protection and repository rulesets are hosted GitHub state and cannot be proven from this file. Verify the live `AsuraAce/ambit` settings before treating the required checks as enforced policy.
 
 The repository merge settings should allow squash merges only and automatically delete merged branches.
 
@@ -67,7 +67,7 @@ Under **Settings > Actions > General**, use the selected-actions policy, require
 - `googleapis/release-please-action`
 - `tauri-apps/tauri-action`
 
-Ambit is private and uses Windows runners, so confirm an Actions spending limit and valid payment method under the account's billing and metered-usage settings. A private-repository quota or payment block can reject workflows before any job starts.
+Ambit uses Windows runners. If a workflow is rejected before any job starts, check GitHub Actions availability, account billing or metered-usage policy, and repository Actions settings before editing the workflow YAML.
 
 ## Release Please GitHub App
 
@@ -145,10 +145,10 @@ Historical runs `27337343607` (`pr-ci`) and `27337343030` (`dependency-security`
 - Review gone-tracking branches individually before deletion; a missing upstream does not prove that unique local commits are disposable.
 - Review all linked worktrees before deleting a local branch.
 
-After CI and the GitHub App are working, inspect the existing Release Please PR. Reuse it only if Release Please can refresh it cleanly; otherwise close the obsolete PR, delete its branch, and dispatch a fresh release PR. Do not merge or publish it merely to test automation.
+If a Release Please PR becomes stale, reuse it only if the automation can refresh it cleanly; otherwise close the obsolete PR and dispatch a fresh release run. Do not merge or publish a release merely to test automation.
 
 ## Updater Risks
 
 - Losing the private updater key prevents existing installed builds from accepting future updates without a migration strategy.
 - A public/private key mismatch causes downloaded updates to be rejected.
-- While the repository and release assets are private, installed apps cannot consume GitHub's unauthenticated public release feed.
+- Installed clients require unauthenticated access to `latest.json`, the referenced installer, and its signature. Draft, private, missing, or mismatched release assets break updater discovery or installation even when authenticated maintainer downloads succeed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 Status: Canonical
-Last reviewed: 2026-07-07
+Last reviewed: 2026-07-22
 
 ## System Overview
 Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust backend exposed through Tauri commands. Images and heavy metadata live in SQLite under Local AppData, lightweight app state lives in `library.json` under app-local data, and sensitive secrets such as the Gemini API key live in the OS keyring.
@@ -11,7 +11,7 @@ Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust back
 Purpose: boot the Tauri app, register plugins, manage app-scoped state, and export Specta bindings.
 Code: `src-tauri/src/lib.rs`, `src-tauri/src/main.rs`, `src/bindings.ts`
 Interacts with: frontend services that call `commands.*`, Tauri plugins for SQL, filesystem, dialog, shell, and window state
-Risks: command signature changes can break TypeScript callers; debug Tauri runs overwrite `src/bindings.ts`
+Risks: command signature changes can break TypeScript callers; use `pnpm run bindings:generate` to regenerate `src/bindings.ts` and `pnpm run bindings:check` to detect drift
 Related docs: `docs/progress.md#current-constraints`
 
 ### SQLite Data, Migrations, and Maintenance
@@ -26,7 +26,14 @@ Purpose: scan image files, extract metadata and workflows, resolve models, and w
 Code: `src-tauri/src/scanner/`, `src-tauri/src/metadata/`, `src-tauri/src/watcher.rs`, `src-tauri/src/fs_commands.rs`, `src-tauri/src/security.rs`
 Interacts with: frontend import, settings, maintenance, and viewer flows
 Risks: parser heuristics and watcher behavior can create wrong metadata or miss library changes; external path handling must stay scoped and local
-Related docs: `docs/WORKFLOW_SETUP.md`
+Related docs: `docs/manual/adding-folders.md`, `docs/manual/generator-integrations.md`
+
+### Thumbnail Generation and Optimization
+Purpose: generate cached WebP thumbnails, repair or upgrade thumbnail records in the background, expose maintenance controls, and throttle or cancel native work around foreground activity.
+Code: `src-tauri/src/thumb/`, `src/services/thumbnailService.ts`, `src/hooks/useThumbnailQueue.ts`, `src/hooks/useThumbnailOps.ts`
+Interacts with: SQLite image rows, app-local thumbnail storage, Activity Dock state, maintenance UI, collection thumbnail refresh, and generated Tauri bindings
+Risks: background jobs write in batches and coordinate cancellation, retry backoff, cache-loss recovery, and foreground throttling; changes can create heavy disk or database work on large libraries
+Related docs: `docs/manual/maintenance.md`, `docs/refactor.md#smart-thumbnail-optimization-and-thumbnail-maintenance-ownership`
 
 ### Frontend App Shell and Feature Surfaces
 Purpose: render the desktop UI, modals, viewer, filter panel, grid/timeline/statistics views, maintenance screens, and settings flows.
@@ -40,7 +47,7 @@ Purpose: own frontend query flows, transient UI state, JSON-backed settings and 
 Code: `src/contexts/`, `src/stores/`, `src/hooks/`, `src/services/`
 Interacts with: `src/features/`, `src/bindings.ts`, `src-tauri/src/db/`, app-local `library.json`
 Risks: state ownership is split across React Query, contexts, Zustand, and repository adapters, which makes duplicate sources of truth easy to introduce
-Related docs: `docs/progress.md#active-workstreams`, `docs/refactor.md#frontend-state-and-shell-coordination`
+Related docs: `docs/progress.md#current-constraints`, `docs/refactor.md#frontend-state-and-shell-coordination`
 
 ### Network Surface
 Purpose: keep the core app local-first while supporting explicit public-beta network paths.
@@ -52,6 +59,7 @@ Related docs: `README.md#privacy-and-network-behavior`, `SECURITY.md`
 ## Invariants
 - SQLite is the source of truth for image records and heavy metadata. On Windows, the main library database lives in Local AppData, with Roaming AppData retained only as a legacy fallback during the public-beta transition. `library.json` should not become a second image store.
 - Rust-exposed command and type changes should flow through Specta into `src/bindings.ts`; do not hand-maintain Rust-backed TypeScript mirrors.
+- Generated binding updates are explicit: run `pnpm run bindings:generate`, then verify with `pnpm run bindings:check` or a broader gate that includes it.
 - Filesystem access must remain local-only and within Tauri-registered or scoped paths.
 - API keys are stored via Rust keyring commands, not persisted in `library.json`.
 - Passive visual assets must be bundled locally. Network calls should be limited to the documented updater, Gemini, CivitAI, and user-clicked external-link paths.
@@ -62,4 +70,5 @@ Related docs: `README.md#privacy-and-network-behavior`, `SECURITY.md`
 - `src/contexts/SearchContext.tsx`: bridges React Query, SQL filter construction, collection refresh, and legacy store synchronization.
 - `src-tauri/src/db/migrations/`: schema changes and backfills affect existing user libraries.
 - `src-tauri/src/metadata/comfyui/`: parser heuristics are subtle and guarded by many Rust tests.
+- `src-tauri/src/thumb/` and `src/hooks/useThumbnailQueue.ts`: native background work, SQLite updates, cancellation, and foreground throttling must stay coordinated.
 - `src/services/TauriFsRepository.ts` and `src/stores/settingsStore.ts`: persistence behavior, settings migration, and folder scope registration.

--- a/docs/plans/release-0.9.0-ux-readiness.md
+++ b/docs/plans/release-0.9.0-ux-readiness.md
@@ -1,6 +1,6 @@
 # Ambit 0.9.0 UX Release Readiness
 
-Status: In Progress
+Status: Superseded after partial completion (`v0.9.0` released 2026-07-22)
 
 ## Reconciliation
 
@@ -8,13 +8,15 @@ Status: In Progress
 - Prompt keyword masking configuration is lightweight persisted state in `library.json`; session Privacy Mode remains fail-closed and enabled at startup.
 - Smart Collections use dynamic thumbnails selected from matching library images; custom thumbnails retain precedence.
 - Exact-duplicate groups remain virtualized cards and keep their existing conservative resolution behavior.
-- Release Please remains responsible for the eventual 0.9.0 version and changelog update.
+- Release Please produced the `0.9.0` version, changelog update, tag, and release commit before this track's remaining packages were completed.
+- Work Packages 1 through 2B shipped before `v0.9.0`. Work Packages 3 and 4 remain unversioned product follow-ups; Work Package 5 is superseded as a `0.9.0` gate.
+- Release Please remains responsible for future version and changelog updates.
 
-## Objective
+## Historical Objective
 
 Remove the confirmed release-smoke trust failures without broadening search semantics, privacy scope, Smart Collection behavior, or duplicate resolution policy.
 
-The release-readiness track is accepted when search never reports a false empty state, prompt masking can be disabled without deleting keywords, replaying the setup guide cannot overwrite untouched privacy settings, action tooltips dismiss after activation, new Smart Collections hydrate a matching thumbnail, every duplicate copy is discoverably reachable, and the full release gate passes.
+The track was intended to be accepted when search never reported a false empty state, prompt masking could be disabled without deleting keywords, replaying the setup guide could not overwrite untouched privacy settings, action tooltips dismissed after activation, new Smart Collections hydrated a matching thumbnail, every duplicate copy was discoverably reachable, and the full release gate passed. Because `v0.9.0` was released first, this document no longer represents a live release gate.
 
 ## Work Package 1: Stable Search Transitions
 
@@ -201,7 +203,7 @@ Verification evidence:
 
 Depends on: Work Package 2B.
 
-Status: Pending (`fix/smart-collection-initial-thumbnail`)
+Status: Pending unversioned follow-up (`fix/smart-collection-initial-thumbnail`)
 
 Primary invariant: every new Smart Collection attempts to establish a thumbnail from its own matches without first being opened or pinned.
 
@@ -227,7 +229,7 @@ Completion criteria:
 
 Depends on: Work Package 3.
 
-Status: Pending (`fix/duplicate-group-navigation`)
+Status: Pending unversioned follow-up (`fix/duplicate-group-navigation`)
 
 Primary invariant: every copy in an exact-duplicate group is visibly reachable and actionable.
 
@@ -253,7 +255,7 @@ Completion criteria:
 
 Depends on: Work Packages 1-4.
 
-Status: Pending (`docs/release-0.9.0-readiness`)
+Status: Superseded by the `v0.9.0` release
 
 Primary invariant: the combined fixes preserve large-library virtualization and fail-closed privacy behavior.
 
@@ -267,7 +269,9 @@ Non-goals:
 
 - No manual version bump or unrelated release automation changes.
 
-## Release Acceptance Gate
+## Historical Release Acceptance Gate
+
+This gate was not completed before `v0.9.0` was released. Preserve it as planning history; do not use it to claim current release readiness.
 
 1. Confirm all four behavior packages are independently review-clean.
 2. Repeat the search, onboarding, Smart Collection, duplicate, and Privacy Mode smoke flows.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,34 +1,31 @@
 # Progress
 Status: Current
-Last reviewed: 2026-07-18
+Last reviewed: 2026-07-22
 
-## Current State
-- The repo is currently on package version `0.6.4`; do not infer release publication status from this file alone.
-- The routed docs package is now baseline repo infrastructure: `AGENTS.md`, `docs/architecture.md`, `docs/WORKFLOW_SETUP.md`, and this file should be maintained rather than re-bootstrapped.
-- Production build hardening is part of the normal build path: `app:build` now runs `verify:release` before `tauri build --ci`, and the release gate includes a no-bundle Tauri compatibility build.
-- Frontend bundle cleanup has a build-output guard: `build:guard` fails if ineffective dynamic imports return or the startup entry chunk exceeds the 500 kB warning threshold.
-- The Live Watch incremental facet branch now avoids the old default idle-time full facet rebuild for normal live imports. Live Watch refreshes changed resource facets through the incremental queue, while manual recovery and non-live flows retain the full rebuild fallback.
-- The latest manual InvokeAI run showed the resource incremental path working as intended: browser logs emitted `mode:"resource-incremental"`, Rust resource refresh completed in about `452ms`, and the previously slow `caradhras-mix_style` LoRA refresh was about `106ms` instead of multi-second.
-- Asset drill-down now uses standard disjunctive faceting semantics: selected Match Any values keep sibling alternatives visible by counting that facet against all other active filters, while Match All keeps narrowed co-occurrence counts. Checkpoints remain multi-select but Any-only because each image has one checkpoint/model, and generator tools remain Any-only in the UI.
-- Maintenance currently exposes Missing, Thumbnails, Duplicates, Untagged, conditional Intermediates, and Removed tabs. Thumbnail optimization remains a visible maintenance surface as well as a background healing path.
+## Current Baseline
+- The current checkout and release manifests are version `0.9.0`: `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/tauri.dev.json`, `src-tauri/Cargo.toml`, and `.github/.release-please-manifest.json` agree. The checkout is tagged `v0.9.0`; hosted release state still belongs to GitHub rather than this file.
+- Release builds remain Windows-only. Linux and macOS packages are manual, unsigned or non-updater experimental artifacts as documented in `docs/experimental-unix-builds.md`.
+- Production packaging runs `verify:release` before Tauri builds. The gate checks version consistency, generated binding drift, lint, TypeScript, guarded frontend output, coverage, Rust tests, and a no-bundle Tauri compatibility build.
+- ComfyUI metadata milestones 22 through 26 are complete. Their files under `docs/plans/` are historical verification records, not active work.
+- The search-transition, prompt-masking, setup-guide replay, and tooltip-dismissal packages recorded in `docs/plans/release-0.9.0-ux-readiness.md` landed before the `v0.9.0` release.
 
 ## Current Constraints
-- `package.json` defines dev, build, lint, typecheck, one-shot frontend test, coverage, Rust test, Tauri no-bundle check, and release verification scripts.
-- `verify:release` runs version consistency, binding drift check, lint, TypeScript, guarded production build, coverage-backed frontend tests, Rust tests, and the no-bundle Tauri build before production desktop packaging.
-- `.github/workflows/pr-ci.yml`, `.github/workflows/release-please.yml`, and `.github/workflows/release.yml` automate PR validation, versioning, and packaging; they do not replace task-specific local verification.
-- `src/bindings.ts` is generated from Rust command signatures during debug Tauri runs and should not be hand-edited.
+- Specta binding generation is explicit. Do not expect a debug Tauri launch to update `src/bindings.ts`; run `pnpm run bindings:generate`, then `pnpm run bindings:check`.
 - Desktop persistence is intentionally split: SQLite stores image records and heavy metadata under Local AppData, `library.json` stores lightweight app settings and recent searches, and the OS keyring stores sensitive API keys.
-- `src/services/repository.ts` is not the shipping desktop persistence path; treat it as legacy or fallback code unless a dedicated cleanup task explicitly changes that contract.
-- Duplicate detection treats same SHA-256 file content as an exact duplicate regardless of filename or path; metadata/dimensions/filesize-only “likely” groups are no longer surfaced.
-- Duplicate maintenance is a global scan. It backfills missing hashes in the native backend as a cancellable Activity Dock task without blocking imports, and reports cancelled/error-remnant scans as incomplete.
-- Duplicate cleanup is transactional and conservative: safe keeper state and collection memberships are merged, redundant records move through the Removed flow, and files are not deleted by default.
+- `src/services/repository.ts` is not the shipping desktop persistence path. Treat its LocalStorage/mock behavior as an ambiguous fallback until a dedicated task either validates or retires it.
+- Exact duplicate detection is a global SHA-256 scan. Cleanup merges safe keeper state and collection memberships, moves redundant records through the Removed flow, and does not delete files by default.
+- The `io.github.asuraace.ambit` identifier is current. Startup migration and reset/repair paths still account for legacy `com.ambit.app` Local and Roaming AppData during the public-beta transition.
 
-## Next Work
-- Add browser smoke tests for lazy-loaded app surfaces: settings, dashboard/statistics, maintenance, command palette, export, viewer, compare, recovery, slideshow, and collection editor.
-- Add coverage thresholds after the public-beta baseline is reviewed.
-- Add a small Tauri desktop launch smoke test later, using a temporary app data/profile directory; keep installer/update testing for release packaging work.
-- Production builds now use the Tauri identifier `io.github.asuraace.ambit`. Release builds run a one-time startup migration from the legacy `com.ambit.app` Roaming and Local AppData directories before SQL initialization, and reset/repair paths still check both identifiers during the public-beta transition.
-- The durable engineering follow-up from earlier work still stands: clarify whether `src/services/repository.ts` remains a supported non-desktop or mock fallback, or should be retired in a dedicated cleanup.
-- Live Watch still needs a separate pending-completion UX pass if we want toggle-off to distinguish "activity detected but output not complete yet" from passive idle or summary states. See `docs/refactor.md#live-watch-pending-completion-state`.
-- Future asset-filter work should centralize facet taxonomy and match-mode support so hook logic, SQL filtering, browser mocks, and UI controls cannot drift. See `docs/refactor.md#facet-semantics-centralization`.
-- Use this file for active repo state and durable near-term follow-ups. Move recurring structural debt to `docs/refactor.md`, and keep personal scratch planning out of tracked files.
+## Active Follow-Ups
+- `docs/plans/release-0.9.0-ux-readiness.md` was overtaken by the `v0.9.0` release and is no longer a live release gate. Its Work Package 3 (initial Smart Collection thumbnail hydration) and Work Package 4 (discoverable duplicate-group navigation) remain unversioned product follow-ups.
+- Add browser smoke coverage for lazy-loaded app surfaces, including settings, statistics, maintenance, command palette, export, viewer, compare, recovery, slideshow, and collection editing.
+- Add coverage thresholds after the public-beta baseline is intentionally reviewed.
+- Add a small Tauri desktop launch smoke test using a temporary app-data/profile directory; keep installer and updater validation in the release-candidate workflow.
+- Decide whether `src/services/repository.ts` remains a supported non-desktop/mock fallback or should be retired in dedicated cleanup.
+- Keep structural follow-ups in `docs/refactor.md`; notably Live Watch pending-completion UX and facet-semantics centralization remain deferred there.
+
+## Status Routing
+- Use this file for moving repository state and near-term follow-ups.
+- Use `docs/release-candidate-validation.md` for release-asset, updater, and installed-app evidence.
+- Treat plans marked `Complete` or `Superseded` as historical. Do not infer active work from a pending item inside a superseded plan without reconciling it here.
+- Use `docs/refactor.md` for actionable deferred structural work, not release status or session notes.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -187,8 +187,8 @@ Status: Deferred
 Status: Deferred
 
 ### Why Cleanup Is Needed
-- `src/App.tsx` is a 487-line integration shell that coordinates view mode, selection, import and export, modals, viewer state, drag and drop, shortcuts, and maintenance hooks.
-- `src/contexts/SearchContext.tsx` is a 287-line bridge between React Query, persisted settings, SQL clause generation, and a mirrored Zustand store.
+- `src/App.tsx` remains a broad integration shell that coordinates view mode, selection, import and export, modals, viewer state, drag and drop, shortcuts, and maintenance hooks.
+- `src/contexts/SearchContext.tsx` remains a broad bridge between React Query, persisted settings, SQL clause generation, and a mirrored Zustand store.
 
 ### Current Pain Points
 - Images, filters, and recent-search state are shared across contexts, hooks, and stores.


### PR DESCRIPTION
## Summary

- add the Assure delivery posture, authoritative-source routing, and thumbnail subsystem ownership to the agent entry point
- reconcile architecture and current-state documentation with the 0.9.0 release and completed ComfyUI milestones
- mark the partially completed 0.9.0 UX plan as superseded while preserving its remaining follow-ups
- remove obsolete private-repository workflow assumptions and brittle refactor line counts

## Why

The repository documentation had drifted from executable sources and the current tree: progress still reported 0.6.4, binding generation was described as an automatic debug-launch side effect, the released 0.9.0 plan still appeared active, and release workflow notes still treated the repository as private. This refresh restores a trustworthy navigation and current-state surface without adding new documentation files.

## Impact

Documentation only. Runtime behavior and public interfaces are unchanged. Future contributors and coding agents get accurate commands, source-of-truth precedence, subsystem routing, release state, and deferred-work boundaries.

## Validation

- `pnpm run check:versions`
- `pnpm run bindings:check`
- `git diff --check`
- verified all added local paths and Markdown anchors