### PR TITLE
fix(deps): unblock release dependency audits

### DIFF
--- a/.github/workflows/dependency-security.yml
+++ b/.github/workflows/dependency-security.yml
@@ -68,8 +68,8 @@ jobs:
         if: steps.audit-scope.outputs.run_rust == 'true'
         run: cargo install cargo-audit --version 0.22.1 --locked
 
-      # RUSTSEC-2023-0071 is ignored by the audit wrapper because it is pulled
-      # through optional sqlx-mysql while Ambit only enables the SQLite beta path.
+      # The audit wrapper ignores advisories only after verifying the affected
+      # optional packages are absent from Ambit's compiled Windows graph.
       - name: run rust dependency advisory audit
         if: steps.audit-scope.outputs.run_rust == 'true'
         run: node ./scripts/audit-rust.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,8 @@ jobs:
       - name: install cargo-audit
         run: cargo install cargo-audit --version 0.22.1 --locked
 
-      # RUSTSEC-2023-0071 is ignored by the audit wrapper because it is pulled
-      # through optional sqlx-mysql while Ambit only enables the SQLite beta path.
+      # The audit wrapper ignores advisories only after verifying the affected
+      # optional packages are absent from Ambit's compiled Windows graph.
       - name: run rust dependency advisory audit
         run: pnpm run audit:rust
 

--- a/scripts/audit-rust.mjs
+++ b/scripts/audit-rust.mjs
@@ -4,9 +4,57 @@ import process from 'node:process';
 const ignoredAdvisories = new Map([
   [
     'RUSTSEC-2023-0071',
-    'optional rsa dependency through sqlx-mysql; Ambit beta only enables the local SQLite path',
+    {
+      packageName: 'rsa',
+      reason: 'optional rsa dependency through sqlx-mysql; Ambit beta only enables the local SQLite path',
+    },
+  ],
+  [
+    'RUSTSEC-2026-0235',
+    {
+      packageName: 'rkyv',
+      reason: 'optional rkyv feature of rust_decimal is not enabled in Ambit\'s compiled dependency graph',
+    },
   ],
 ]);
+
+for (const [id, { packageName }] of ignoredAdvisories) {
+  const treeResult = spawnSync(
+    'cargo',
+    [
+      'tree',
+      '--locked',
+      '--manifest-path',
+      'src-tauri/Cargo.toml',
+      '--target',
+      'x86_64-pc-windows-msvc',
+      '--invert',
+      packageName,
+    ],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+
+  if (treeResult.error || treeResult.status !== 0) {
+    if (treeResult.stdout) {
+      console.error(treeResult.stdout);
+    }
+    if (treeResult.stderr) {
+      console.error(treeResult.stderr);
+    }
+    console.error(`Failed to verify that ignored advisory ${id} is outside the compiled dependency graph.`);
+    process.exit(treeResult.status ?? 1);
+  }
+
+  if (treeResult.stdout.trim()) {
+    console.error(`Ignored advisory ${id} is present in the compiled dependency graph:`);
+    console.error(treeResult.stdout.trim());
+    process.exit(1);
+  }
+}
 
 const args = [
   'audit',
@@ -79,7 +127,7 @@ const dependencyCount = report.lockfile?.['dependency-count'] ?? 'unknown';
 console.log(`Rust advisory audit passed: 0 unignored vulnerabilities across ${dependencyCount} dependencies.`);
 console.log(
   `Ignored advisories: ${[...ignoredAdvisories.entries()]
-    .map(([id, reason]) => `${id} (${reason})`)
+    .map(([id, { reason }]) => `${id} (${reason})`)
     .join('; ')}`,
 );
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Updates the active h2 dependency to patched 0.4.16, guards ignored rsa and rkyv advisories by proving those packages are absent from the compiled Windows dependency graph, and documents the guarded audit policy in both release workflows. Verified with pnpm run audit:rust and the complete pnpm verify:release gate; independent release-infrastructure review returned CLEAN. After merge, Release Please should refresh PR #276 and rerun its required checks.