### PR TITLE
fix: recover prompts from maintenance viewer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 Status: Canonical
-Last reviewed: 2026-07-22
+Last reviewed: 2026-07-27
 
 ## System Overview
 Ambit is a Tauri v2 desktop app with a React/TypeScript frontend and a Rust backend exposed through Tauri commands. Images and heavy metadata live in SQLite under Local AppData, lightweight app state lives in `library.json` under app-local data, and sensitive secrets such as the Gemini API key live in the OS keyring.
@@ -39,8 +39,8 @@ Related docs: `docs/manual/maintenance.md`, `docs/refactor.md#smart-thumbnail-op
 Purpose: render the desktop UI, modals, viewer, filter panel, grid/timeline/statistics views, maintenance screens, and settings flows.
 Code: `src/index.tsx`, `src/App.tsx`, `src/components/`, `src/features/`
 Interacts with: contexts, stores, hooks, `src/services/`, generated bindings, and Tauri plugins
-Risks: `src/App.tsx` coordinates many cross-feature concerns, so changes can regress areas outside the touched feature
-Related docs: `docs/refactor.md#frontend-state-and-shell-coordination`
+Risks: `src/App.tsx` coordinates many cross-feature concerns, so changes can regress areas outside the touched feature. Gallery and Maintenance both render the shared `src/features/viewer/components/ImageViewer.tsx`, but each owns context-specific session navigation and action wiring; viewer feature changes must verify both entry points.
+Related docs: `docs/refactor.md#frontend-state-and-shell-coordination`, `docs/refactor.md#shared-image-viewer-integration-boundary`
 
 ### Query, State, and Persistence Adapters
 Purpose: own frontend query flows, transient UI state, JSON-backed settings and recent-search persistence, thumbnail services, and database helper modules.
@@ -64,6 +64,7 @@ Related docs: `README.md#privacy-and-network-behavior`, `SECURITY.md`
 - API keys are stored via Rust keyring commands, not persisted in `library.json`.
 - Passive visual assets must be bundled locally. Network calls should be limited to the documented updater, Gemini, CivitAI, and user-clicked external-link paths.
 - Large library browsing paths must remain virtualized and performance-conscious.
+- Gallery and Maintenance should reuse the shared `ImageViewer` presentation instead of developing separate viewer implementations. Their navigation, deletion, recovery, and other context-dependent policies remain owned by their respective controllers.
 
 ## High-Risk Areas
 - `src/App.tsx`: app shell integration point for selection, viewer, import, shortcuts, modals, and layout state.

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -1,6 +1,6 @@
 # Refactor Notes
 Status: Deferred
-Last reviewed: 2026-07-07
+Last reviewed: 2026-07-27
 
 ## How to Use This File
 Use this file to record deferred structural cleanup that changes how contributors should edit the repo safely. Keep active workstreams and short-lived blockers in `docs/progress.md`.
@@ -213,6 +213,41 @@ Status: Deferred
 ### Related Docs
 - `docs/architecture.md#frontend-app-shell-and-feature-surfaces`
 - `docs/architecture.md#query-state-and-persistence-adapters`
