### PR TITLE
fix(updater): improve diagnostics and published release verification

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm check:versions
 
       - name: test release automation scripts
-        run: node --test scripts/check-release-tag.node-test.mjs scripts/check-version-consistency.node-test.mjs scripts/extract-release-notes.node-test.mjs
+        run: node --test scripts/check-release-tag.node-test.mjs scripts/check-version-consistency.node-test.mjs scripts/extract-release-notes.node-test.mjs scripts/verify-published-updater.node-test.mjs
 
       - name: install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,3 +119,6 @@ jobs:
           prerelease: false
           updaterJsonPreferNsis: true
           args: --bundles nsis msi
+
+      - name: verify published updater release
+        run: pnpm run verify:published-updater -- ${{ github.ref_name }}

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -116,8 +116,12 @@ Use **Actions > updater-signing-preflight > Run workflow** before publishing. Th
 7. Confirm the generated `vX.Y.Z` tag starts `release.yml`.
 
 The release workflow currently publishes Windows NSIS and MSI artifacts, updater signatures, and `latest.json`. It copies the matching version section from `CHANGELOG.md` into the updater metadata so installed apps can show the same release notes. When `CURRENT_PARSER_VERSION` increases from the previous stable release, the extraction step prepends a metadata-refresh notice to the published GitHub and updater notes without modifying `CHANGELOG.md`. Release tags must use the exact `vX.Y.Z` format, match `package.json`, both Tauri configuration files, `src-tauri/Cargo.toml`, the local `app` package in `src-tauri/Cargo.lock`, and `.github/.release-please-manifest.json`, and point to a commit reachable from `main`.
+After publishing, `release.yml` runs `pnpm run verify:published-updater -- <tag>` without GitHub authentication. The check downloads every unique Windows artifact referenced by `latest.json` using Tauri's updater headers, matches its size and SHA-256 digest to GitHub's public asset metadata, validates the installer format, and verifies its Minisign signature against the public key embedded in `tauri.conf.json`. A failure blocks the release workflow even if artifact upload succeeded.
+
 
 Release Please remains the normal and preferred tag creator. Do not create manual release tags except for recovery work after confirming the tag target is already on `main` and all version files match.
+For updater incident triage, run the same command locally with the affected tag, for example `pnpm run verify:published-updater -- v0.12.0`. A passing result proves the public feed and signed artifacts are currently valid; it does not rule out a transient client network, proxy, or security-software failure.
+
 
 ## Experimental Unix Builds
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:pr-title": "node ./scripts/check-pr-title.mjs",
     "typecheck": "tsc --noEmit",
     "verify:release": "corepack pnpm run check:versions && corepack pnpm run check:mediainfo && corepack pnpm run bindings:check && corepack pnpm run lint && corepack pnpm run typecheck && corepack pnpm run build:guard && corepack pnpm run coverage && corepack pnpm run test:rust && corepack pnpm run tauri:check",
+    "verify:published-updater": "node ./scripts/verify-published-updater.mjs",
     "audit:prod": "pnpm audit --prod",
     "audit:rust": "node ./scripts/audit-rust.mjs",
     "audit:comfyui-catalog": "node ./scripts/audit-comfyui-catalog.mjs",

