### PR TITLE
fix: reduce Removed listing memory while preserving privacy

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,7 @@ Related docs: `README.md#privacy-and-network-behavior`, `SECURITY.md`
 - API keys are stored via Rust keyring commands, not persisted in `library.json`.
 - Passive visual assets must be bundled locally. Network calls should be limited to the documented updater, Gemini, CivitAI, and user-clicked external-link paths.
 - Large library browsing paths must remain virtualized and performance-conscious.
+- Removed listings exclude archival JSON blobs from IPC. SQLite extracts the positive prompt needed for privacy masking with the same sparse-metadata fallback as full row mapping; full ID lookups retain archival metadata for lifecycle and InvokeAI consumers. Maintenance hydrates only the currently opened Removed viewer item, with no retained detail cache after closing or navigating away.
 - Gallery and timeline results for videos render static posters or a generic placeholder; they must not instantiate background video players.
 - The bundled MediaInfo sidecar is invoked only by Rust-owned fixed arguments against canonical picker-scoped regular files, with bounded output, timeout, cancellation, and single-process concurrency.
 - Gallery and Maintenance should reuse the shared `ImageViewer` presentation instead of developing separate viewer implementations. Their navigation, deletion, recovery, and other context-dependent policies remain owned by their respective controllers.

--- a/src/features/maintenance/components/MaintenanceView.test.tsx
+++ b/src/features/maintenance/components/MaintenanceView.test.tsx
@@ -31,6 +31,7 @@ const maintenanceDataMock = vi.hoisted(() => ({
 
 const imageRepoMock = vi.hoisted(() => ({
     getImagesByIds: vi.fn().mockResolvedValue([]),
+    getRemovedImagesByIds: vi.fn().mockResolvedValue([]),
     toggleImageIntermediate: vi.fn().mockResolvedValue(undefined)
 }));
 
@@ -293,7 +294,7 @@ vi.mock('../../../features/viewer/components/ImageViewer', () => ({
         onUpdatePrompt?: (id: string, prompt: string) => void;
         isShortcutBlocked?: boolean;
     }) => (
-        <div data-testid="maintenance-viewer" data-image-id={image.id} data-prompt={image.metadata.positivePrompt} data-editable={String(Boolean(onUpdatePrompt))} data-shortcuts-blocked={String(isShortcutBlocked)}>
+        <div data-testid="maintenance-viewer" data-image-id={image.id} data-prompt={image.metadata.positivePrompt} data-metadata={JSON.stringify(image.metadata)} data-original-chunks={JSON.stringify(image.originalChunks)} data-editable={String(Boolean(onUpdatePrompt))} data-shortcuts-blocked={String(isShortcutBlocked)}>
             {onDelete && <button onClick={onDelete}>Viewer Cleanup</button>}
             <button onClick={onNext}>Viewer Next</button>
             <button onClick={onPrev}>Viewer Previous</button>
@@ -320,7 +321,7 @@ vi.mock('../../../features/viewer/components/VideoViewer', () => ({
         onUpdateNotes?: (id: string, notes: string) => void;
         onSetCollectionMembership?: (imageId: string, collectionId: string, shouldBelong: boolean) => Promise<boolean>;
     }) => (
-        <div data-testid="maintenance-video-viewer" data-video-id={video.id} data-editable={String(Boolean(onUpdateNotes))}>
+        <div data-testid="maintenance-video-viewer" data-video-id={video.id} data-metadata={JSON.stringify(video.metadata)} data-original-chunks={JSON.stringify(video.originalChunks)} data-editable={String(Boolean(onUpdateNotes))}>
             {onDelete && <button onClick={() => onDelete(video.id)}>Video Cleanup</button>}
             <button onClick={onClose}>Close Video Viewer</button>
             {onToggleFavorite && <button onClick={() => onToggleFavorite(video.id)}>Favorite Video Viewer</button>}
@@ -350,6 +351,7 @@ vi.mock('../../../features/viewer/components/CompareModal', () => ({
 
 vi.mock('../../../services/db/imageRepo', () => ({
     getImagesByIds: imageRepoMock.getImagesByIds,
+    getRemovedImagesByIds: imageRepoMock.getRemovedImagesByIds,
     toggleImageIntermediate: imageRepoMock.toggleImageIntermediate
 }));
 
@@ -416,6 +418,7 @@ describe('MaintenanceView', () => {
                 : update;
         });
         imageRepoMock.getImagesByIds.mockResolvedValue([]);
+        imageRepoMock.getRemovedImagesByIds.mockImplementation(async (ids: string[]) => maintenanceDataMock.localDeletedImages.filter(image => ids.includes(image.id)));
         imageRepoMock.toggleImageIntermediate.mockResolvedValue(undefined);
         thumbnailServiceMock.regenerateAllUnoptimized.mockResolvedValue(0);
         thumbnailConsumerRefreshMock.refreshThumbnailConsumers.mockResolvedValue(undefined);
@@ -424,6 +427,67 @@ describe('MaintenanceView', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+    });
+
+    it.each(['image', 'video'] as const)('hydrates only the opened Removed %s for its viewer', async mediaType => {
+        const light = mediaType === 'video' ? createVideo() : createImage();
+        const full = {
+            ...light,
+            metadata: {
+                ...light.metadata, model: 'Archived model', tool: GeneratorTool.COMFYUI,
+                positivePrompt: 'Current prompt', negativePrompt: 'Original negative',
+                steps: 28, workflowJson: '{"nodes":[]}',
+            },
+            originalChunks: { workflow: 'archived workflow' },
+        };
+        maintenanceDataMock.initializedTabs.add('trash');
+        maintenanceDataMock.localDeletedImages = [light];
+        imageRepoMock.getRemovedImagesByIds.mockResolvedValue([full]);
+        renderView();
+        fireEvent.click(screen.getByText('Tab trash'));
+        expect(imageRepoMock.getRemovedImagesByIds).not.toHaveBeenCalled();
+        fireEvent.click(await screen.findByText('Open Trash Viewer'));
+        const viewerId = mediaType === 'video' ? 'maintenance-video-viewer' : 'maintenance-viewer';
+        await waitFor(() => expect(screen.getByTestId(viewerId).getAttribute('data-metadata'))
+            .toBe(JSON.stringify(full.metadata)));
+        expect(screen.getByTestId(viewerId).getAttribute('data-original-chunks')).toBe(JSON.stringify(full.originalChunks));
+        expect(imageRepoMock.getRemovedImagesByIds).toHaveBeenCalledExactlyOnceWith([light.id]);
+        expect(maintenanceDataMock.localDeletedImages[0]).toBe(light);
+    });
+
+    it('ignores a late Removed detail response after navigating to another item', async () => {
+        const first = createImage({ id: 'first' });
+        const second = createImage({ id: 'second' });
+        maintenanceDataMock.initializedTabs.add('trash');
+        maintenanceDataMock.localDeletedImages = [first, second];
+        let resolveFirst!: (images: AIImage[]) => void;
+        imageRepoMock.getRemovedImagesByIds
+            .mockImplementationOnce(() => new Promise<AIImage[]>(resolve => { resolveFirst = resolve; }))
+            .mockResolvedValueOnce([{ ...second, metadata: { ...second.metadata, positivePrompt: 'Second full prompt' } }]);
+        renderView();
+        fireEvent.click(screen.getByText('Tab trash'));
+        fireEvent.click(await screen.findByText('Open Trash Viewer'));
+        fireEvent.click(screen.getByText('Viewer Next'));
+        await waitFor(() => expect(screen.getByTestId('maintenance-viewer').getAttribute('data-prompt')).toBe('Second full prompt'));
+        await act(async () => resolveFirst([{ ...first, metadata: { ...first.metadata, positivePrompt: 'Late first prompt' } }]));
+        expect(screen.getByTestId('maintenance-viewer').getAttribute('data-image-id')).toBe('second');
+        expect(screen.getByTestId('maintenance-viewer').getAttribute('data-prompt')).toBe('Second full prompt');
+        fireEvent.click(screen.getByText('Close Viewer'));
+        expect(screen.queryByTestId('maintenance-viewer')).toBeNull();
+    });
+
+    it('reports failed Removed hydration and allows retry by reopening the viewer', async () => {
+        const image = createImage();
+        maintenanceDataMock.initializedTabs.add('trash');
+        maintenanceDataMock.localDeletedImages = [image];
+        imageRepoMock.getRemovedImagesByIds.mockRejectedValueOnce(new Error('sqlite busy'));
+        renderView();
+        fireEvent.click(screen.getByText('Tab trash'));
+        fireEvent.click(await screen.findByText('Open Trash Viewer'));
+        await waitFor(() => expect(toastMock.addToast).toHaveBeenCalledWith('Could not load removed item details. Close and reopen the viewer to retry.', 'error'));
+        fireEvent.click(screen.getByText('Close Viewer'));
+        fireEvent.click(screen.getByText('Open Trash Viewer'));
+        await waitFor(() => expect(imageRepoMock.getRemovedImagesByIds).toHaveBeenCalledTimes(2));
     });
 
     it('does not derive Missing tab results from gallery search images', () => {

--- a/src/features/maintenance/components/MaintenanceView.tsx
+++ b/src/features/maintenance/components/MaintenanceView.tsx
@@ -19,12 +19,12 @@ import { ConfirmDialog } from '../../../components/ui/ConfirmDialog';
 import { useSelection } from '../../../hooks/useSelection';
 import { useLibraryStore } from '../../../stores/libraryStore';
 import { useLibraryContext } from '../../../contexts/LibraryContext';
-import { getImagesByIds, toggleImageIntermediate } from '../../../services/db/imageRepo';
+import { getImagesByIds, getRemovedImagesByIds, toggleImageIntermediate } from '../../../services/db/imageRepo';
 import { regenerateAllUnoptimized } from '../../../services/thumbnailService';
 import type { DeleteRemovedImagesResult, ExactDuplicateResolution } from '../../../bindings';
 import { isImageMasked } from '../../../utils/maskingUtils';
 import { useSettingsStore } from '../../../stores/settingsStore';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCollectionStore } from '../../../stores/collectionStore';
 import { refreshThumbnailConsumers } from '../../../services/thumbnailConsumerRefresh';
 import { useToast } from '../../../hooks/useToast';
@@ -175,6 +175,29 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
         return lists[activeTab];
     }, [activeTab, localDeletedImages, localUntaggedImages, localUnoptimizedImages, missingImages, localIntermediateImages, localDuplicateCandidates]);
 
+    const removedViewerId = viewingImageId && localDeletedImages.some(image => image.id === viewingImageId)
+        ? viewingImageId : null;
+    // Keep Removed browsing light; retain full metadata only for the current viewer.
+    const { data: removedViewerImage, error: removedViewerError } = useQuery({
+        queryKey: ['removed-image-detail', removedViewerId],
+        queryFn: async () => {
+            if (!removedViewerId) return null;
+            const [image] = await getRemovedImagesByIds([removedViewerId]);
+            if (!image) throw new Error('Removed item is no longer available');
+            return image;
+        },
+        enabled: removedViewerId !== null,
+        gcTime: 0,
+        retry: false,
+        refetchOnWindowFocus: false,
+    });
+
+    useEffect(() => {
+        if (removedViewerError) {
+            addToast('Could not load removed item details. Close and reopen the viewer to retry.', 'error');
+        }
+    }, [removedViewerError, addToast]);
+
     const targetImage = useMemo(() => {
         if (!viewingImageId) return null;
         // Search in all pools to find the image object
@@ -188,8 +211,10 @@ export const MaintenanceView: React.FC<MaintenanceViewProps> = ({
             ...activeImages
         ];
         const image = allPool.find(i => i.id === viewingImageId) || null;
-        return image ? recoveredImages.get(image.id) ?? image : null;
-    }, [viewingImageId, missingImages, localUntaggedImages, localDeletedImages, localUnoptimizedImages, localDuplicateCandidates, localIntermediateImages, activeImages, recoveredImages]);
+        if (!image) return null;
+        if (image.id === removedViewerId) return removedViewerImage ?? image;
+        return recoveredImages.get(image.id) ?? image;
+    }, [removedViewerId, removedViewerImage, viewingImageId, missingImages, localUntaggedImages, localDeletedImages, localUnoptimizedImages, localDuplicateCandidates, localIntermediateImages, activeImages, recoveredImages]);
 
     const handleRecoveredImage = useCallback((image: AIImage) => {
         setRecoveredImages(previous => {

--- a/src/services/db/__tests__/maintenanceRepo.test.ts
+++ b/src/services/db/__tests__/maintenanceRepo.test.ts
@@ -47,7 +47,7 @@ vi.mock('../../browserMockData', () => ({
 
 vi.mock('../repoUtils', () => ({
     getImageFieldsLight: () => 'id, path',
-    REMOVED_IMAGE_FIELDS: 'id, path',
+    REMOVED_IMAGE_FIELDS_LIGHT: 'id, path',
     mapRowToImage: mocks.mapRowToImage,
 }));
 

--- a/src/services/db/__tests__/removedImages.integration.test.ts
+++ b/src/services/db/__tests__/removedImages.integration.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment node
+import { DatabaseSync, type SQLInputValue } from 'node:sqlite';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDeletedImages } from '../maintenanceRepo';
+import { getRemovedImagesByIds } from '../imageRepo';
+import { mapRowToImage, REMOVED_IMAGE_FIELDS, type ImageRow } from '../repoUtils';
+import { isImageMasked } from '../../../utils/maskingUtils';
+import { isVideoAsset } from '../../../types';
+import * as runtime from '../../runtime';
+import * as browserMockData from '../../browserMockData';
+
+const mocks = vi.hoisted(() => ({ getDb: vi.fn() }));
+vi.mock('../connection', () => ({ getDb: mocks.getDb, dbMutex: {} }));
+vi.mock('@tauri-apps/api/core', () => ({
+    invoke: vi.fn(),
+    convertFileSrc: (path: string) => `asset://${path}`,
+}));
+
+const baseRow: Record<string, SQLInputValue> = {
+    id: 'C:/library/removed.png', path: 'C:/library/removed.png',
+    width: 1024, height: 768, file_size: 123456, timestamp: 10, removed_at: 20,
+    thumbnail_path: 'C:/thumbs/removed.webp', micro_thumbnail: 'data:image/webp;base64,AAAA',
+    thumbnail_source: 'ambit', is_favorite: 1, is_pinned: 1, is_missing: 0,
+    user_masked: null, group_id: 'group', board_id: 'board', notes: 'note', is_corrupt: 0,
+    invoke_image_name: 'removed.png', invoke_image_category: 'general',
+    invoke_image_origin: 'internal', invoke_owner_id: 'visible', invoke_scope_hidden: 0,
+    metadata_json: JSON.stringify({ positivePrompt: 'private sunset', steps: 20, sampler: 'euler' }),
+    original_metadata_json: JSON.stringify({ workflow: 'archival workflow' }),
+    original_parsed_json: JSON.stringify({ positivePrompt: 'original prompt', seed: 0 }),
+    original_state_json: JSON.stringify({ isFavorite: true, boardId: 'original-board' }),
+    media_type: 'image', media_container: null, media_mime_type: null, duration_ms: null,
+    video_codec: null, video_profile: null, audio_present: null, audio_codec: null,
+    frame_rate_num: null, frame_rate_den: null, rotation_degrees: null,
+    probe_status: null, playback_status: null,
+};
+const blobFields = ['metadata_json', 'original_metadata_json', 'original_parsed_json', 'original_state_json'];
+
+describe('Removed listings over SQLite', () => {
+    let sqlite: DatabaseSync;
+    let returnedRows: ImageRow[];
+
+    const insert = (overrides: Record<string, SQLInputValue> = {}) => {
+        const row = { ...baseRow, ...overrides };
+        sqlite.prepare(`INSERT INTO removed_images (${Object.keys(row).join(',')})
+            VALUES (${Object.keys(row).map(() => '?').join(',')})`).run(...Object.values(row));
+    };
+
+    beforeEach(() => {
+        sqlite = new DatabaseSync(':memory:');
+        // Fixture storage columns are independent of either SELECT projection.
+        sqlite.exec(`CREATE TABLE removed_images (${Object.keys(baseRow).join(',')});
+            CREATE VIEW scoped_removed_images AS SELECT * FROM removed_images
+            WHERE invoke_owner_id IS NULL OR invoke_owner_id = 'visible';`);
+        returnedRows = [];
+        mocks.getDb.mockResolvedValue({
+            select: vi.fn(async (sql: string, params: SQLInputValue[] = []) => {
+                const rows = sqlite.prepare(sql).all(...params);
+                returnedRows.push(...rows);
+                return rows;
+            }),
+        });
+    });
+
+    afterEach(() => {
+        sqlite.close();
+        vi.restoreAllMocks();
+    });
+
+    it('loads scoped rows newest first without sending archival blobs across IPC', async () => {
+        insert();
+        insert({ id: 'newer', path: 'C:/library/newer.png', removed_at: 30 });
+        insert({ id: 'hidden', invoke_scope_hidden: 1 });
+        insert({ id: 'other-owner', invoke_owner_id: 'other' });
+        const images = await getDeletedImages();
+        expect(images.map(image => image.id)).toEqual(['newer', baseRow.id]);
+        for (const row of returnedRows) {
+            for (const field of blobFields) expect(row).not.toHaveProperty(field);
+        }
+        expect(images[1]).toMatchObject({
+            filename: 'removed.png', width: 1024, height: 768, fileSize: 123456, timestamp: 10,
+            thumbnailUrl: 'asset://C:/thumbs/removed.webp', microThumbnail: baseRow.micro_thumbnail,
+            isFavorite: true, isPinned: true, isMissing: false, isCorrupt: false,
+            groupId: 'group', boardId: 'board', notes: 'note', invokeOwnerId: 'visible',
+            invokeImageName: 'removed.png', invokeImageCategory: 'general', invokeImageOrigin: 'internal',
+            metadata: { positivePrompt: 'private sunset' },
+        });
+        expect(images[1].originalChunks).toBeUndefined();
+        expect(images[1].originalMetadata).toBeUndefined();
+        expect(images[1].originalState).toBeUndefined();
+    });
+
+    it.each([
+        ['current prompt wins', { positivePrompt: 'private current' }, 'private current'],
+        ['nonmatching current wins', { positivePrompt: 'public current' }, 'public current'],
+        ['missing prompt falls back', {}, 'private original'],
+        ['empty prompt falls back', { positivePrompt: '', sampler: 'Unknown', steps: 0 }, 'private original'],
+        ['null fields fall back', { positivePrompt: null, sampler: null, steps: null }, 'private original'],
+        ['empty fields fall back', { positivePrompt: '', sampler: '', steps: '' }, 'private original'],
+        ['sampler prevents fallback', { positivePrompt: '', sampler: 'euler', steps: 0 }, ''],
+        ['steps prevent fallback', { positivePrompt: '', steps: 20 }, ''],
+        ['string zero prevents fallback', { positivePrompt: '', steps: '0' }, ''],
+    ])('preserves privacy for %s', async (_name, current, prompt) => {
+        insert({
+            metadata_json: JSON.stringify(current),
+            original_parsed_json: JSON.stringify({ positivePrompt: 'private original' }),
+        });
+        const [light] = await getDeletedImages();
+        const full = mapRowToImage(sqlite.prepare(`SELECT ${REMOVED_IMAGE_FIELDS} FROM removed_images`).get()!);
+        expect(light.metadata.positivePrompt).toBe(prompt);
+        expect(light.metadata.positivePrompt).toBe(full.metadata.positivePrompt);
+        for (const privacyEnabled of [true, false]) {
+            for (const userMasked of [undefined, true, false]) {
+                expect(isImageMasked({ ...light, userMasked }, privacyEnabled, ['PRIVATE']))
+                    .toBe(isImageMasked({ ...full, userMasked }, privacyEnabled, ['PRIVATE']));
+            }
+        }
+        expect(isImageMasked(light, true, ['PRIVATE'])).toBe(String(prompt).includes('private'));
+    });
+
+    it.each([null, '', '{}'])('handles absent metadata (%s) without needing archival blobs', async metadata => {
+        insert({ metadata_json: metadata, original_parsed_json: metadata });
+        const [image] = await getDeletedImages();
+        expect(image.metadata.positivePrompt).toBe('');
+        expect(isImageMasked(image, true, ['private'])).toBe(false);
+    });
+
+    it('retains video poster and playback facts in lightweight rows', async () => {
+        insert({
+            path: 'C:/library/removed.mp4', media_type: 'video', thumbnail_source: 'ambit-video-v1',
+            media_container: 'mp4', media_mime_type: 'video/mp4', duration_ms: 1500,
+            video_codec: 'h264', video_profile: 'High', audio_present: 1, audio_codec: 'aac',
+            frame_rate_num: 30, frame_rate_den: 1, rotation_degrees: 90,
+            probe_status: 'ready', playback_status: 'supported',
+        });
+        const [image] = await getDeletedImages();
+        expect(isVideoAsset(image)).toBe(true);
+        expect(image).toMatchObject({
+            thumbnailSource: 'ambit-video-v1', thumbnailUrl: 'asset://C:/thumbs/removed.webp',
+            mediaContainer: 'mp4', mediaMimeType: 'video/mp4', durationMs: 1500,
+            videoCodec: 'h264', videoProfile: 'High', audioPresent: true, audioCodec: 'aac',
+            frameRateNum: 30, frameRateDen: 1, rotationDegrees: 90,
+            probeStatus: 'ready', playbackStatus: 'supported',
+        });
+    });
+
+    it('hydrates browser mock Removed viewers without invoking the desktop database', async () => {
+        const removed = { ...mapRowToImage(baseRow), isDeleted: true };
+        vi.spyOn(runtime, 'isBrowserMockMode').mockReturnValue(true);
+        vi.spyOn(browserMockData, 'getBrowserMockImages').mockReturnValue([
+            removed,
+            { ...removed, id: 'other-removed' },
+            { ...removed, id: 'active', isDeleted: false },
+        ]);
+        mocks.getDb.mockClear();
+        expect(await getRemovedImagesByIds(['C:\\library\\removed.png', 'active'])).toEqual([removed]);
+        expect(mocks.getDb).not.toHaveBeenCalled();
+    });
+
+    it('keeps full metadata available for scoped ID lookups', async () => {
+        insert();
+        insert({ id: 'hidden', invoke_scope_hidden: 1 });
+        insert({ id: 'other-owner', invoke_owner_id: 'other' });
+        const images = await getRemovedImagesByIds(['C:\\library\\removed.png', 'hidden', 'other-owner']);
+        expect(images).toHaveLength(1);
+        expect(images[0]).toMatchObject({
+            metadata: { positivePrompt: 'private sunset', steps: 20, sampler: 'euler' },
+            originalChunks: { workflow: 'archival workflow' },
+            originalMetadata: { positivePrompt: 'original prompt', seed: 0 },
+            originalState: { isFavorite: true, boardId: 'original-board' },
+        });
+        for (const field of blobFields) expect(returnedRows[0]).toHaveProperty(field, baseRow[field]);
+        expect(returnedRows[0].positive_prompt).toBeNull();
+    });
+
+    it('does not grow the listing payload when unrelated workflow metadata grows', async () => {
+        insert();
+        const initialImages = await getDeletedImages();
+        const initialPayload = JSON.stringify(returnedRows);
+        const workflow = 'x'.repeat(512 * 1024);
+        sqlite.prepare(`UPDATE removed_images SET metadata_json = ?, original_parsed_json = ?,
+            original_metadata_json = ?, original_state_json = ?`).run(
+            JSON.stringify({ positivePrompt: 'private sunset', steps: 20, sampler: 'euler', workflow }),
+            JSON.stringify({ positivePrompt: 'original prompt', seed: 0, workflow }),
+            JSON.stringify({ workflow }), JSON.stringify({ workflow }),
+        );
+        returnedRows = [];
+        const enlargedImages = await getDeletedImages();
+        expect(JSON.stringify(returnedRows).length).toBe(initialPayload.length);
+        expect(enlargedImages).toEqual(initialImages);
+        expect(JSON.stringify(returnedRows)).toBe(initialPayload);
+    });
+});

--- a/src/services/db/imageRepo.ts
+++ b/src/services/db/imageRepo.ts
@@ -795,6 +795,10 @@ export const getFlatInvokeImageIdsForRoot = async (invokeRoot: string): Promise<
 
 export const getRemovedImagesByIds = async (ids: string[]): Promise<AIImage[]> => {
     if (ids.length === 0) return [];
+    if (isBrowserMockMode()) {
+        const normalizedIds = new Set(ids.map(normalizePath));
+        return getBrowserMockImages().filter(image => image.isDeleted && normalizedIds.has(normalizePath(image.id)));
+    }
     const db = await getDb();
 
     const CHUNK_SIZE = 900;

--- a/src/services/db/maintenanceRepo.ts
+++ b/src/services/db/maintenanceRepo.ts
@@ -5,7 +5,7 @@ import {
 import { unwrap } from '../../utils/spectaUtils';
 import { isVideoAsset, type AIImage, type MissingFileAuditResult } from '../../types';
 import { getDb, dbMutex } from './connection';
-import { mapRowToImage, getImageFieldsLight, REMOVED_IMAGE_FIELDS, type ImageRow } from './repoUtils';
+import { mapRowToImage, getImageFieldsLight, REMOVED_IMAGE_FIELDS_LIGHT, type ImageRow } from './repoUtils';
 import { isBrowserMockMode } from '../runtime';
 import {
     getBrowserMockImages,
@@ -166,7 +166,7 @@ export const getDeletedImages = async (): Promise<AIImage[]> => {
     }
 
     const db = await getDb();
-    const rows = await db.select<ImageRow[]>(`SELECT ${REMOVED_IMAGE_FIELDS} FROM scoped_removed_images AS removed_images WHERE invoke_scope_hidden = 0 ORDER BY removed_at DESC`);
+    const rows = await db.select<ImageRow[]>(`SELECT ${REMOVED_IMAGE_FIELDS_LIGHT} FROM scoped_removed_images AS removed_images WHERE invoke_scope_hidden = 0 ORDER BY removed_at DESC`);
     return rows.map(mapRowToImage);
 };
 

--- a/src/services/db/repoUtils.ts
+++ b/src/services/db/repoUtils.ts
@@ -40,17 +40,38 @@ export const getImageFieldsFull = (alias = 'images'): string => {
     `;
 };
 
-export const REMOVED_IMAGE_FIELDS = `
+const REMOVED_IMAGE_FIELDS_BASE = `
     id, path, width, height, file_size, timestamp, thumbnail_path, micro_thumbnail, thumbnail_source,
     is_favorite, is_pinned, 0 as is_deleted, is_missing, user_masked, group_id, board_id, notes,
     ${INVOKE_IMAGE_SOURCE_FIELDS},
     0 as is_intermediate_gen, 0 as is_grid_gen,
-    original_metadata_json, original_parsed_json, original_state_json, is_corrupt, metadata_json,
+    is_corrupt,
     NULL as model_name, NULL as model_hash, NULL as tool, NULL as resolved_model_name, NULL as file_hash,
     NULL as steps, NULL as seed, NULL as cfg, NULL as sampler, NULL as generation_type,
-    NULL as positive_prompt, NULL as negative_prompt,
+    NULL as negative_prompt,
     media_type, media_container, media_mime_type, duration_ms, video_codec, video_profile,
     audio_present, audio_codec, frame_rate_num, frame_rate_den, rotation_degrees, probe_status, playback_status
+`;
+
+// Removed lists must not send archival JSON blobs across IPC (#308). Extract only
+// the positive prompt needed for privacy masking, matching mapRowToImage's sparse
+// fallback to originalMetadata (no current prompt, sampler, or nonzero steps).
+export const REMOVED_IMAGE_FIELDS_LIGHT = `
+    ${REMOVED_IMAGE_FIELDS_BASE},
+    CASE
+        WHEN json_extract(NULLIF(metadata_json, ''), '$.positivePrompt') NOT IN ('', 0)
+        THEN CASE WHEN json_type(NULLIF(metadata_json, ''), '$.positivePrompt') = 'text'
+            THEN json_extract(NULLIF(metadata_json, ''), '$.positivePrompt') END
+        WHEN COALESCE(json_extract(NULLIF(metadata_json, ''), '$.sampler'), 'Unknown') IN ('Unknown', '', 0)
+         AND COALESCE(json_extract(NULLIF(metadata_json, ''), '$.steps'), 0) IN (0, '')
+        THEN CASE WHEN json_type(NULLIF(original_parsed_json, ''), '$.positivePrompt') = 'text'
+            THEN json_extract(NULLIF(original_parsed_json, ''), '$.positivePrompt') END
+    END AS positive_prompt
+`;
+
+export const REMOVED_IMAGE_FIELDS = `
+    ${REMOVED_IMAGE_FIELDS_BASE}, NULL as positive_prompt,
+    original_metadata_json, original_parsed_json, original_state_json, metadata_json
 `;
 
 export type ImageRow = Record<string, unknown>;


### PR DESCRIPTION
## Summary

Opening Removed currently transfers four archival JSON blobs for every row before the virtualized grid can render. Use a lightweight listing projection to remove this metadata-driven IPC memory growth, while extracting the positive prompt inside SQLite with the mapper's existing sparse-metadata fallback so keyword privacy masking stays effective.

Keep full archival lookups for restore and Invoke synchronization. Opening an image or video in Removed hydrates only that selected item; its detail cache is discarded after navigation or close. Scope filtering, ordering, complete selection, media display fields, and virtualization remain intact. No schema, Rust command, binding, or public signature changes.

Fixes #308. Thanks to @justineightyone for the reproduction, measurements, and light/full projection proposal. The investigation additionally identified the masking requirement and confirmed that Removed items can open in the viewer, requiring selected-item metadata hydration.

## Verification

- Full frontend suite after viewer hydration: 279 files, 3,372 tests passed, 1 skipped. After the final browser-mock compatibility change, the affected repository suites passed again (74 tests).
- TypeScript, lint, and diff whitespace checks passed on the final patch.
- Regression coverage uses the real projections against SQLite and checks blob omission, prompt/masking parity, image/video fields, archival lookups, scopes, existing ID batching, selected-item hydration, stale responses, and retry behavior.
- Independent standards and correctness reviews found no actionable issues.

A synthetic SQLite/Node run with 10,571 metadata-heavy removed rows reduced serialized query payload from 793,670,142 bytes to 11,035,586 bytes (98.6%). Query and mapping took 195 ms; JSON round-trip took 48 ms; observed Node heap was 98 MiB. These are in-memory synthetic measurements, not Windows desktop responsiveness or WebView memory measurements. Increasing unrelated workflow JSON does not increase listing payload.

## Remaining acceptance gate

- [ ] Windows desktop smoke test with a disposable library containing at least 10,571 metadata-heavy Removed items: open, scroll, select, restore, and delete disposable files through the existing confirmation flow; verify masking and restored metadata; record responsiveness and memory.

Native desktop controls were unavailable in the implementation environment, so this journey has not been verified. Keep this PR in draft until that acceptance check is complete. Rust/build/packaging release checks were not run for this frontend-only patch.

## Deferred

The slow maintenance count query reported in #308 needs a separate performance follow-up. Pagination is also outside this fix: the patch reduces metadata-driven memory growth and does not claim unlimited row-count scalability.