+
+## Shared Image Viewer Integration Boundary
+Status: Deferred
+Priority: P3
+
+### Current Architecture
+- Gallery and Maintenance use the same `ImageViewer` component rather than separate viewer implementations.
+- Gallery owns its frozen viewer-session list and normal library actions in `src/App.tsx`.
+- Maintenance owns navigation over the active maintenance result set plus maintenance-specific cleanup and recovered-image state in `MaintenanceView.tsx`.
+
+### Why Cleanup Is Needed
+- The two entry points repeat a broad callback and capability contract when mounting `ImageViewer`.
+- Maintenance currently represents some unsupported integrations with no-op callbacks and omits other Gallery capabilities. This makes intentional context differences difficult to distinguish from incomplete wiring.
+- Adding a shared viewer feature can appear complete after updating the Gallery entry point while remaining unavailable or inert in Maintenance.
+
+### Suggested Future Direction
+- Keep `ImageViewer` as the shared presentation and interaction component.
+- Keep Gallery and Maintenance navigation, deletion, recovery, and other context-specific policies in separate controllers.
+- Introduce thin Gallery and Maintenance viewer adapters, or make optional capabilities explicit in the shared viewer contract, when another parity issue or viewer feature justifies the change.
+- Replace no-op callbacks with intentionally unavailable capabilities or real shared handlers, and add focused coverage for capabilities expected in both entry points.
+
+### Safe-Change Warning
+- Do not move both viewer sessions into one global controller merely to remove prop duplication; their list stability, cleanup, and recovery semantics differ.
+- Do not expand this into a broad `App.tsx` or state-management rewrite.
+
+### Acceptance Direction
+- A contributor can tell which viewer capabilities are shared and which are context-specific from the component contracts.
+- Adding a shared viewer capability has an explicit verification path for both Gallery and Maintenance.
+- Maintenance does not expose controls backed by no-op handlers.
+
+### Related Code
+- `src/features/viewer/components/ImageViewer.tsx`
+- `src/App.tsx`
+- `src/features/maintenance/components/MaintenanceView.tsx`
+- `src/components/AppLayout.tsx`
 
 ## Backend-Supported Timeline Buckets
 Status: Deferred

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -183,6 +183,7 @@ const mocks = vi.hoisted(() => ({
     updateCollectionFilters: vi.fn().mockResolvedValue(undefined),
     handleExportConfirm: vi.fn(),
     executeDelete: vi.fn(),
+    openMetadataRecovery: vi.fn(),
     executeMetadataRecovery: vi.fn(),
     handlePinImage: vi.fn(),
     handleFavoriteImage: vi.fn(),
@@ -382,6 +383,7 @@ vi.mock('./hooks/useAppActions', () => ({
     useAppActions: () => ({
         handleExportConfirm: mocks.handleExportConfirm,
         executeDelete: mocks.executeDelete,
+        openMetadataRecovery: mocks.openMetadataRecovery,
         executeMetadataRecovery: mocks.executeMetadataRecovery,
         handlePinImage: mocks.handlePinImage,
         handleFavoriteImage: mocks.handleFavoriteImage,
@@ -1300,7 +1302,7 @@ describe('App orchestration', () => {
         expect(requireProbe(captured.appLayout, 'AppLayout').scopeTotal).toBe(2);
     });
 
-    it('updates searches and gates recovery on AI configuration', async () => {
+    it('updates searches and delegates viewer recovery launch', async () => {
         render(<App />);
         act(() => requireProbe(captured.appLayout, 'AppLayout').setViewingImageId('one'));
         await waitFor(() => expect(captured.viewer?.image.id).toBe('one'));
@@ -1310,20 +1312,7 @@ describe('App orchestration', () => {
         await waitFor(() => expect(mocks.setFilters).toHaveBeenCalled());
         expect(mocks.setRecentSearches).toHaveBeenCalledWith(expect.any(Function));
         viewer.onRecoverMetadata();
-        expect(mocks.modals.setInitialSettingsTab).toHaveBeenCalledWith('intelligence');
-        expect(mocks.addToast).toHaveBeenCalledWith(
-            'Enable AI features and configure a Gemini API key in Settings to use Prompt Recovery.',
-            'info'
-        );
-
-        mocks.settings.enableAI = true;
-        mocks.geminiApiKey = 'key';
-        const { rerender } = render(<App />);
-        rerender(<App />);
-        act(() => requireProbe(captured.appLayout, 'AppLayout').setViewingImageId('one'));
-        await waitFor(() => expect(captured.viewer).not.toBeNull());
-        requireProbe(captured.viewer, 'ImageViewer').onRecoverMetadata();
-        expect(mocks.modals.openModal).toHaveBeenCalledWith('recovery');
+        expect(mocks.openMetadataRecovery).toHaveBeenCalledWith();
     });
 
     it('imports selected browser files through the hidden input', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,6 @@ export default function App() {
     // --- Store Subscriptions ---
     const isSettingsLoaded = useSettingsStore(s => s.isLoaded);
     const settings = useSettingsStore(s => s.settings);
-    const geminiApiKey = useSettingsStore(s => s.geminiApiKey);
     const setSettings = useSettingsStore(s => s.setSettings);
     const flushSettings = useSettingsStore(s => s.flushSettings);
 
@@ -266,17 +265,6 @@ export default function App() {
 
         fileOps.fileInputRef.current?.click();
     }, [fileOps]);
-
-    const handleOpenRecovery = useCallback(() => {
-        if (!settings.enableAI || !geminiApiKey) {
-            modals.setInitialSettingsTab('intelligence');
-            modals.openModal('settings');
-            addToast('Enable AI features and configure a Gemini API key in Settings to use Prompt Recovery.', 'info');
-            return;
-        }
-
-        modals.openModal('recovery');
-    }, [settings.enableAI, geminiApiKey, modals, addToast]);
 
     useFolderMonitor({
         isLoaded,
@@ -829,7 +817,7 @@ export default function App() {
                                 setRecentSearches(prev => [term, ...prev.filter(s => s !== term)].slice(0, 8));
                             }}
                             onRevertMetadata={(id) => handlers.handleRevertMetadata(id)}
-                            onRecoverMetadata={handleOpenRecovery}
+                            onRecoverMetadata={() => actions.openMetadataRecovery()}
                             onSetCollectionMembership={handleSetViewerCollectionMembership}
                             availableTags={availableTags}
                             isSidebarOpen={!settings.defaultTheaterMode}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -150,7 +150,6 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
 
     // Stores
     const settings = useSettingsStore(s => s.settings);
-    const geminiApiKey = useSettingsStore(s => s.geminiApiKey);
     const privacyEnabled = useSettingsStore(s => s.privacyEnabled);
     const privacyMaskIndexStatus = useSettingsStore(s => s.privacyMaskIndexStatus);
     const privacyExposureBlocked = privacyEnabled && privacyMaskIndexStatus !== 'ready';
@@ -419,14 +418,8 @@ export const AppLayout: React.FC<AppLayoutProps> = ({
                                         onUpdateModel={handlers.handleUpdateModel}
                                         onUpdateTool={handlers.handleUpdateTool}
                                         onUpdateNotes={(id, n) => { handlers.handleUpdateNotes(id, n); }}
-                                        onRecoverMetadata={() => {
-                                            if (!settings.enableAI || !geminiApiKey) {
-                                                addToast("Enable AI features and configure a Gemini API key first", "error");
-                                                modals.setInitialSettingsTab('intelligence');
-                                                modals.openModal('settings');
-                                            } else {
-                                                modals.openModal('recovery');
-                                            }
+                                        onRecoverMetadata={(targetId, onRecovered) => {
+                                            actions.openMetadataRecovery(targetId, onRecovered);
                                         }}
                                         onToggleFavorite={(id) => toggleFavorite(id)}
                                         onTogglePin={actions.handlePinImage}

--- a/src/components/__tests__/AppLayout.test.tsx
+++ b/src/components/__tests__/AppLayout.test.tsx
@@ -675,51 +675,33 @@ describe('AppLayout', () => {
         expect(vi.getTimerCount()).toBe(0);
     });
 
-    it('routes maintenance actions and gates AI recovery on configuration', async () => {
-        const originalStore = useSettingsStore.getState();
-        const addToast = vi.fn();
+    it('routes maintenance actions and explicit recovery targets', async () => {
         const setViewingImageId = vi.fn();
-        const toggleFavorite = vi.fn();
         const handleUpdateNotes = vi.fn();
-        const modals = { setInitialSettingsTab: vi.fn(), openModal: vi.fn() };
-        useSettingsStore.setState({
-            settings: { ...originalStore.settings, enableAI: false },
-            geminiApiKey: null
-        });
-        const { rerender } = render(<AppLayout
+        const openMetadataRecovery = vi.fn();
+        render(<AppLayout
             {...defaultProps}
             viewMode="maintenance"
-            addToast={addToast}
             setViewingImageId={setViewingImageId}
             handlers={{ handleUpdateNotes }}
-            modals={modals}
+            actions={{ openMetadataRecovery }}
         />);
         await screen.findByTestId('maintenance-view');
-        let maintenance = capturedProps.maintenance as {
+        const maintenance = capturedProps.maintenance as {
             onViewImage: (id: string) => void;
             onUpdateNotes: (id: string, notes: string) => void;
-            onRecoverMetadata: () => void;
+            onRecoverMetadata: (id: string, onRecovered: (image: AIImage) => void) => void;
             onToggleFavorite: (id: string) => void;
         };
+        const onRecovered = vi.fn();
         maintenance.onViewImage('image-1');
         maintenance.onUpdateNotes('image-1', 'note');
-        maintenance.onRecoverMetadata();
+        maintenance.onRecoverMetadata('image-1', onRecovered);
         maintenance.onToggleFavorite('image-1');
         expect(setViewingImageId).toHaveBeenCalledWith('image-1');
         expect(handleUpdateNotes).toHaveBeenCalledWith('image-1', 'note');
-        expect(addToast).toHaveBeenCalledWith('Enable AI features and configure a Gemini API key first', 'error');
-        expect(modals.setInitialSettingsTab).toHaveBeenCalledWith('intelligence');
+        expect(openMetadataRecovery).toHaveBeenCalledWith('image-1', onRecovered);
         expect(searchState.value.toggleFavorite).toHaveBeenCalledWith('image-1');
-
-        useSettingsStore.setState({
-            settings: { ...originalStore.settings, enableAI: true },
-            geminiApiKey: 'configured-key'
-        });
-        rerender(<AppLayout {...defaultProps} viewMode="maintenance" addToast={addToast} modals={modals} />);
-        maintenance = capturedProps.maintenance as typeof maintenance;
-        maintenance.onRecoverMetadata();
-        expect(modals.openModal).toHaveBeenCalledWith('recovery');
-        useSettingsStore.setState({ settings: originalStore.settings, geminiApiKey: originalStore.geminiApiKey });
     });
 
     it('wires timeline and pinned-shelf image interactions', () => {

--- a/src/features/maintenance/components/MaintenanceView.test.tsx
+++ b/src/features/maintenance/components/MaintenanceView.test.tsx
@@ -240,7 +240,7 @@ vi.mock('./ScanPlaceholder', () => ({
 }));
 
 vi.mock('../../../features/viewer/components/ImageViewer', () => ({
-    ImageViewer: ({ image, onDelete, onNext, onPrev, onClose, onToggleFavorite, onTogglePin, onSetCollectionMembership, onSearch, onOpenSettings, isShortcutBlocked }: {
+    ImageViewer: ({ image, onDelete, onNext, onPrev, onClose, onToggleFavorite, onTogglePin, onSetCollectionMembership, onSearch, onOpenSettings, onRecoverMetadata, isShortcutBlocked }: {
         image: AIImage;
         onDelete?: () => void;
         onNext: () => void;
@@ -251,9 +251,10 @@ vi.mock('../../../features/viewer/components/ImageViewer', () => ({
         onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
         onSearch: () => void;
         onOpenSettings: () => void;
+        onRecoverMetadata?: () => void;
         isShortcutBlocked?: boolean;
     }) => (
-        <div data-testid="maintenance-viewer" data-image-id={image.id} data-shortcuts-blocked={String(isShortcutBlocked)}>
+        <div data-testid="maintenance-viewer" data-image-id={image.id} data-prompt={image.metadata.positivePrompt} data-shortcuts-blocked={String(isShortcutBlocked)}>
             {onDelete && <button onClick={onDelete}>Viewer Cleanup</button>}
             <button onClick={onNext}>Viewer Next</button>
             <button onClick={onPrev}>Viewer Previous</button>
@@ -264,6 +265,7 @@ vi.mock('../../../features/viewer/components/ImageViewer', () => ({
             <button onClick={() => void onSetCollectionMembership(image.id, 'collection', false)}>Remove Viewer Collection</button>
             <button onClick={onSearch}>Viewer Search</button>
             <button onClick={onOpenSettings}>Viewer Settings</button>
+            {onRecoverMetadata && <button onClick={onRecoverMetadata}>Recover Viewer Prompt</button>}
         </div>
     )
 }));
@@ -608,7 +610,13 @@ describe('MaintenanceView', () => {
         const onTogglePin = vi.fn();
         const onViewerOpenChange = vi.fn();
         const onSetCollectionMembership = vi.fn().mockResolvedValue(true);
-        renderView({ onToggleFavorite, onTogglePin, onViewerOpenChange, onSetCollectionMembership, isShortcutBlocked: true });
+        const onRecoverMetadata = vi.fn((id: string, onRecovered: (image: AIImage) => void) => {
+            onRecovered(createImage({
+                id,
+                metadata: { ...createImage().metadata, positivePrompt: 'Recovered maintenance prompt' }
+            }));
+        });
+        renderView({ onToggleFavorite, onTogglePin, onViewerOpenChange, onSetCollectionMembership, onRecoverMetadata, isShortcutBlocked: true });
 
         fireEvent.click(screen.getByText('Select Missing Item'));
         expect(onViewerOpenChange).toHaveBeenLastCalledWith(true);
@@ -629,6 +637,9 @@ describe('MaintenanceView', () => {
         expect(onSetCollectionMembership).toHaveBeenNthCalledWith(2, 'missing-a', 'collection', false);
         fireEvent.click(screen.getByText('Viewer Search'));
         fireEvent.click(screen.getByText('Viewer Settings'));
+        fireEvent.click(screen.getByText('Recover Viewer Prompt'));
+        expect(onRecoverMetadata).toHaveBeenCalledWith('missing-a', expect.any(Function));
+        expect(screen.getByTestId('maintenance-viewer').getAttribute('data-prompt')).toBe('Recovered maintenance prompt');
         fireEvent.click(screen.getByText('Close Viewer'));
         expect(screen.queryByTestId('maintenance-viewer')).toBeNull();
         expect(onViewerOpenChange).toHaveBeenLastCalledWith(false);

--- a/src/features/maintenance/components/MaintenanceView.tsx
+++ b/src/features/maintenance/components/MaintenanceView.tsx
@@ -36,7 +36,7 @@ interface MaintenanceViewProps {
     onUpdateModel?: (id: string, model: string) => void;
     onUpdateTool?: (id: string, tool: GeneratorTool) => void;
     onUpdateNotes?: (id: string, notes: string) => void;
-    onRecoverMetadata?: () => void;
+    onRecoverMetadata?: (targetId: string, onRecovered: (image: AIImage) => void) => void;
     onToggleFavorite?: (id: string) => void;
     onTogglePin?: (id: string, isPinned: boolean) => void;
     onSetCollectionMembership: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
@@ -86,6 +86,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
 
     const [viewingImageId, setViewingImageId] = useState<string | null>(null);
     const [compareImages, setCompareImages] = useState<[AIImage, AIImage] | null>(null);
+    const [recoveredImages, setRecoveredImages] = useState<Map<string, AIImage>>(() => new Map());
     const [removedAction, setRemovedAction] = useState<'restoring' | 'deleting' | null>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -151,8 +152,17 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
             ...localIntermediateImages,
             ...activeImages
         ];
-        return allPool.find(i => i.id === viewingImageId) || null;
-    }, [viewingImageId, missingImages, localUntaggedImages, localDeletedImages, localUnoptimizedImages, localDuplicateCandidates, localIntermediateImages, activeImages]);
+        const image = allPool.find(i => i.id === viewingImageId) || null;
+        return image ? recoveredImages.get(image.id) ?? image : null;
+    }, [viewingImageId, missingImages, localUntaggedImages, localDeletedImages, localUnoptimizedImages, localDuplicateCandidates, localIntermediateImages, activeImages, recoveredImages]);
+
+    const handleRecoveredImage = useCallback((image: AIImage) => {
+        setRecoveredImages(previous => {
+            const next = new Map(previous);
+            next.set(image.id, image);
+            return next;
+        });
+    }, []);
 
     // --- Selection Hook ---
     const {
@@ -633,7 +643,7 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
                     onUpdateModel={onUpdateModel}
                     onUpdateTool={onUpdateTool}
                     onUpdateNotes={onUpdateNotes}
-                    onRecoverMetadata={onRecoverMetadata}
+                    onRecoverMetadata={() => onRecoverMetadata?.(viewingImageId, handleRecoveredImage)}
                     availableTags={availableTags}
                     onOpenSettings={() => { }}
                     onDelete={activeTab === 'trash' ? undefined : handleViewerCleanup}

--- a/src/hooks/__tests__/useAppActions.test.tsx
+++ b/src/hooks/__tests__/useAppActions.test.tsx
@@ -58,7 +58,7 @@ vi.mock('../../stores/settingsStore', () => {
         privacyEnabled: mockPrivacyEnabled,
         setPrivacyEnabled: mockSetPrivacyEnabled,
     });
-    useSettingsStore.getState = () => ({ geminiApiKey: mockGeminiApiKey });
+    useSettingsStore.getState = () => ({ settings: mockSettings, geminiApiKey: mockGeminiApiKey });
     return { useSettingsStore };
 });
 
@@ -481,38 +481,81 @@ describe('useAppActions', () => {
         expect(mockAddToast).toHaveBeenCalledWith('Privacy Mode Disabled (Hidden/Blurred items revealed)', 'info');
     });
 
-    it('routes recovery to settings when AI configuration is missing', async () => {
+    it('routes recovery launch to settings when AI configuration is missing', () => {
         const setInitialSettingsTab = vi.fn();
-        const recoveryProps = { ...props, viewingImageId: '1', modalManager: { ...mockModalManager, setInitialSettingsTab } };
+        const recoveryProps = { ...props, modalManager: { ...mockModalManager, setInitialSettingsTab } };
         const { result } = renderHook(() => useAppActions(recoveryProps));
-        await act(async () => result.current.executeMetadataRecovery('generic'));
-        expect(mockModalManager.closeModal).toHaveBeenCalledWith('recovery');
+        act(() => result.current.openMetadataRecovery('1'));
         expect(setInitialSettingsTab).toHaveBeenCalledWith('intelligence');
         expect(mockModalManager.openModal).toHaveBeenCalledWith('settings');
+        expect(mockModalManager.openModal).not.toHaveBeenCalledWith('recovery');
     });
 
-    it('routes recovery to settings without an initial-tab callback', async () => {
-        const { result } = renderHook(() => useAppActions({ ...props, viewingImageId: '1' }));
-        await act(async () => result.current.executeMetadataRecovery('generic'));
+    it('routes recovery launch to settings without an initial-tab callback', () => {
+        const { result } = renderHook(() => useAppActions(props));
+        act(() => result.current.openMetadataRecovery('1'));
         expect(mockModalManager.openModal).toHaveBeenCalledWith('settings');
     });
 
-    it('reports unavailable recovery and recovers targets by viewer, index, then selection', async () => {
+    it('recovers the current Gallery viewer image before index or selection targets', async () => {
         mockSettings = { ...mockSettings, enableAI: true };
         mockGeminiApiKey = 'key';
-        const unavailable = renderHook(() => useAppActions({ ...props, viewingImageId: '1' }));
+        const recoveredImage = mockStoreImages[0] as AIImage;
+        const recoverMetadata = vi.fn().mockResolvedValue(recoveredImage);
+        const { result } = renderHook(() => useAppActions({
+            ...props,
+            viewingImageId: '1',
+            selectedImageIndex: 1,
+            selectedIds: new Set(['2']),
+            fileOps: { ...mockFileOps, recoverMetadata },
+        }));
+
+        act(() => result.current.openMetadataRecovery());
+        await act(async () => result.current.executeMetadataRecovery('midjourney'));
+
+        expect(mockModalManager.openModal).toHaveBeenCalledWith('recovery');
+        expect(recoverMetadata).toHaveBeenCalledWith('1', 'midjourney');
+        expect(mockModalManager.closeModal).toHaveBeenCalledWith('recovery');
+    });
+
+    it('resolves indexed Gallery recovery from the frozen viewer session', async () => {
+        mockSettings = { ...mockSettings, enableAI: true };
+        mockGeminiApiKey = 'key';
+        const frozenViewerImages = [mockStoreImages[1], mockStoreImages[0]] as AIImage[];
+        const recoverMetadata = vi.fn().mockResolvedValue(frozenViewerImages[0]);
+        const { result } = renderHook(() => useAppActions({
+            ...props,
+            selectedImageIndex: 0,
+            viewerImages: frozenViewerImages,
+            selectedIds: new Set(['1']),
+            fileOps: { ...mockFileOps, recoverMetadata },
+        }));
+
+        act(() => result.current.openMetadataRecovery());
+        await act(async () => result.current.executeMetadataRecovery('generic'));
+
+        expect(recoverMetadata).toHaveBeenCalledWith('2', 'generic');
+    });
+
+    it('reports unavailable recovery and recovers targets by index then selection', async () => {
+        mockSettings = { ...mockSettings, enableAI: true };
+        mockGeminiApiKey = 'key';
+        const unavailable = renderHook(() => useAppActions(props));
+        act(() => unavailable.result.current.openMetadataRecovery('1'));
         await act(async () => unavailable.result.current.executeMetadataRecovery('sdxl'));
         expect(mockAddToast).toHaveBeenCalledWith('Prompt Recovery is unavailable in this runtime.', 'error');
         unavailable.unmount();
 
-        const recoverMetadata = vi.fn(async (_id, _style, onComplete) => onComplete());
+        const recoverMetadata = vi.fn(async (id: string) => mockStoreImages.find(image => image.id === id) as AIImage);
         const byIndex = renderHook(() => useAppActions({
             ...props,
             selectedImageIndex: 1,
+            selectedIds: new Set(),
             fileOps: { ...mockFileOps, recoverMetadata },
         }));
+        act(() => byIndex.result.current.openMetadataRecovery());
         await act(async () => byIndex.result.current.executeMetadataRecovery('generic'));
-        expect(recoverMetadata).toHaveBeenCalledWith('2', 'generic', expect.any(Function));
+        expect(recoverMetadata).toHaveBeenCalledWith('2', 'generic');
         expect(mockModalManager.closeModal).toHaveBeenCalledWith('recovery');
         byIndex.unmount();
 
@@ -522,14 +565,54 @@ describe('useAppActions', () => {
             selectedIds: new Set(['1']),
             fileOps: { ...mockFileOps, recoverMetadata },
         }));
+        act(() => bySelection.result.current.openMetadataRecovery());
         await act(async () => bySelection.result.current.executeMetadataRecovery('sdxl'));
-        expect(recoverMetadata).toHaveBeenCalledWith('1', 'sdxl', expect.any(Function));
+        expect(recoverMetadata).toHaveBeenCalledWith('1', 'sdxl');
     });
 
-    it('no-ops recovery without a target', async () => {
-        const { result } = renderHook(() => useAppActions({ ...props, selectedIds: new Set(), lastSelectedId: null }));
+    it('recovers an explicit Maintenance target and publishes the updated image', async () => {
+        mockSettings = { ...mockSettings, enableAI: true };
+        mockGeminiApiKey = 'key';
+        const recoveredImage = { ...mockStoreImages[0], id: 'maintenance-image' } as AIImage;
+        const recoverMetadata = vi.fn().mockResolvedValue(recoveredImage);
+        const onRecovered = vi.fn();
+        const { result } = renderHook(() => useAppActions({
+            ...props,
+            viewingImageId: 'gallery-image',
+            fileOps: { ...mockFileOps, recoverMetadata },
+        }));
+
+        act(() => result.current.openMetadataRecovery('maintenance-image', onRecovered));
         await act(async () => result.current.executeMetadataRecovery('generic'));
-        expect(mockAddToast).not.toHaveBeenCalled();
+
+        expect(mockModalManager.openModal).toHaveBeenCalledWith('recovery');
+        expect(recoverMetadata).toHaveBeenCalledWith('maintenance-image', 'generic');
+        expect(onRecovered).toHaveBeenCalledWith(recoveredImage);
+        expect(mockModalManager.closeModal).toHaveBeenCalledWith('recovery');
+    });
+
+    it('keeps recovery retryable when the operation fails', async () => {
+        mockSettings = { ...mockSettings, enableAI: true };
+        mockGeminiApiKey = 'key';
+        const recoverMetadata = vi.fn().mockResolvedValue(null);
+        const onRecovered = vi.fn();
+        const { result } = renderHook(() => useAppActions({
+            ...props,
+            fileOps: { ...mockFileOps, recoverMetadata },
+        }));
+
+        act(() => result.current.openMetadataRecovery('maintenance-image', onRecovered));
+        await act(async () => result.current.executeMetadataRecovery('generic'));
+
+        expect(onRecovered).not.toHaveBeenCalled();
+        expect(mockModalManager.closeModal).not.toHaveBeenCalledWith('recovery');
+    });
+
+    it('reports recovery launch without a target', () => {
+        const { result } = renderHook(() => useAppActions({ ...props, selectedIds: new Set(), lastSelectedId: null }));
+        act(() => result.current.openMetadataRecovery());
+        expect(mockAddToast).toHaveBeenCalledWith('Select an image before starting Prompt Recovery.', 'error');
+        expect(mockModalManager.openModal).not.toHaveBeenCalledWith('recovery');
     });
 
     it('routes favorite and pin shortcuts between viewer and bulk actions', async () => {

--- a/src/hooks/__tests__/useMaintenanceOps.test.tsx
+++ b/src/hooks/__tests__/useMaintenanceOps.test.tsx
@@ -115,9 +115,9 @@ describe('useMaintenanceOps metadata recovery', () => {
             settings,
         }), { wrapper });
 
-        const onComplete = vi.fn();
+        let recoveredImage: AIImage | null = null;
         await act(async () => {
-            await result.current.recoverMetadata(image.id, 'generic', onComplete);
+            recoveredImage = await result.current.recoverMetadata(image.id, 'generic');
         });
 
         expect(mockImageToBase64).toHaveBeenCalledWith(image.id);
@@ -138,10 +138,10 @@ describe('useMaintenanceOps metadata recovery', () => {
         expect(cached?.pages[0].images[0].metadata.positivePrompt).toBe('Recovered prompt');
         expect(cached?.pages[0].images[0].originalMetadata).toBeUndefined();
         expect(mockAddToast).toHaveBeenCalledWith('Metadata recovered successfully!', 'success');
-        expect(onComplete).toHaveBeenCalledTimes(1);
+        expect((recoveredImage as AIImage | null)?.metadata.positivePrompt).toBe('Recovered prompt');
     });
 
-    it('returns without entering recovery when the target image is absent', async () => {
+    it('reports an error when the target image is absent from memory and the database', async () => {
         const queryClient = new QueryClient();
         const wrapper = ({ children }: { children: React.ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -153,10 +153,35 @@ describe('useMaintenanceOps metadata recovery', () => {
             settings,
         }), { wrapper });
 
-        await act(async () => result.current.recoverMetadata('missing', 'generic', vi.fn()));
+        await act(async () => result.current.recoverMetadata('missing', 'generic'));
 
         expect(result.current.isRecoveringMetadata).toBe(false);
+        expect(imageRepoMocks.getImagesByIds).toHaveBeenCalledWith(['missing']);
         expect(mockImageToBase64).not.toHaveBeenCalled();
+        expect(mockAddToast).toHaveBeenCalledWith('Prompt Recovery could not find this image in the library.', 'error');
+    });
+
+    it('recovers a Maintenance image fetched from the database when it is outside the Gallery query', async () => {
+        imageRepoMocks.getImagesByIds.mockResolvedValueOnce([image]);
+        const queryClient = new QueryClient();
+        const wrapper = ({ children }: { children: React.ReactNode }) => (
+            <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        );
+        const { result } = renderHook(() => useMaintenanceOps({
+            images: [],
+            setImages: vi.fn(),
+            refreshCollections: vi.fn(),
+            settings,
+        }), { wrapper });
+
+        let recoveredImage: AIImage | null = null;
+        await act(async () => {
+            recoveredImage = await result.current.recoverMetadata(image.id, 'generic');
+        });
+
+        expect(imageRepoMocks.getImagesByIds).toHaveBeenCalledWith([image.id]);
+        expect(mockImageToBase64).toHaveBeenCalledWith(image.id);
+        expect((recoveredImage as AIImage | null)?.metadata.positivePrompt).toBe('Recovered prompt');
     });
 
     it('reports missing API credentials and releases recovery state', async () => {
@@ -173,10 +198,10 @@ describe('useMaintenanceOps metadata recovery', () => {
             settings,
         }), { wrapper });
 
-        await act(async () => result.current.recoverMetadata(image.id, 'generic', vi.fn()));
+        await act(async () => result.current.recoverMetadata(image.id, 'generic'));
 
         expect(mockRecoverImageMetadata).not.toHaveBeenCalled();
-        expect(mockAddToast).toHaveBeenCalledWith('AI Analysis Failed', 'error');
+        expect(mockAddToast).toHaveBeenCalledWith('AI Prompt Recovery failed. Please try again.', 'error');
         expect(result.current.isRecoveringMetadata).toBe(false);
         error.mockRestore();
     });
@@ -194,15 +219,14 @@ describe('useMaintenanceOps metadata recovery', () => {
             settings,
         }), { wrapper });
 
-        await act(async () => result.current.recoverMetadata(image.id, 'generic', vi.fn()));
+        await act(async () => result.current.recoverMetadata(image.id, 'generic'));
 
         expect(mockUpdateImageMetadataFields).toHaveBeenCalledWith(image.id, { positivePrompt: '' });
     });
 
-    it('reports recovery service failures without calling completion', async () => {
+    it('returns null and reports recovery service failures', async () => {
         const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
         mockRecoverImageMetadata.mockRejectedValue(new Error('provider unavailable'));
-        const onComplete = vi.fn();
         const queryClient = new QueryClient();
         const wrapper = ({ children }: { children: React.ReactNode }) => (
             <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -214,10 +238,13 @@ describe('useMaintenanceOps metadata recovery', () => {
             settings,
         }), { wrapper });
 
-        await act(async () => result.current.recoverMetadata(image.id, 'generic', onComplete));
+        let recoveredImage: AIImage | null = image;
+        await act(async () => {
+            recoveredImage = await result.current.recoverMetadata(image.id, 'generic');
+        });
 
-        expect(mockAddToast).toHaveBeenCalledWith('AI Analysis Failed', 'error');
-        expect(onComplete).not.toHaveBeenCalled();
+        expect(mockAddToast).toHaveBeenCalledWith('AI Prompt Recovery failed. Please try again.', 'error');
+        expect(recoveredImage).toBeNull();
         expect(result.current.isRecoveringMetadata).toBe(false);
         error.mockRestore();
     });

--- a/src/hooks/useAppActions.ts
+++ b/src/hooks/useAppActions.ts
@@ -20,7 +20,7 @@ import type { ImagesQueryKey } from './useImagesQuery';
 interface AppActionFileOps {
     deleteImages: (ids: string[]) => void | Promise<void>;
     exportImages: (filename: string, ids: Set<string> | string[], destinationFolder: string, onComplete?: () => void) => Promise<void>;
-    recoverMetadata?: (targetId: string, style: RecoveryStyle, onComplete: () => void) => Promise<void>;
+    recoverMetadata?: (targetId: string, style: RecoveryStyle) => Promise<AIImage | null>;
 }
 
 interface AppActionModalManager {
@@ -49,6 +49,11 @@ interface SingleImageActionOptions {
     showToast?: boolean;
 }
 
+interface PendingMetadataRecovery {
+    targetId: string;
+    onRecovered?: (image: AIImage) => void;
+}
+
 export const useAppActions = ({
     viewingImageId,
     selectedImageIndex,
@@ -64,6 +69,7 @@ export const useAppActions = ({
 }: UseAppActionsProps) => {
     const { addToast } = useToast();
     const queryClient = useQueryClient();
+    const pendingMetadataRecoveryRef = React.useRef<PendingMetadataRecovery | null>(null);
 
     // Store access
     const images = useSearchStore(s => s.images);
@@ -294,12 +300,44 @@ export const useAppActions = ({
         addToast(next ? "Privacy Mode Enabled" : "Privacy Mode Disabled (Hidden/Blurred items revealed)", "info");
     };
 
-    const executeMetadataRecovery = async (style: RecoveryStyle) => {
-        const targetId = viewingImageId || (selectedImageIndex !== null ? images[selectedImageIndex]?.id : null) || (selectedIds.size > 0 ? Array.from(selectedIds)[0] : null);
-        if (!targetId) return;
+    const resolveMetadataRecoveryTargetId = (targetId?: string) => (
+        targetId
+        || viewingImageId
+        || (selectedImageIndex !== null ? viewerImages[selectedImageIndex]?.id : null)
+        || (selectedIds.size > 0 ? Array.from(selectedIds)[0] : null)
+    );
 
-        const { geminiApiKey } = useSettingsStore.getState();
-        if (!settings.enableAI || !geminiApiKey) {
+    const openMetadataRecovery = (targetId?: string, onRecovered?: (image: AIImage) => void) => {
+        const resolvedTargetId = resolveMetadataRecoveryTargetId(targetId);
+        if (!resolvedTargetId) {
+            addToast('Select an image before starting Prompt Recovery.', 'error');
+            return;
+        }
+
+        const currentSettings = useSettingsStore.getState();
+        if (!currentSettings.settings.enableAI || !currentSettings.geminiApiKey) {
+            pendingMetadataRecoveryRef.current = null;
+            modals.setInitialSettingsTab?.('intelligence');
+            openModal('settings');
+            addToast('Enable AI features and configure a Gemini API key in Settings to use Prompt Recovery.', 'info');
+            return;
+        }
+
+        pendingMetadataRecoveryRef.current = { targetId: resolvedTargetId, onRecovered };
+        openModal('recovery');
+    };
+
+    const executeMetadataRecovery = async (style: RecoveryStyle) => {
+        const pendingRecovery = pendingMetadataRecoveryRef.current;
+        const targetId = pendingRecovery?.targetId ?? resolveMetadataRecoveryTargetId();
+        if (!targetId) {
+            addToast('Select an image before starting Prompt Recovery.', 'error');
+            return;
+        }
+
+        const currentSettings = useSettingsStore.getState();
+        if (!currentSettings.settings.enableAI || !currentSettings.geminiApiKey) {
+            pendingMetadataRecoveryRef.current = null;
             closeModal('recovery');
             modals.setInitialSettingsTab?.('intelligence');
             openModal('settings');
@@ -312,7 +350,12 @@ export const useAppActions = ({
             return;
         }
 
-        fileOps.recoverMetadata(targetId, style, () => closeModal('recovery'));
+        const recoveredImage = await fileOps.recoverMetadata(targetId, style);
+        if (!recoveredImage) return;
+
+        pendingMetadataRecoveryRef.current = null;
+        closeModal('recovery');
+        pendingRecovery?.onRecovered?.(recoveredImage);
     };
 
     const handlePinImage = (id: string, newPinned: boolean, options: SingleImageActionOptions = { showToast: true }) => {
@@ -375,6 +418,7 @@ export const useAppActions = ({
         handleBulkPin,
         handleBulkMask,
         handleTogglePrivacy,
+        openMetadataRecovery,
         executeMetadataRecovery,
         handleFavoriteImage,
         handlePinImage,

--- a/src/hooks/useMaintenanceOps.ts
+++ b/src/hooks/useMaintenanceOps.ts
@@ -94,12 +94,16 @@ export const useMaintenanceOps = ({
         }
     }, [setImages, addToast, refreshCollections, incrementFacetCacheVersion]);
 
-    const recoverMetadata = useCallback(async (targetId: string, style: RecoveryStyle, onComplete: () => void) => {
-        const img = images.find(i => i.id === targetId);
-        if (!img) return;
-
+    const recoverMetadata = useCallback(async (targetId: string, style: RecoveryStyle): Promise<AIImage | null> => {
         setIsRecoveringMetadata(true);
         try {
+            const img = images.find(i => i.id === targetId)
+                ?? (await getImagesByIds([targetId]))[0];
+            if (!img) {
+                addToast("Prompt Recovery could not find this image in the library.", "error");
+                return null;
+            }
+
             const base64 = await imageToBase64(img.id);
             const apiKey = useSettingsStore.getState().geminiApiKey;
             if (!apiKey) throw new Error("No API Key");
@@ -131,10 +135,11 @@ export const useMaintenanceOps = ({
             ));
 
             addToast("Metadata recovered successfully!", "success");
-            onComplete();
+            return updatedImg;
         } catch (e) {
             console.error(e);
-            addToast("AI Analysis Failed", "error");
+            addToast("AI Prompt Recovery failed. Please try again.", "error");
+            return null;
         } finally {
             setIsRecoveringMetadata(false);
         }


### PR DESCRIPTION
## Summary

- route Prompt Recovery through a single target-aware app action
- recover Maintenance images that are outside the active Gallery query
- refresh the open Maintenance viewer with the recovered prompt
- preserve frozen Gallery viewer target identity when live results reorder

## Root cause

Maintenance used the global recovery modal without carrying the locally viewed image ID. The recovery operation then resolved its target from Gallery state and could not find Maintenance-only images in the active Gallery result set.

## Impact

Prompt Recovery now works from Maintenance viewers, including hidden intermediate images, while Gallery recovery continues to target the image actually displayed. Missing AI configuration is handled consistently by routing to Intelligence settings.

## Validation

- manual Maintenance → Intermediates → viewer → Prompt Recovery smoke test
- full frontend suite: 2,884 passed, 1 skipped
- TypeScript check
- ESLint
- production frontend build
- `git diff --check`

Closes #257