### PR TITLE
fix(release): forward updater verification tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,4 +121,4 @@ jobs:
           args: --bundles nsis msi
 
       - name: verify published updater release
-        run: pnpm run verify:published-updater -- ${{ github.ref_name }}
+        run: pnpm run verify:published-updater ${{ github.ref_name }}

--- a/docs/WORKFLOW_SETUP.md
+++ b/docs/WORKFLOW_SETUP.md
@@ -116,11 +116,11 @@ Use **Actions > updater-signing-preflight > Run workflow** before publishing. Th
 7. Confirm the generated `vX.Y.Z` tag starts `release.yml`.
 
 The release workflow currently publishes Windows NSIS and MSI artifacts, updater signatures, and `latest.json`. It copies the matching version section from `CHANGELOG.md` into the updater metadata so installed apps can show the same release notes. When `CURRENT_PARSER_VERSION` increases from the previous stable release, the extraction step prepends a metadata-refresh notice to the published GitHub and updater notes without modifying `CHANGELOG.md`. Release tags must use the exact `vX.Y.Z` format, match `package.json`, both Tauri configuration files, `src-tauri/Cargo.toml`, the local `app` package in `src-tauri/Cargo.lock`, and `.github/.release-please-manifest.json`, and point to a commit reachable from `main`.
-After publishing, `release.yml` runs `pnpm run verify:published-updater -- <tag>` without GitHub authentication. The check downloads every unique Windows artifact referenced by `latest.json` using Tauri's updater headers, matches its size and SHA-256 digest to GitHub's public asset metadata, validates the installer format, and verifies its Minisign signature against the public key embedded in `tauri.conf.json`. A failure blocks the release workflow even if artifact upload succeeded.
+After publishing, `release.yml` runs `pnpm run verify:published-updater <tag>` without GitHub authentication. The check downloads every unique Windows artifact referenced by `latest.json` using Tauri's updater headers, matches its size and SHA-256 digest to GitHub's public asset metadata, validates the installer format, and verifies its Minisign signature against the public key embedded in `tauri.conf.json`. A failure blocks the release workflow even if artifact upload succeeded.
 
 
 Release Please remains the normal and preferred tag creator. Do not create manual release tags except for recovery work after confirming the tag target is already on `main` and all version files match.
-For updater incident triage, run the same command locally with the affected tag, for example `pnpm run verify:published-updater -- v0.12.0`. A passing result proves the public feed and signed artifacts are currently valid; it does not rule out a transient client network, proxy, or security-software failure.
+For updater incident triage, run the same command locally with the affected tag, for example `pnpm run verify:published-updater v0.12.0`. A passing result proves the public feed and signed artifacts are currently valid; it does not rule out a transient client network, proxy, or security-software failure.
 
 
 ## Experimental Unix Builds

--- a/scripts/verify-published-updater.node-test.mjs
+++ b/scripts/verify-published-updater.node-test.mjs
@@ -1,8 +1,21 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { verifyPublishedUpdater } from './verify-published-updater.mjs';
+
+test('release workflow forwards the tag directly to the published updater verifier', () => {
+  const workflow = readFileSync(
+    new URL('../.github/workflows/release.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(
+    workflow,
+    /run: pnpm run verify:published-updater \$\{\{ github\.ref_name \}\}/,
+  );
+});
 
 const MANIFEST_URL = 'https://github.com/example/ambit/releases/latest/download/latest.json';
 const NSIS_ASSET_URL = 'https://api.github.com/repos/example/ambit/releases/assets/42';


### PR DESCRIPTION
## Summary

- remove the pnpm argument separator that CI forwarded as the verifier version
- add regression coverage for the release workflow command contract
- update release and incident-triage documentation to use the corrected command

## Root cause

The v0.12.1 release uploaded and signed all artifacts successfully, but the final verification command forwarded a literal double-dash to the Node script. The verifier received that token instead of v0.12.1 and marked the deployment failed.

## Verification

- regression test demonstrated red before the fix and green after it
- 42 release-automation Node tests passed
- corrected command verified the live v0.12.1 NSIS and MSI artifacts
- full release gate passed: 3316 frontend tests, 852 Rust tests plus 18 support-tool tests, and Tauri compatibility build
- independent standards review: clean
- independent specification review: clean