--- a/scripts/verify-published-updater.mjs
+++ b/scripts/verify-published-updater.mjs
@@ -1,0 +1,357 @@
+import { createHash, createPublicKey, verify as verifyEd25519 } from 'node:crypto';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
+
+const updaterVersion = packageJson.dependencies['@tauri-apps/plugin-updater'];
+const UPDATER_USER_AGENT = `tauri-plugin-updater/${updaterVersion}`;
+const WINDOWS_PLATFORM_PREFIX = 'windows-';
+const REQUIRED_WINDOWS_PLATFORMS = [
+  'windows-x86_64',
+  'windows-x86_64-nsis',
+  'windows-x86_64-msi',
+];
+const DEFAULT_RETRY_DELAYS_MS = [1_000, 3_000, 6_000, 10_000];
+const MINISIGN_PUBLIC_KEY_LENGTH = 42;
+const MINISIGN_SIGNATURE_LENGTH = 74;
+const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
+
+class RetryableUpdaterVerificationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'RetryableUpdaterVerificationError';
+  }
+}
+
+const responseError = (label, response) =>
+  new Error(`${label} request failed with status ${response.status} ${response.statusText}`.trim());
+
+const fetchOk = async (fetchImpl, url, options, label) => {
+  let response;
+
+  try {
+    response = await fetchImpl(url, options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new RetryableUpdaterVerificationError(
+      `${label} request failed: ${message}`,
+    );
+  }
+
+  if (!response.ok) {
+    const error = responseError(label, response);
+
+    if (response.status === 408 || response.status === 429 || response.status >= 500) {
+      throw new RetryableUpdaterVerificationError(error.message);
+    }
+
+    throw error;
+  }
+
+  return response;
+};
+
+const readResponseBody = async (response, method, label) => {
+  try {
+    return await response[method]();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new RetryableUpdaterVerificationError(
+      `${label} response body failed: ${message}`,
+    );
+  }
+};
+
+const readJson = (response, label) => readResponseBody(response, 'json', label);
+const readBytes = (response, label) => readResponseBody(response, 'arrayBuffer', label);
+
+const decodeOuterBase64Text = (value, label) => {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${label} must be a non-empty base64 string.`);
+  }
+
+  return Buffer.from(value, 'base64').toString('utf8');
+};
+
+const parsePublicKey = (encodedPublicKey) => {
+  const lines = decodeOuterBase64Text(encodedPublicKey, 'Updater public key').trim().split(/\r?\n/);
+  const bytes = Buffer.from(lines[1] ?? '', 'base64');
+
+  if (bytes.length !== MINISIGN_PUBLIC_KEY_LENGTH) {
+    throw new Error('Updater public key is not a valid Minisign public key.');
+  }
+
+  return {
+    keyId: bytes.subarray(2, 10),
+    key: createPublicKey({
+      key: Buffer.concat([ED25519_SPKI_PREFIX, bytes.subarray(10)]),
+      format: 'der',
+      type: 'spki',
+    }),
+  };
+};
+
+const parseSignature = (encodedSignature) => {
+  const lines = decodeOuterBase64Text(encodedSignature, 'Updater signature').trim().split(/\r?\n/);
+  const primary = Buffer.from(lines[1] ?? '', 'base64');
+  const trustedCommentPrefix = 'trusted comment: ';
+  const trustedCommentLine = lines[2] ?? '';
+  const globalSignature = Buffer.from(lines[3] ?? '', 'base64');
+
+  if (
+    primary.length !== MINISIGN_SIGNATURE_LENGTH ||
+    primary.subarray(0, 2).toString('ascii') !== 'ED' ||
+    !trustedCommentLine.startsWith(trustedCommentPrefix) ||
+    globalSignature.length !== 64
+  ) {
+    throw new Error('Updater signature is not a supported prehashed Minisign signature.');
+  }
+
+  return {
+    keyId: primary.subarray(2, 10),
+    primary: primary.subarray(10),
+    trustedComment: trustedCommentLine.slice(trustedCommentPrefix.length),
+    global: globalSignature,
+  };
+};
+
+const verifyMinisign = ({ bytes, encodedSignature, publicKey }) => {
+  const signature = parseSignature(encodedSignature);
+
+  if (!signature.keyId.equals(publicKey.keyId)) {
+    throw new Error('Updater signature was created with a different key.');
+  }
+
+  const digest = createHash('blake2b512').update(bytes).digest();
+
+  if (!verifyEd25519(null, digest, publicKey.key, signature.primary)) {
+    throw new Error('Updater artifact signature verification failed.');
+  }
+
+  const globalPayload = Buffer.concat([
+    signature.primary,
+    Buffer.from(signature.trustedComment, 'utf8'),
+  ]);
+
+  if (!verifyEd25519(null, globalPayload, publicKey.key, signature.global)) {
+    throw new Error('Updater signature trusted-comment verification failed.');
+  }
+};
+
+const verifyInstallerFormat = (name, bytes) => {
+  const normalizedName = name.toLowerCase();
+
+  if (normalizedName.endsWith('.exe') && bytes.subarray(0, 2).equals(Buffer.from('MZ'))) {
+    return;
+  }
+
+  const msiMagic = Buffer.from('d0cf11e0a1b11ae1', 'hex');
+  if (normalizedName.endsWith('.msi') && bytes.subarray(0, msiMagic.length).equals(msiMagic)) {
+    return;
+  }
+
+  throw new Error(`Updater asset ${name} does not match its installer format.`);
+};
+
+const parseExpectedVersion = (expectedVersion) => {
+  const normalized = expectedVersion?.startsWith('v') ? expectedVersion.slice(1) : expectedVersion;
+
+  if (!/^\d+\.\d+\.\d+$/.test(normalized ?? '')) {
+    throw new Error(`Expected version must use X.Y.Z or vX.Y.Z format. Received: ${expectedVersion ?? '<unset>'}`);
+  }
+
+  return normalized;
+};
+
+const readManifest = async ({ expectedVersion, fetchImpl, manifestUrl }) => {
+  const response = await fetchOk(fetchImpl, manifestUrl, undefined, 'Updater manifest');
+  const manifest = await readJson(response, 'Updater manifest');
+
+  if (manifest.version !== expectedVersion) {
+    throw new RetryableUpdaterVerificationError(
+      `Updater manifest version ${manifest.version ?? '<missing>'} does not match ${expectedVersion}.`,
+    );
+  }
+
+  if (!manifest.platforms || typeof manifest.platforms !== 'object') {
+    throw new Error('Updater manifest does not contain a platforms object.');
+  }
+
+  return manifest;
+};
+
+const collectWindowsArtifacts = (platforms) => {
+  const artifacts = new Map();
+
+  for (const platform of REQUIRED_WINDOWS_PLATFORMS) {
+    if (!Object.hasOwn(platforms, platform)) {
+      throw new Error(`Updater manifest is missing required platform ${platform}.`);
+    }
+  }
+
+  for (const [platform, release] of Object.entries(platforms)) {
+    if (!platform.startsWith(WINDOWS_PLATFORM_PREFIX)) continue;
+    if (!release || typeof release.url !== 'string' || typeof release.signature !== 'string') {
+      throw new Error(`Updater manifest platform ${platform} is incomplete.`);
+    }
+
+    const existing = artifacts.get(release.url);
+    if (existing) {
+      if (existing.signature !== release.signature) {
+        throw new Error(`Updater manifest reuses ${release.url} with conflicting signatures.`);
+      }
+
+      existing.platforms.push(platform);
+      continue;
+    }
+
+    artifacts.set(release.url, {
+      platforms: [platform],
+      signature: release.signature,
+      url: release.url,
+    });
+  }
+
+  if (artifacts.size === 0) {
+    throw new Error('Updater manifest does not contain a Windows artifact.');
+  }
+
+  return [...artifacts.values()];
+};
+
+const verifyArtifact = async ({ artifact, fetchImpl, publicKey }) => {
+  const metadataResponse = await fetchOk(fetchImpl, artifact.url, undefined, 'Updater asset metadata');
+  const metadata = await readJson(metadataResponse, 'Updater asset metadata');
+
+  if (
+    metadata.state !== 'uploaded' ||
+    typeof metadata.name !== 'string' ||
+    !Number.isInteger(metadata.size) ||
+    typeof metadata.digest !== 'string' ||
+    !metadata.digest.startsWith('sha256:')
+  ) {
+    throw new Error(`Updater asset metadata for ${artifact.url} is incomplete.`);
+  }
+
+  const binaryResponse = await fetchOk(
+    fetchImpl,
+    artifact.url,
+    {
+      headers: {
+        Accept: 'application/octet-stream',
+        'User-Agent': UPDATER_USER_AGENT,
+      },
+    },
+    'Updater artifact',
+  );
+  const bytes = Buffer.from(await readBytes(binaryResponse, 'Updater artifact'));
+
+  if (bytes.length !== metadata.size) {
+    throw new Error(`Updater asset ${metadata.name} size mismatch: expected ${metadata.size}, received ${bytes.length}.`);
+  }
+
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  const expectedSha256 = metadata.digest.slice('sha256:'.length).toLowerCase();
+
+  if (sha256 !== expectedSha256) {
+    throw new Error(`Updater asset ${metadata.name} SHA-256 mismatch.`);
+  }
+
+  verifyInstallerFormat(metadata.name, bytes);
+  verifyMinisign({ bytes, encodedSignature: artifact.signature, publicKey });
+
+  return {
+    name: metadata.name,
+    platforms: artifact.platforms,
+    bytes: bytes.length,
+    sha256,
+  };
+};
+
+const verifyPublishedUpdaterOnce = async ({
+  expectedVersion,
+  manifestUrl,
+  publicKey: encodedPublicKey,
+  fetchImpl = globalThis.fetch,
+}) => {
+  const version = parseExpectedVersion(expectedVersion);
+  const manifest = await readManifest({ expectedVersion: version, fetchImpl, manifestUrl });
+  const publicKey = parsePublicKey(encodedPublicKey);
+  const artifacts = [];
+
+  for (const artifact of collectWindowsArtifacts(manifest.platforms)) {
+    artifacts.push(await verifyArtifact({ artifact, fetchImpl, publicKey }));
+  }
+
+  return { version, artifacts };
+};
+
+const wait = (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs));
+
+export const verifyPublishedUpdater = async ({
+  retryDelaysMs = DEFAULT_RETRY_DELAYS_MS,
+  ...options
+}) => {
+  let retryIndex = 0;
+
+  while (true) {
+    try {
+      return await verifyPublishedUpdaterOnce(options);
+    } catch (error) {
+      if (
+        !(error instanceof RetryableUpdaterVerificationError) ||
+        retryIndex >= retryDelaysMs.length
+      ) {
+        throw error;
+      }
+
+      const delayMs = retryDelaysMs[retryIndex];
+      retryIndex += 1;
+      if (delayMs > 0) await wait(delayMs);
+    }
+  }
+};
+
+const runCli = async () => {
+  const expectedVersion = process.argv[2] || process.env.GITHUB_REF_NAME;
+
+  if (!expectedVersion) {
+    throw new Error('Usage: node scripts/verify-published-updater.mjs <version-or-tag>');
+  }
+
+  const rootDir = process.cwd();
+  const config = JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'src-tauri', 'tauri.conf.json'), 'utf8'),
+  );
+  const manifestUrl = config.plugins?.updater?.endpoints?.[0];
+  const publicKey = config.plugins?.updater?.pubkey;
+
+  if (!manifestUrl || !publicKey) {
+    throw new Error('Tauri updater endpoint and public key must be configured.');
+  }
+
+  const result = await verifyPublishedUpdater({
+    expectedVersion,
+    manifestUrl,
+    publicKey,
+  });
+
+  const artifacts = result.artifacts
+    .map(({ name, bytes }) => `${name} (${bytes} bytes)`)
+    .join(', ');
+  console.log(`Published updater verification passed for ${result.version}: ${artifacts}`);
+};
+
+const isCli = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isCli) {
+  runCli().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-published-updater.mjs
+++ b/scripts/verify-published-updater.mjs
@@ -18,6 +18,7 @@ const REQUIRED_WINDOWS_PLATFORMS = [
 ];
 const DEFAULT_RETRY_DELAYS_MS = [1_000, 3_000, 6_000, 10_000];
 const MINISIGN_PUBLIC_KEY_LENGTH = 42;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 const MINISIGN_SIGNATURE_LENGTH = 74;
 const ED25519_SPKI_PREFIX = Buffer.from('302a300506032b6570032100', 'hex');
 
@@ -67,7 +68,8 @@ const readResponseBody = async (response, method, label) => {
   }
 };
 
-const readJson = (response, label) => readResponseBody(response, 'json', label);
+const readJson = async (response, label) =>
+  JSON.parse(await readResponseBody(response, 'text', label));
 const readBytes = (response, label) => readResponseBody(response, 'arrayBuffer', label);
 
 const decodeOuterBase64Text = (value, label) => {
@@ -84,6 +86,13 @@ const parsePublicKey = (encodedPublicKey) => {
 
   if (bytes.length !== MINISIGN_PUBLIC_KEY_LENGTH) {
     throw new Error('Updater public key is not a valid Minisign public key.');
+  }
+
+  const algorithm = bytes.subarray(0, 2).toString('ascii');
+  if (algorithm !== 'Ed' && algorithm !== 'ED') {
+    throw new Error(
+      `Updater public key uses unsupported Minisign algorithm marker ${algorithm}.`,
+    );
   }
 
   return {
@@ -161,7 +170,7 @@ const verifyInstallerFormat = (name, bytes) => {
 const parseExpectedVersion = (expectedVersion) => {
   const normalized = expectedVersion?.startsWith('v') ? expectedVersion.slice(1) : expectedVersion;
 
-  if (!/^\d+\.\d+\.\d+$/.test(normalized ?? '')) {
+  if (!VERSION_PATTERN.test(normalized ?? '')) {
     throw new Error(`Expected version must use X.Y.Z or vX.Y.Z format. Received: ${expectedVersion ?? '<unset>'}`);
   }
 
@@ -171,6 +180,10 @@ const parseExpectedVersion = (expectedVersion) => {
 const readManifest = async ({ expectedVersion, fetchImpl, manifestUrl }) => {
   const response = await fetchOk(fetchImpl, manifestUrl, undefined, 'Updater manifest');
   const manifest = await readJson(response, 'Updater manifest');
+
+  if (typeof manifest.version !== 'string' || !VERSION_PATTERN.test(manifest.version)) {
+    throw new Error('Updater manifest does not contain a valid version.');
+  }
 
   if (manifest.version !== expectedVersion) {
     throw new RetryableUpdaterVerificationError(
@@ -224,7 +237,40 @@ const collectWindowsArtifacts = (platforms) => {
   return [...artifacts.values()];
 };
 
-const verifyArtifact = async ({ artifact, fetchImpl, publicKey }) => {
+const getGitHubRepository = (manifestUrl) => {
+  const url = new URL(manifestUrl);
+  const [, owner, repository, releases] = url.pathname.split('/');
+
+  if (url.hostname !== 'github.com' || !owner || !repository || releases !== 'releases') {
+    throw new Error(`Updater manifest URL is not a GitHub release URL: ${manifestUrl}`);
+  }
+
+  return `${owner}/${repository}`;
+};
+
+const assertArtifactRepository = (artifactUrl, repository) => {
+  const url = new URL(artifactUrl);
+  const expectedPrefix = `/repos/${repository}/releases/assets/`;
+  const assetId = url.pathname.slice(expectedPrefix.length);
+
+  if (
+    url.protocol !== 'https:' ||
+    url.hostname !== 'api.github.com' ||
+    !url.pathname.startsWith(expectedPrefix) ||
+    !/^\d+$/.test(assetId)
+  ) {
+    throw new Error(
+      `Updater artifact ${artifactUrl} must belong to GitHub repository ${repository}.`,
+    );
+  }
+};
+
+const expectedWindowsAssetName = (platform, version) =>
+  platform === 'windows-x86_64-msi'
+    ? `Ambit_${version}_x64_en-US.msi`
+    : `Ambit_${version}_x64-setup.exe`;
+
+const verifyArtifact = async ({ artifact, expectedVersion, fetchImpl, publicKey }) => {
   const metadataResponse = await fetchOk(fetchImpl, artifact.url, undefined, 'Updater asset metadata');
   const metadata = await readJson(metadataResponse, 'Updater asset metadata');
 
@@ -236,6 +282,15 @@ const verifyArtifact = async ({ artifact, fetchImpl, publicKey }) => {
     !metadata.digest.startsWith('sha256:')
   ) {
     throw new Error(`Updater asset metadata for ${artifact.url} is incomplete.`);
+  }
+
+  for (const platform of artifact.platforms) {
+    const expectedName = expectedWindowsAssetName(platform, expectedVersion);
+    if (metadata.name !== expectedName) {
+      throw new Error(
+        `Updater manifest platform ${platform} must reference ${expectedName}, received ${metadata.name}.`,
+      );
+    }
   }
 
   const binaryResponse = await fetchOk(
@@ -283,9 +338,14 @@ const verifyPublishedUpdaterOnce = async ({
   const manifest = await readManifest({ expectedVersion: version, fetchImpl, manifestUrl });
   const publicKey = parsePublicKey(encodedPublicKey);
   const artifacts = [];
+  const repository = getGitHubRepository(manifestUrl);
+  const windowsArtifacts = collectWindowsArtifacts(manifest.platforms);
 
-  for (const artifact of collectWindowsArtifacts(manifest.platforms)) {
-    artifacts.push(await verifyArtifact({ artifact, fetchImpl, publicKey }));
+  for (const artifact of windowsArtifacts) {
+    assertArtifactRepository(artifact.url, repository);
+    artifacts.push(
+      await verifyArtifact({ artifact, expectedVersion: version, fetchImpl, publicKey }),
+    );
   }
 
   return { version, artifacts };

--- a/scripts/verify-published-updater.node-test.mjs
+++ b/scripts/verify-published-updater.node-test.mjs
@@ -1,0 +1,330 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import { verifyPublishedUpdater } from './verify-published-updater.mjs';
+
+const MANIFEST_URL = 'https://example.test/latest.json';
+const ASSET_URL = 'https://api.github.com/repos/example/ambit/releases/assets/42';
+const INSTALLER = Buffer.from('TVphbWJpdC10ZXN0LWluc3RhbGxlcg==', 'base64');
+const INSTALLER_SHA256 = 'a5ae64dfd453dc3e05a520145ade574aebd7f1ac167143b135e2a483c601beae';
+const PUBLIC_KEY = 'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXkgdGVzdApSV1FCQWdNRUJRWUhDQU9oQjcvenpoQytIWERkR09kTHdKbG41Tll3bTZVTlh4M2NobVFTVlRHNAo=';
+const SIGNATURE = 'dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRlc3Qga2V5ClJVUUJBZ01FQlFZSENIbk5tUmV5SEJHb3VXWEc3N2R5VGdMZ05BSlc4TlFlWmNnTjFhMUQyTFMzNjd2aXF5OG1IQ29BMmdJMlZ2LzJyd3NSVFFlZUI0V05UWmU3aUtGUEtRWT0KdHJ1c3RlZCBjb21tZW50OiB0aW1lc3RhbXA6MTc4NzkzMjgwMAlmaWxlOkFtYml0XzkuOS45X3g2NC1zZXR1cC5leGUKc1NjMVEzc241K0VCU1plbEJKL2xoMVVJZzVMWEY0OUhjYm5Lem9oUGxIRDRaeUZDUHF5NnZtYzFYVHZmTkZadktSdEJZa0k1U2hENXZueUhaTVlLQmc9PQo=';
+
+const manifest = {
+  version: '9.9.9',
+  platforms: {
+    'windows-x86_64': { signature: SIGNATURE, url: ASSET_URL },
+    'windows-x86_64-nsis': { signature: SIGNATURE, url: ASSET_URL },
+    'windows-x86_64-msi': { signature: SIGNATURE, url: ASSET_URL },
+  },
+};
+
+const asset = {
+  name: 'Ambit_9.9.9_x64-setup.exe',
+  state: 'uploaded',
+  size: INSTALLER.length,
+  digest: `sha256:${INSTALLER_SHA256}`,
+};
+
+const createFetch = ({
+  manifestValue = manifest,
+  assetValue = asset,
+  installer = INSTALLER,
+  binaryStatus = 200,
+} = {}) => {
+  const calls = [];
+
+  const fetchImpl = async (url, options = {}) => {
+    calls.push({ url: String(url), options });
+
+    if (url === MANIFEST_URL) {
+      return Response.json(manifestValue);
+    }
+
+    if (url === ASSET_URL && options.headers?.Accept === 'application/octet-stream') {
+      return new Response(binaryStatus === 200 ? installer : 'Request failed', {
+        status: binaryStatus,
+        statusText: binaryStatus === 200 ? 'OK' : 'Forbidden',
+      });
+    }
+
+    if (url === ASSET_URL) {
+      return Response.json(assetValue);
+    }
+
+    return new Response('Not found', { status: 404 });
+  };
+
+  return { calls, fetchImpl };
+};
+
+test('verifies a publicly downloadable signed Windows updater artifact', async () => {
+  const { calls, fetchImpl } = createFetch();
+
+  const result = await verifyPublishedUpdater({
+    expectedVersion: 'v9.9.9',
+    manifestUrl: MANIFEST_URL,
+    publicKey: PUBLIC_KEY,
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, {
+    version: '9.9.9',
+    artifacts: [
+      {
+        name: 'Ambit_9.9.9_x64-setup.exe',
+        platforms: [
+          'windows-x86_64',
+          'windows-x86_64-nsis',
+          'windows-x86_64-msi',
+        ],
+        bytes: INSTALLER.length,
+        sha256: INSTALLER_SHA256,
+      },
+    ],
+  });
+
+  const binaryRequest = calls.find(({ options }) => options.headers?.Accept === 'application/octet-stream');
+  assert.equal(binaryRequest?.options.headers['User-Agent'], 'tauri-plugin-updater/2.10.1');
+});
+test('rejects a manifest for a different release version', async () => {
+  const { fetchImpl } = createFetch({
+    manifestValue: { ...manifest, version: '9.9.8' },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: 'v9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+      retryDelaysMs: [],
+    }),
+    /manifest version 9\.9\.8 does not match 9\.9\.9/,
+  );
+});
+
+test('rejects an updater artifact that is not publicly downloadable', async () => {
+  const { fetchImpl } = createFetch({ binaryStatus: 403 });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /Updater artifact request failed with status 403 Forbidden/,
+  );
+});
+
+test('rejects an updater artifact whose GitHub digest does not match', async () => {
+  const { fetchImpl } = createFetch({
+    assetValue: { ...asset, digest: `sha256:${'0'.repeat(64)}` },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /SHA-256 mismatch/,
+  );
+});
+
+test('rejects an updater artifact whose bytes do not match its installer format', async () => {
+  const malformedInstaller = Buffer.from('bm90LWFuLWluc3RhbGxlcg==', 'base64');
+  const { fetchImpl } = createFetch({
+    installer: malformedInstaller,
+    assetValue: {
+      ...asset,
+      size: malformedInstaller.length,
+      digest: 'sha256:a868128f565df09533eab3fa8194612f5bcd334f5b72469cdcc4b5f75e2fb301',
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /does not match its installer format/,
+  );
+});
+
+test('rejects an updater artifact whose signature does not match its bytes', async () => {
+  const corruptedInstaller = Buffer.from('TVphbWJpdC10ZXN0LWluc3RhbGxlUg==', 'base64');
+  const { fetchImpl } = createFetch({
+    installer: corruptedInstaller,
+    assetValue: {
+      ...asset,
+      size: corruptedInstaller.length,
+      digest: 'sha256:619ae686e825094e3e237f70647a071884d312ecec030aab15fbca1034dd32c4',
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /artifact signature verification failed/,
+  );
+});
+
+test('CLI rejects a missing expected release version before making requests', () => {
+  const result = spawnSync(process.execPath, ['scripts/verify-published-updater.mjs'], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_REF_NAME: '' },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(
+    result.stderr,
+    /Usage: node scripts\/verify-published-updater\.mjs <version-or-tag>/,
+  );
+});
+test('rejects one asset URL reused with conflicting signatures', async () => {
+  const { fetchImpl } = createFetch({
+    manifestValue: {
+      ...manifest,
+      platforms: {
+        ...manifest.platforms,
+        'windows-x86_64-nsis': { signature: 'conflicting-signature', url: ASSET_URL },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /conflicting signatures/,
+  );
+});
+
+test('rejects a manifest missing a required Windows updater platform', async () => {
+  const { ['windows-x86_64-msi']: _missing, ...platforms } = manifest.platforms;
+  const { fetchImpl } = createFetch({
+    manifestValue: { ...manifest, platforms },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /missing required platform windows-x86_64-msi/,
+  );
+});
+
+for (const missingPlatform of ['windows-x86_64', 'windows-x86_64-nsis']) {
+  test(`rejects a manifest missing required platform ${missingPlatform}`, async () => {
+    const platforms = Object.fromEntries(
+      Object.entries(manifest.platforms).filter(([platform]) => platform !== missingPlatform),
+    );
+    const { fetchImpl } = createFetch({
+      manifestValue: { ...manifest, platforms },
+    });
+
+    await assert.rejects(
+      verifyPublishedUpdater({
+        expectedVersion: '9.9.9',
+        manifestUrl: MANIFEST_URL,
+        publicKey: PUBLIC_KEY,
+        fetchImpl,
+      }),
+      new RegExp(`missing required platform ${missingPlatform}`),
+    );
+  });
+}
+
+test('retries the complete verification after a transient manifest failure', async () => {
+  const { fetchImpl: successfulFetch } = createFetch();
+  let manifestAttempts = 0;
+
+  const fetchImpl = async (url, options) => {
+    if (url === MANIFEST_URL && manifestAttempts++ === 0) {
+      return new Response('Try again', { status: 503, statusText: 'Service Unavailable' });
+    }
+
+    return successfulFetch(url, options);
+  };
+
+  const result = await verifyPublishedUpdater({
+    expectedVersion: '9.9.9',
+    manifestUrl: MANIFEST_URL,
+    publicKey: PUBLIC_KEY,
+    fetchImpl,
+    retryDelaysMs: [0],
+  });
+
+  assert.equal(result.version, '9.9.9');
+  assert.equal(manifestAttempts, 2);
+});
+
+test('retries the complete verification while the public manifest is stale', async () => {
+  const { fetchImpl: successfulFetch } = createFetch();
+  let manifestAttempts = 0;
+
+  const fetchImpl = async (url, options) => {
+    if (url === MANIFEST_URL && manifestAttempts++ === 0) {
+      return Response.json({ ...manifest, version: '9.9.8' });
+    }
+
+    return successfulFetch(url, options);
+  };
+
+  const result = await verifyPublishedUpdater({
+    expectedVersion: '9.9.9',
+    manifestUrl: MANIFEST_URL,
+    publicKey: PUBLIC_KEY,
+    fetchImpl,
+    retryDelaysMs: [0],
+  });
+
+  assert.equal(result.version, '9.9.9');
+  assert.equal(manifestAttempts, 2);
+});
+
+test('retries the complete verification after a response-body network failure', async () => {
+  const { fetchImpl: successfulFetch } = createFetch();
+  let manifestAttempts = 0;
+
+  const fetchImpl = async (url, options) => {
+    if (url === MANIFEST_URL && manifestAttempts++ === 0) {
+      return {
+        ok: true,
+        json: async () => {
+          throw new TypeError('terminated');
+        },
+      };
+    }
+
+    return successfulFetch(url, options);
+  };
+
+  const result = await verifyPublishedUpdater({
+    expectedVersion: '9.9.9',
+    manifestUrl: MANIFEST_URL,
+    publicKey: PUBLIC_KEY,
+    fetchImpl,
+    retryDelaysMs: [0],
+  });
+
+  assert.equal(result.version, '9.9.9');
+  assert.equal(manifestAttempts, 2);
+});

--- a/scripts/verify-published-updater.node-test.mjs
+++ b/scripts/verify-published-updater.node-test.mjs
@@ -4,33 +4,47 @@ import test from 'node:test';
 
 import { verifyPublishedUpdater } from './verify-published-updater.mjs';
 
-const MANIFEST_URL = 'https://example.test/latest.json';
-const ASSET_URL = 'https://api.github.com/repos/example/ambit/releases/assets/42';
-const INSTALLER = Buffer.from('TVphbWJpdC10ZXN0LWluc3RhbGxlcg==', 'base64');
-const INSTALLER_SHA256 = 'a5ae64dfd453dc3e05a520145ade574aebd7f1ac167143b135e2a483c601beae';
+const MANIFEST_URL = 'https://github.com/example/ambit/releases/latest/download/latest.json';
+const NSIS_ASSET_URL = 'https://api.github.com/repos/example/ambit/releases/assets/42';
+const MSI_ASSET_URL = 'https://api.github.com/repos/example/ambit/releases/assets/43';
+const NSIS_INSTALLER = Buffer.from('TVphbWJpdC10ZXN0LWluc3RhbGxlcg==', 'base64');
+const FOREIGN_ASSET_URL = 'https://api.github.com/repos/other/ambit/releases/assets/44';
+const MSI_INSTALLER = Buffer.from('0M8R4KGxGuFhbWJpdC10ZXN0LW1zaQ==', 'base64');
+const NSIS_SHA256 = 'a5ae64dfd453dc3e05a520145ade574aebd7f1ac167143b135e2a483c601beae';
+const MSI_SHA256 = '206d9011b92c2961d4fe09f153f392d56984504e33218869e6e1db8da782c36b';
 const PUBLIC_KEY = 'dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXkgdGVzdApSV1FCQWdNRUJRWUhDQU9oQjcvenpoQytIWERkR09kTHdKbG41Tll3bTZVTlh4M2NobVFTVlRHNAo=';
-const SIGNATURE = 'dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRlc3Qga2V5ClJVUUJBZ01FQlFZSENIbk5tUmV5SEJHb3VXWEc3N2R5VGdMZ05BSlc4TlFlWmNnTjFhMUQyTFMzNjd2aXF5OG1IQ29BMmdJMlZ2LzJyd3NSVFFlZUI0V05UWmU3aUtGUEtRWT0KdHJ1c3RlZCBjb21tZW50OiB0aW1lc3RhbXA6MTc4NzkzMjgwMAlmaWxlOkFtYml0XzkuOS45X3g2NC1zZXR1cC5leGUKc1NjMVEzc241K0VCU1plbEJKL2xoMVVJZzVMWEY0OUhjYm5Lem9oUGxIRDRaeUZDUHF5NnZtYzFYVHZmTkZadktSdEJZa0k1U2hENXZueUhaTVlLQmc9PQo=';
+const NSIS_SIGNATURE = 'dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRlc3Qga2V5ClJVUUJBZ01FQlFZSENIbk5tUmV5SEJHb3VXWEc3N2R5VGdMZ05BSlc4TlFlWmNnTjFhMUQyTFMzNjd2aXF5OG1IQ29BMmdJMlZ2LzJyd3NSVFFlZUI0V05UWmU3aUtGUEtRWT0KdHJ1c3RlZCBjb21tZW50OiB0aW1lc3RhbXA6MTc4NzkzMjgwMAlmaWxlOkFtYml0XzkuOS45X3g2NC1zZXR1cC5leGUKc1NjMVEzc241K0VCU1plbEJKL2xoMVVJZzVMWEY0OUhjYm5Lem9oUGxIRDRaeUZDUHF5NnZtYzFYVHZmTkZadktSdEJZa0k1U2hENXZueUhaTVlLQmc9PQo=';
+const MSI_SIGNATURE = 'dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRlc3Qga2V5ClJVUUJBZ01FQlFZSENFeG1Fa0V5SzNJODJXZnRwaTd0WjdYbUlXMC9yZzh4bitaUVpoRG16MW1wR3gwS2dnb3dpRmpvZTc2RElSM2RkZG4xemJ5RGxCcW15anpSMDc4WmNnRT0KdHJ1c3RlZCBjb21tZW50OiB0aW1lc3RhbXA6MTc4NzkzMjgwMAlmaWxlOkFtYml0XzkuOS45X3g2NF9lbi1VUy5tc2kKYTFra1hSRnpVU2FtdnRjVzE0NkFHUjZzU1FKeGlacnhYUm9tbzNZQ28wTkc4SC9oQXE1c0Z5TklKRG9WNUhadnNrNkZ6N0tHL3hzdDMrN2RCaW12QXc9PQo=';
 
 const manifest = {
   version: '9.9.9',
   platforms: {
-    'windows-x86_64': { signature: SIGNATURE, url: ASSET_URL },
-    'windows-x86_64-nsis': { signature: SIGNATURE, url: ASSET_URL },
-    'windows-x86_64-msi': { signature: SIGNATURE, url: ASSET_URL },
+    'windows-x86_64': { signature: NSIS_SIGNATURE, url: NSIS_ASSET_URL },
+    'windows-x86_64-nsis': { signature: NSIS_SIGNATURE, url: NSIS_ASSET_URL },
+    'windows-x86_64-msi': { signature: MSI_SIGNATURE, url: MSI_ASSET_URL },
   },
 };
 
-const asset = {
+const nsisAsset = {
   name: 'Ambit_9.9.9_x64-setup.exe',
   state: 'uploaded',
-  size: INSTALLER.length,
-  digest: `sha256:${INSTALLER_SHA256}`,
+  size: NSIS_INSTALLER.length,
+  digest: `sha256:${NSIS_SHA256}`,
+};
+
+const msiAsset = {
+  name: 'Ambit_9.9.9_x64_en-US.msi',
+  state: 'uploaded',
+  size: MSI_INSTALLER.length,
+  digest: `sha256:${MSI_SHA256}`,
 };
 
 const createFetch = ({
   manifestValue = manifest,
-  assetValue = asset,
-  installer = INSTALLER,
+  assetValue = nsisAsset,
+  installer = NSIS_INSTALLER,
+  msiAssetValue = msiAsset,
+  msiInstaller = MSI_INSTALLER,
   binaryStatus = 200,
 } = {}) => {
   const calls = [];
@@ -42,15 +56,23 @@ const createFetch = ({
       return Response.json(manifestValue);
     }
 
-    if (url === ASSET_URL && options.headers?.Accept === 'application/octet-stream') {
-      return new Response(binaryStatus === 200 ? installer : 'Request failed', {
+    if (
+      (url === NSIS_ASSET_URL || url === MSI_ASSET_URL) &&
+      options.headers?.Accept === 'application/octet-stream'
+    ) {
+      const bytes = url === NSIS_ASSET_URL ? installer : msiInstaller;
+      return new Response(binaryStatus === 200 ? bytes : 'Request failed', {
         status: binaryStatus,
         statusText: binaryStatus === 200 ? 'OK' : 'Forbidden',
       });
     }
 
-    if (url === ASSET_URL) {
+    if (url === NSIS_ASSET_URL) {
       return Response.json(assetValue);
+    }
+
+    if (url === MSI_ASSET_URL) {
+      return Response.json(msiAssetValue);
     }
 
     return new Response('Not found', { status: 404 });
@@ -74,19 +96,26 @@ test('verifies a publicly downloadable signed Windows updater artifact', async (
     artifacts: [
       {
         name: 'Ambit_9.9.9_x64-setup.exe',
-        platforms: [
-          'windows-x86_64',
-          'windows-x86_64-nsis',
-          'windows-x86_64-msi',
-        ],
-        bytes: INSTALLER.length,
-        sha256: INSTALLER_SHA256,
+        platforms: ['windows-x86_64', 'windows-x86_64-nsis'],
+        bytes: NSIS_INSTALLER.length,
+        sha256: NSIS_SHA256,
+      },
+      {
+        name: 'Ambit_9.9.9_x64_en-US.msi',
+        platforms: ['windows-x86_64-msi'],
+        bytes: MSI_INSTALLER.length,
+        sha256: MSI_SHA256,
       },
     ],
   });
 
-  const binaryRequest = calls.find(({ options }) => options.headers?.Accept === 'application/octet-stream');
-  assert.equal(binaryRequest?.options.headers['User-Agent'], 'tauri-plugin-updater/2.10.1');
+  const binaryRequests = calls.filter(
+    ({ options }) => options.headers?.Accept === 'application/octet-stream',
+  );
+  assert.equal(binaryRequests.length, 2);
+  assert.ok(binaryRequests.every(
+    ({ options }) => options.headers['User-Agent'] === 'tauri-plugin-updater/2.10.1',
+  ));
 });
 test('rejects a manifest for a different release version', async () => {
   const { fetchImpl } = createFetch({
@@ -121,7 +150,7 @@ test('rejects an updater artifact that is not publicly downloadable', async () =
 
 test('rejects an updater artifact whose GitHub digest does not match', async () => {
   const { fetchImpl } = createFetch({
-    assetValue: { ...asset, digest: `sha256:${'0'.repeat(64)}` },
+    assetValue: { ...nsisAsset, digest: `sha256:${'0'.repeat(64)}` },
   });
 
   await assert.rejects(
@@ -140,7 +169,7 @@ test('rejects an updater artifact whose bytes do not match its installer format'
   const { fetchImpl } = createFetch({
     installer: malformedInstaller,
     assetValue: {
-      ...asset,
+      ...nsisAsset,
       size: malformedInstaller.length,
       digest: 'sha256:a868128f565df09533eab3fa8194612f5bcd334f5b72469cdcc4b5f75e2fb301',
     },
@@ -162,7 +191,7 @@ test('rejects an updater artifact whose signature does not match its bytes', asy
   const { fetchImpl } = createFetch({
     installer: corruptedInstaller,
     assetValue: {
-      ...asset,
+      ...nsisAsset,
       size: corruptedInstaller.length,
       digest: 'sha256:619ae686e825094e3e237f70647a071884d312ecec030aab15fbca1034dd32c4',
     },
@@ -176,6 +205,79 @@ test('rejects an updater artifact whose signature does not match its bytes', asy
       fetchImpl,
     }),
     /artifact signature verification failed/,
+  );
+});
+
+test('rejects an unsupported Minisign public-key algorithm marker', async () => {
+  const publicKeyLines = Buffer.from(PUBLIC_KEY, 'base64').toString('utf8').split('\n');
+  const publicKeyPacket = Buffer.from(publicKeyLines[1], 'base64');
+  publicKeyPacket.write('XX', 0, 'ascii');
+  publicKeyLines[1] = publicKeyPacket.toString('base64');
+  const invalidPublicKey = Buffer.from(publicKeyLines.join('\n'), 'utf8').toString('base64');
+  const { fetchImpl } = createFetch();
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: invalidPublicKey,
+      fetchImpl,
+    }),
+    /unsupported Minisign algorithm marker XX/,
+  );
+});
+
+test('rejects a Minisign signature created with a different key ID', async () => {
+  const signatureLines = Buffer.from(NSIS_SIGNATURE, 'base64').toString('utf8').split('\n');
+  const primaryPacket = Buffer.from(signatureLines[1], 'base64');
+  primaryPacket[2] ^= 0xff;
+  signatureLines[1] = primaryPacket.toString('base64');
+  const wrongKeySignature = Buffer.from(signatureLines.join('\n'), 'utf8').toString('base64');
+  const { fetchImpl } = createFetch({
+    manifestValue: {
+      ...manifest,
+      platforms: {
+        ...manifest.platforms,
+        'windows-x86_64': { signature: wrongKeySignature, url: NSIS_ASSET_URL },
+        'windows-x86_64-nsis': { signature: wrongKeySignature, url: NSIS_ASSET_URL },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /signature was created with a different key/,
+  );
+});
+
+test('rejects a tampered Minisign trusted comment', async () => {
+  const signatureLines = Buffer.from(NSIS_SIGNATURE, 'base64').toString('utf8').split('\n');
+  signatureLines[2] += '-tampered';
+  const tamperedSignature = Buffer.from(signatureLines.join('\n'), 'utf8').toString('base64');
+  const { fetchImpl } = createFetch({
+    manifestValue: {
+      ...manifest,
+      platforms: {
+        ...manifest.platforms,
+        'windows-x86_64': { signature: tamperedSignature, url: NSIS_ASSET_URL },
+        'windows-x86_64-nsis': { signature: tamperedSignature, url: NSIS_ASSET_URL },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /trusted-comment verification failed/,
   );
 });
 
@@ -198,7 +300,7 @@ test('rejects one asset URL reused with conflicting signatures', async () => {
       ...manifest,
       platforms: {
         ...manifest.platforms,
-        'windows-x86_64-nsis': { signature: 'conflicting-signature', url: ASSET_URL },
+        'windows-x86_64-nsis': { signature: 'conflicting-signature', url: NSIS_ASSET_URL },
       },
     },
   });
@@ -211,6 +313,72 @@ test('rejects one asset URL reused with conflicting signatures', async () => {
       fetchImpl,
     }),
     /conflicting signatures/,
+  );
+});
+
+test('rejects an MSI platform that reuses the signed NSIS artifact', async () => {
+  const { fetchImpl } = createFetch({
+    manifestValue: {
+      ...manifest,
+      platforms: {
+        ...manifest.platforms,
+        'windows-x86_64-msi': {
+          signature: NSIS_SIGNATURE,
+          url: NSIS_ASSET_URL,
+        },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /windows-x86_64-msi must reference Ambit_9\.9\.9_x64_en-US\.msi/,
+  );
+});
+
+test('rejects a signed installer from a different release version', async () => {
+  const { fetchImpl } = createFetch({
+    assetValue: {
+      ...nsisAsset,
+      name: 'Ambit_9.9.8_x64-setup.exe',
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /windows-x86_64 must reference Ambit_9\.9\.9_x64-setup\.exe/,
+  );
+});
+
+test('rejects an updater artifact from a different GitHub repository', async () => {
+  const { fetchImpl } = createFetch({
+    manifestValue: {
+      ...manifest,
+      platforms: {
+        ...manifest.platforms,
+        'windows-x86_64-msi': { signature: MSI_SIGNATURE, url: FOREIGN_ASSET_URL },
+      },
+    },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+    }),
+    /must belong to GitHub repository example\/ambit/,
   );
 });
 
@@ -300,6 +468,51 @@ test('retries the complete verification while the public manifest is stale', asy
   assert.equal(manifestAttempts, 2);
 });
 
+test('does not retry malformed manifest JSON', async () => {
+  let manifestAttempts = 0;
+  const fetchImpl = async () => {
+    manifestAttempts += 1;
+    return new Response('{not-json', {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+      retryDelaysMs: [0, 0],
+    }),
+    { name: 'SyntaxError' },
+  );
+
+  assert.equal(manifestAttempts, 1);
+});
+
+test('does not retry a manifest without a valid version', async () => {
+  const { calls, fetchImpl } = createFetch({
+    manifestValue: { platforms: manifest.platforms },
+  });
+
+  await assert.rejects(
+    verifyPublishedUpdater({
+      expectedVersion: '9.9.9',
+      manifestUrl: MANIFEST_URL,
+      publicKey: PUBLIC_KEY,
+      fetchImpl,
+      retryDelaysMs: [0, 0],
+    }),
+    /manifest does not contain a valid version/,
+  );
+
+  assert.equal(
+    calls.filter(({ url }) => url === MANIFEST_URL).length,
+    1,
+  );
+});
+
 test('retries the complete verification after a response-body network failure', async () => {
   const { fetchImpl: successfulFetch } = createFetch();
   let manifestAttempts = 0;
@@ -308,7 +521,7 @@ test('retries the complete verification after a response-body network failure', 
     if (url === MANIFEST_URL && manifestAttempts++ === 0) {
       return {
         ok: true,
-        json: async () => {
+        text: async () => {
           throw new TypeError('terminated');
         },
       };

--- a/src/hooks/__tests__/useAppUpdater.test.tsx
+++ b/src/hooks/__tests__/useAppUpdater.test.tsx
@@ -139,7 +139,7 @@ describe('useAppUpdater', () => {
 
     it('preserves raw install errors when package download or installation fails', async () => {
         const mockUpdate = createMockUpdate();
-        vi.mocked(mockUpdate.downloadAndInstall).mockRejectedValue(new Error('404 Not Found'));
+        vi.mocked(mockUpdate.downloadAndInstall).mockRejectedValue('Download request timed out');
         vi.mocked(check).mockResolvedValue(mockUpdate);
 
         const { result } = renderHook(() => useAppUpdater({
@@ -158,8 +158,8 @@ describe('useAppUpdater', () => {
         });
 
         expect(result.current.status).toBe('error');
-        expect(result.current.errorMessage).toBe('404 Not Found');
-        expect(mockAddToast).toHaveBeenCalledWith('Failed to install update: 404 Not Found', 'error');
+        expect(result.current.errorMessage).toBe('Download request timed out');
+        expect(mockAddToast).toHaveBeenCalledWith('Failed to install update: Download request timed out', 'error');
     });
 
     it('disables checks in development builds and only explains manual attempts', async () => {
@@ -222,8 +222,37 @@ describe('useAppUpdater', () => {
         }
     );
 
-    it('uses a generic message for non-Error check failures', async () => {
-        vi.mocked(check).mockRejectedValueOnce('opaque failure');
+    it('preserves serialized Tauri check failures', async () => {
+        vi.mocked(check).mockRejectedValueOnce('Network request timed out');
+        const { result } = renderHook(() => useAppUpdater({
+            addToast: mockAddToast,
+            autoCheckEnabled: false,
+            isSettingsLoaded: true,
+            isDevBuild: false,
+        }));
+
+        await act(async () => result.current.checkForUpdates({ manual: true }));
+
+        expect(result.current.errorMessage).toBe('Network request timed out');
+    });
+
+    it('preserves message-bearing updater failures', async () => {
+        vi.mocked(check).mockRejectedValueOnce({ message: 'Proxy authentication required' });
+        const { result } = renderHook(() => useAppUpdater({
+            addToast: mockAddToast,
+            autoCheckEnabled: false,
+            isSettingsLoaded: true,
+            isDevBuild: false,
+        }));
+
+        await act(async () => result.current.checkForUpdates({ manual: true }));
+
+        expect(result.current.errorMessage).toBe('Proxy authentication required');
+    });
+
+
+    it('uses a generic message for opaque updater failures', async () => {
+        vi.mocked(check).mockRejectedValueOnce({ code: 'opaque' });
         const { result } = renderHook(() => useAppUpdater({
             addToast: mockAddToast,
             autoCheckEnabled: false,
@@ -235,7 +264,6 @@ describe('useAppUpdater', () => {
 
         expect(result.current.errorMessage).toBe('Unexpected updater error');
     });
-
     it('does nothing when installation is requested without an update', async () => {
         const { result } = renderHook(() => useAppUpdater({
             addToast: mockAddToast,

--- a/src/hooks/useAppUpdater.ts
+++ b/src/hooks/useAppUpdater.ts
@@ -31,8 +31,17 @@ const isLikelyReleaseFeedAccessError = (message: string) => {
   );
 };
 
-const getRawUpdaterErrorMessage = (error: unknown) =>
-  error instanceof Error ? error.message : 'Unexpected updater error';
+const getRawUpdaterErrorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const { message } = error;
+    if (typeof message === 'string' && message.trim()) return message;
+  }
+
+  if (typeof error === 'string' && error.trim()) return error;
+
+  return 'Unexpected updater error';
+};
 
 const getCheckForUpdatesErrorMessage = (error: unknown) => {
   const rawMessage = getRawUpdaterErrorMessage(error);


### PR DESCRIPTION
## Summary

- preserve the original updater error and report the failing update phase
- verify published Windows updater artifacts, hashes, formats, and Minisign signatures
- require exact versioned NSIS and MSI assets from the release repository
- retry only transient transport failures or a valid stale manifest

## Verification

- focused updater verifier tests: 22 passed
- release automation tests: 41 passed
- live verification of the published v0.12.0 NSIS and MSI assets
- full pnpm run verify:release gate passed
- independent standards review: clean